### PR TITLE
Correct SSD info for cr1.8xlarge

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -289,7 +289,7 @@
           <td class="name">High Memory Cluster Eight Extra Large</td>
           <td class="memory"><span sort="244.00">244.00 GB</span></td>
           <td class="computeunits"><span sort="88">88 (2 x Intel <abbr title="Eight-core. Intel Turbo, NUMA">Xeon E5-2670</abbr>)</span></td>
-          <td class="storage"><span sort="240">240 GB SSD</span></td>
+          <td class="storage"><span sort="240">240 GB (2x120 GB SSD)</span></td>
           <td class="architecture">64-bit</td>
           <td class="ioperf"><span sort="4"><abbr title="10 Gigabit Ethernet">Very High</abbr></sort></td>
           <td class="maxips">1</td>


### PR DESCRIPTION
Was described as having a 240 GB SSD, in reality it has 2 x 120 GB SSDs. https://aws.amazon.com/ec2/instance-types/#instance-details
