### PR TITLE
Append generation time to index.html

### DIFF
--- a/in/index.html.mako
+++ b/in/index.html.mako
@@ -177,6 +177,9 @@
       <p>This site was created out of frustration while trying to compare EC2 instances using Amazon's <a href="http://aws.amazon.com/ec2/instance-types/" target="_blank">instance type</a> and <a href="http://aws.amazon.com/ec2/pricing/" target="_blank">pricing</a> pages.</p>
       <p>It was started by <a href="http://twitter.com/powdahound" target="_blank">@powdahound</a>, contributed to by <a href="https://github.com/powdahound/ec2instances.info/contributors" target="_blank">many</a>, is <a href="http://powdahound.com/2011/03/hosting-a-static-site-on-amazon-s3-ec2instances-info" target="_blank">hosted on S3</a>, and awaits your improvements <a href="https://github.com/powdahound/ec2instances.info" target="_blank">on GitHub</a>.</p>
     </div>
+    <div class="well-small">
+      <p class="small">Generated at: ${generated_at}</p>
+    </div>
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js" type="text/javascript" charset="utf-8"></script>
     <script src="bootstrap/js/bootstrap.min.js" type="text/javascript" charset="utf-8"></script>

--- a/render.py
+++ b/render.py
@@ -1,6 +1,7 @@
 import mako.template
 import mako.exceptions
 import json
+import datetime
 
 
 def pretty_name(inst):
@@ -88,9 +89,10 @@ def render(data_file, template_file, destination_file):
     for i in instances:
         add_render_info(i)
     print "Rendering to %s..." % destination_file
+    generated_at = datetime.datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S UTC')
     with open(destination_file, 'w') as fh:
         try:
-            fh.write(template.render(instances=instances))
+            fh.write(template.render(instances=instances, generated_at=generated_at))
         except:
             print mako.exceptions.text_error_template().render()
 


### PR DESCRIPTION
Modified build process to add current UTC time as "Generation Time" at the bottom of `index.html`, so that [ec2instances.info](http://www.ec2instances.info) visitors know when the website was last updated.
