### PR TITLE
m1.small and c1.medium can now be 64bit

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -50,7 +50,7 @@
           <td>1.7 GB</td>
           <td>1 (1 core x 1 unit)</td>
           <td>160 GB</td>
-          <td>32-bit</td>
+          <td>32/64-bit</td>
           <td>Moderate</td>
           <td>m1.small</td>
           <td class="cost" hour_cost="0.085">$0.085 per hour</td>
@@ -127,7 +127,7 @@
           <td>1.7 GB</td>
           <td>5 (2 cores x 2.5 units)</td>
           <td>350 GB</td>
-          <td>32-bit</td>
+          <td>32/64-bit</td>
           <td>Moderate</td>
           <td>c1.medium</td>
           <td class="cost" hour_cost="0.17">$0.17 per hour</td>


### PR DESCRIPTION
updating descriptions of m1.small and c1.medium instances to reflect that they can now be either 32 or 64bit
