### PR TITLE
Updated c3.xlarge memory size to 7.5GiB

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -323,7 +323,7 @@
         </tr>
         <tr>
           <td class="name">C3 Extra Large</td>
-          <td class="memory"><span sort="7.00">7.00 GB</span></td>
+          <td class="memory"><span sort="7.50">7.50 GB</span></td>
           <td class="computeunits"><span sort="14">14 (4 x Intel <abbr title="Ten-core. Intel Turbo, NUMA">Xeon E5-2680 v2</abbr>)</span></td>
           <td class="storage"><span sort="80">80 GB (2x40 GB SSD)</span></td>
           <td class="architecture">64-bit</td>


### PR DESCRIPTION
While on the main EC2 [service page](http://aws.amazon.com/ec2/#instance), it states that c3.xlarge instances have 7GiB of memory, on the dedicated instance types [page](http://aws.amazon.com/ec2/instance-types/) it states that it has 7.5GiB. And most importantly: the instance has in fact 7.5GiB of memory.
