### PR TITLE
cg1.4xlarge instances have 2 gpus

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -264,7 +264,7 @@
         <tr>
           <td class="name">Cluster GPU Quadruple Extra Large</td>
           <td class="memory"><span sort="22">22.00 GB</span></td>
-          <td class="computeunits"><span sort="33.5">33.5 (2 x Intel <abbr title="Quad-core Nehalem architecture">Xeon X5570</abbr>), 1 x NVIDIA Tesla M2050 GPU (Fermi GF100) </span></td>
+          <td class="computeunits"><span sort="33.5">33.5 (2 x Intel <abbr title="Quad-core Nehalem architecture">Xeon X5570</abbr>), 2 x NVIDIA Tesla M2050 GPU (Fermi GF100) </span></td>
           <td class="storage"><span sort="1690">1690 GB (2x840 GB)</span></td>
           <td class="architecture">64-bit</td>
           <td class="ioperf"><span sort="4"><abbr title="10 Gigabit Ethernet">Very High</abbr></sort></td>


### PR DESCRIPTION
Hey there, according to the [aws docs](http://aws.amazon.com/ec2/instance-types/instance-details/), cg1.4xlarge instances actually have 2 gpus.

"CG1 instances are backed by 2 x Intel Xeon X5570, quad-core with hyperthread plus 2 NVIDIA Tesla M2050 GPUs"
