### PR TITLE
updating scrape and render scripts to work with new EC2 types and the ne...

### DIFF
--- a/in/index.html.mako
+++ b/in/index.html.mako
@@ -107,8 +107,8 @@
           <td class="name">${inst['pretty_name']}</td>
           <td class="memory"><span sort="${inst['memory']}">${inst['memory']} GB</span></td>
           <td class="computeunits">
-            % if inst['instance_type'] == 't1.micro':
-            <span sort="2">2 (only for short bursts)</span>
+            % if inst['ECU'] == 0 :
+            <span sort="0">Burstable</span>
             % else:
             <span sort="${inst['ECU']}">${"%g" % (inst['ECU'],)}
               % if 'cpu_details' in inst:

--- a/render.py
+++ b/render.py
@@ -9,7 +9,6 @@ def pretty_name(inst):
     family = pieces[0]
     short  = pieces[1]
     family_names = {
-        't1': '',
         'r3': 'R3 High-Memory',
         'c3': 'C3 High-CPU',
         'm3': 'M3 General Purpose',

--- a/scrape.py
+++ b/scrape.py
@@ -99,7 +99,7 @@ def scrape_instances():
     current_gen = [parse_instance(r) for r in rows]
 
     tree = etree.parse(urllib2.urlopen("http://aws.amazon.com/ec2/previous-generation/"), etree.HTMLParser())
-    details = tree.xpath('//table')[4]
+    details = tree.xpath('//table')[5]
     rows = details.xpath('tbody/tr')[1:]
     assert len(rows) > 0, "Didn't find any table rows."
     prev_gen = [parse_prev_generation_instance(r) for r in rows]
@@ -161,7 +161,7 @@ def add_pricing(imap, data):
                 # ECU is only available here
                 ecu = i_spec['ECU']
                 if ecu == 'variable':
-                    inst.ECU = None
+                    inst.ECU = 0
                 else:
                     inst.ECU = float(ecu)
 


### PR DESCRIPTION
Hi,

I like this tooI a lot. I have updated the scrape and render scripts to work with new EC2 web page (issue #75). There are still some missing info -

Changes / known issues:
- Fetching basic info from current generation instances and previous-generation pages
- Previous generation instances pricing are fetched from /pricing/1/ec2/previous-generation/{linux|mswin}-od.min.js
- ECU and Arch are no longer available from the web page and so not covered here
- Some prices for Windows instances are missing
