### PR TITLE
Turn on bootstrap tooltip

### DIFF
--- a/www/default.js
+++ b/www/default.js
@@ -74,6 +74,12 @@ $(function() {
   change_cost('hourly');
 
   column_toggle_setup();
+  
+  $('abbr').tooltip({ 
+    placement: function(tt, el) { 
+      return (this.$element.parents('thead').length) ? 'top' : 'right';
+    }
+  });
 });
 
 $("#cost-dropdown li").bind("click", function(e) {


### PR DESCRIPTION
Bootstrap was already included so I just turned on the Tooltip function. I set it up so that tooltips are positioned above table headings and to the right of table cells. I though that offered a better user experience.
