### PR TITLE
Fixing c3.large ioperf

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -315,7 +315,7 @@
           <td class="computeunits"><span sort="7">7 (2 x Intel <abbr title="Ten-core. Intel Turbo, NUMA">Xeon E5-2680 v2</abbr>)</span></td>
           <td class="storage"><span sort="32">32 GB (2x16 GB SSD)</span></td>
           <td class="architecture">64-bit</td>
-          <td class="ioperf"><span sort="4"><abbr title="10 Gigabit Ethernet">Very High</abbr></sort></td>
+          <td class="ioperf"><span sort="1">Moderate</span></td>
           <td class="maxips"><abbr title="Unlisted">1</abbr></td>
           <td class="apiname">c3.large</td>
           <td class="cost" hour_cost="0.150">$0.150 per hour</td>


### PR DESCRIPTION
The was documentation describes the network performance of c3.large to be only moderate, not as very high as described

http://aws.amazon.com/ec2/instance-types/#instance-details
