### PR TITLE
If we have it, use history.replaceState to live-update the URL.

### DIFF
--- a/www/default.js
+++ b/www/default.js
@@ -109,7 +109,6 @@ function maybe_update_url() {
 
 $(function() {
   $(document).ready(function() {
-    console.log("document.ready...");
     $('#data').dataTable({
       "bPaginate": false,
       "bInfo": false,


### PR DESCRIPTION
Update the URL in-place as the user searches or selects filters, so that
users can just copy the address from the address bar and get the current
page they're looking at.

Keep the button and box for browsers that don't have replaceState yet,
but we could also plausibly just drop it.
