### PR TITLE
Corrected network throughput of m2.2xlarge

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -159,7 +159,7 @@
           <td class="computeunits"><span sort="13">13 (4 cores x 3.25 units)</span></td>
           <td class="storage"><span sort="850">850 GB</span></td>
           <td class="architecture">64-bit</td>
-          <td class="ioperf"><span sort="2">High</span></td>
+          <td class="ioperf"><span sort="3">Moderate / <abbr title="EBS-Optimized available">500 Mbps</abbr></span></td>
           <td class="maxips">120</td>
           <td class="apiname">m2.2xlarge</td>
           <td class="cost" hour_cost="0.82">$0.82 per hour</td>


### PR DESCRIPTION
According to http://aws.amazon.com/ec2/instance-types/#measuring-performance, the network throughput for m2.2xlarge is  Moderate. It is also an EBS-Optimized instance with dedicated throughput of 500 Mbps [http://aws.typepad.com/aws/2013/03/additional-ebs-optimized-instance-types-for-amazon-ec2.html].
