### PR TITLE
Updated template to include the actual instance type in the displayed values

### DIFF
--- a/in/index.html.mako
+++ b/in/index.html.mako
@@ -106,7 +106,10 @@
       <tbody>
 % for inst in instances:
         <tr class='instance' id="${inst['instance_type']}">
-          <td class="name">${inst['pretty_name']}</td>
+          <td class="name">
+            ${inst['pretty_name']}
+            <span class="instance-name">${inst['instance_type']}</span>
+          </td>
           <td class="memory"><span sort="${inst['memory']}">${inst['memory']} GB</span></td>
           <td class="computeunits">
             % if inst['ECU'] == 0 :

--- a/www/default.css
+++ b/www/default.css
@@ -22,6 +22,13 @@ body {
   text-align: left;
 }
 
+#data td.name span.instance-name {
+  font-style: italic;
+  white-space: nowrap;
+  font-size: 75%;
+  color: #bbb;
+}
+
 #data td.memory {
   text-align: right;
 }

--- a/www/index.html
+++ b/www/index.html
@@ -103,7 +103,10 @@
       </thead>
       <tbody>
         <tr class='instance' id="m1.small">
-          <td class="name">M1 General Purpose Small</td>
+          <td class="name">
+            M1 General Purpose Small
+            <span class="instance-name">m1.small</span>
+          </td>
           <td class="memory"><span sort="1.7">1.7 GB</span></td>
           <td class="computeunits">
             <span sort="1.0">1
@@ -135,7 +138,10 @@
           </td>
         </tr>
         <tr class='instance' id="m1.medium">
-          <td class="name">M1 General Purpose Medium</td>
+          <td class="name">
+            M1 General Purpose Medium
+            <span class="instance-name">m1.medium</span>
+          </td>
           <td class="memory"><span sort="3.75">3.75 GB</span></td>
           <td class="computeunits">
             <span sort="2.0">2
@@ -167,7 +173,10 @@
           </td>
         </tr>
         <tr class='instance' id="m1.large">
-          <td class="name">M1 General Purpose Large</td>
+          <td class="name">
+            M1 General Purpose Large
+            <span class="instance-name">m1.large</span>
+          </td>
           <td class="memory"><span sort="7.5">7.5 GB</span></td>
           <td class="computeunits">
             <span sort="4.0">4
@@ -200,7 +209,10 @@
           </td>
         </tr>
         <tr class='instance' id="m1.xlarge">
-          <td class="name">M1 General Purpose Extra Large</td>
+          <td class="name">
+            M1 General Purpose Extra Large
+            <span class="instance-name">m1.xlarge</span>
+          </td>
           <td class="memory"><span sort="15.0">15.0 GB</span></td>
           <td class="computeunits">
             <span sort="8.0">8
@@ -233,7 +245,10 @@
           </td>
         </tr>
         <tr class='instance' id="c1.medium">
-          <td class="name">C1 High-CPU Medium</td>
+          <td class="name">
+            C1 High-CPU Medium
+            <span class="instance-name">c1.medium</span>
+          </td>
           <td class="memory"><span sort="1.7">1.7 GB</span></td>
           <td class="computeunits">
             <span sort="5.0">5
@@ -265,7 +280,10 @@
           </td>
         </tr>
         <tr class='instance' id="c1.xlarge">
-          <td class="name">C1 High-CPU Extra Large</td>
+          <td class="name">
+            C1 High-CPU Extra Large
+            <span class="instance-name">c1.xlarge</span>
+          </td>
           <td class="memory"><span sort="7.0">7.0 GB</span></td>
           <td class="computeunits">
             <span sort="20.0">20
@@ -298,7 +316,10 @@
           </td>
         </tr>
         <tr class='instance' id="cc2.8xlarge">
-          <td class="name">Cluster Compute Eight Extra Large</td>
+          <td class="name">
+            Cluster Compute Eight Extra Large
+            <span class="instance-name">cc2.8xlarge</span>
+          </td>
           <td class="memory"><span sort="60.5">60.5 GB</span></td>
           <td class="computeunits">
             <span sort="88.0">88
@@ -334,7 +355,10 @@
           </td>
         </tr>
         <tr class='instance' id="cg1.4xlarge">
-          <td class="name">Cluster GPU Quadruple Extra Large</td>
+          <td class="name">
+            Cluster GPU Quadruple Extra Large
+            <span class="instance-name">cg1.4xlarge</span>
+          </td>
           <td class="memory"><span sort="22.5">22.5 GB</span></td>
           <td class="computeunits">
             <span sort="33.5">33.5
@@ -370,7 +394,10 @@
           </td>
         </tr>
         <tr class='instance' id="m2.xlarge">
-          <td class="name">M2 High Memory Extra Large</td>
+          <td class="name">
+            M2 High Memory Extra Large
+            <span class="instance-name">m2.xlarge</span>
+          </td>
           <td class="memory"><span sort="17.1">17.1 GB</span></td>
           <td class="computeunits">
             <span sort="6.5">6.5
@@ -402,7 +429,10 @@
           </td>
         </tr>
         <tr class='instance' id="m2.2xlarge">
-          <td class="name">M2 High Memory Double Extra Large</td>
+          <td class="name">
+            M2 High Memory Double Extra Large
+            <span class="instance-name">m2.2xlarge</span>
+          </td>
           <td class="memory"><span sort="34.2">34.2 GB</span></td>
           <td class="computeunits">
             <span sort="13.0">13
@@ -435,7 +465,10 @@
           </td>
         </tr>
         <tr class='instance' id="m2.4xlarge">
-          <td class="name">M2 High Memory Quadruple Extra Large</td>
+          <td class="name">
+            M2 High Memory Quadruple Extra Large
+            <span class="instance-name">m2.4xlarge</span>
+          </td>
           <td class="memory"><span sort="68.4">68.4 GB</span></td>
           <td class="computeunits">
             <span sort="26.0">26
@@ -468,7 +501,10 @@
           </td>
         </tr>
         <tr class='instance' id="cr1.8xlarge">
-          <td class="name">High Memory Cluster Eight Extra Large</td>
+          <td class="name">
+            High Memory Cluster Eight Extra Large
+            <span class="instance-name">cr1.8xlarge</span>
+          </td>
           <td class="memory"><span sort="244.0">244.0 GB</span></td>
           <td class="computeunits">
             <span sort="88.0">88
@@ -504,7 +540,10 @@
           </td>
         </tr>
         <tr class='instance' id="hi1.4xlarge">
-          <td class="name">HI1. High I/O Quadruple Extra Large</td>
+          <td class="name">
+            HI1. High I/O Quadruple Extra Large
+            <span class="instance-name">hi1.4xlarge</span>
+          </td>
           <td class="memory"><span sort="60.5">60.5 GB</span></td>
           <td class="computeunits">
             <span sort="35.0">35
@@ -540,7 +579,10 @@
           </td>
         </tr>
         <tr class='instance' id="t1.micro">
-          <td class="name">T1 Micro</td>
+          <td class="name">
+            T1 Micro
+            <span class="instance-name">t1.micro</span>
+          </td>
           <td class="memory"><span sort="0.613">0.613 GB</span></td>
           <td class="computeunits">
             <span sort="0">Burstable</span>
@@ -567,7 +609,10 @@
           </td>
         </tr>
         <tr class='instance' id="t2.micro">
-          <td class="name">T2 Micro</td>
+          <td class="name">
+            T2 Micro
+            <span class="instance-name">t2.micro</span>
+          </td>
           <td class="memory"><span sort="1.0">1.0 GB</span></td>
           <td class="computeunits">
             <span sort="0">Burstable</span>
@@ -594,7 +639,10 @@
           </td>
         </tr>
         <tr class='instance' id="t2.small">
-          <td class="name">T2 Small</td>
+          <td class="name">
+            T2 Small
+            <span class="instance-name">t2.small</span>
+          </td>
           <td class="memory"><span sort="2.0">2.0 GB</span></td>
           <td class="computeunits">
             <span sort="0">Burstable</span>
@@ -621,7 +669,10 @@
           </td>
         </tr>
         <tr class='instance' id="t2.medium">
-          <td class="name">T2 Medium</td>
+          <td class="name">
+            T2 Medium
+            <span class="instance-name">t2.medium</span>
+          </td>
           <td class="memory"><span sort="4.0">4.0 GB</span></td>
           <td class="computeunits">
             <span sort="0">Burstable</span>
@@ -648,7 +699,10 @@
           </td>
         </tr>
         <tr class='instance' id="m3.medium">
-          <td class="name">M3 General Purpose Medium</td>
+          <td class="name">
+            M3 General Purpose Medium
+            <span class="instance-name">m3.medium</span>
+          </td>
           <td class="memory"><span sort="3.75">3.75 GB</span></td>
           <td class="computeunits">
             <span sort="3.0">3
@@ -680,7 +734,10 @@
           </td>
         </tr>
         <tr class='instance' id="m3.large">
-          <td class="name">M3 General Purpose Large</td>
+          <td class="name">
+            M3 General Purpose Large
+            <span class="instance-name">m3.large</span>
+          </td>
           <td class="memory"><span sort="7.5">7.5 GB</span></td>
           <td class="computeunits">
             <span sort="6.5">6.5
@@ -712,7 +769,10 @@
           </td>
         </tr>
         <tr class='instance' id="m3.xlarge">
-          <td class="name">M3 General Purpose Extra Large</td>
+          <td class="name">
+            M3 General Purpose Extra Large
+            <span class="instance-name">m3.xlarge</span>
+          </td>
           <td class="memory"><span sort="15.0">15.0 GB</span></td>
           <td class="computeunits">
             <span sort="13.0">13
@@ -745,7 +805,10 @@
           </td>
         </tr>
         <tr class='instance' id="m3.2xlarge">
-          <td class="name">M3 General Purpose Double Extra Large</td>
+          <td class="name">
+            M3 General Purpose Double Extra Large
+            <span class="instance-name">m3.2xlarge</span>
+          </td>
           <td class="memory"><span sort="30.0">30.0 GB</span></td>
           <td class="computeunits">
             <span sort="26.0">26
@@ -778,7 +841,10 @@
           </td>
         </tr>
         <tr class='instance' id="c3.large">
-          <td class="name">C3 High-CPU Large</td>
+          <td class="name">
+            C3 High-CPU Large
+            <span class="instance-name">c3.large</span>
+          </td>
           <td class="memory"><span sort="3.75">3.75 GB</span></td>
           <td class="computeunits">
             <span sort="7.0">7
@@ -810,7 +876,10 @@
           </td>
         </tr>
         <tr class='instance' id="c3.xlarge">
-          <td class="name">C3 High-CPU Extra Large</td>
+          <td class="name">
+            C3 High-CPU Extra Large
+            <span class="instance-name">c3.xlarge</span>
+          </td>
           <td class="memory"><span sort="7.5">7.5 GB</span></td>
           <td class="computeunits">
             <span sort="14.0">14
@@ -843,7 +912,10 @@
           </td>
         </tr>
         <tr class='instance' id="c3.2xlarge">
-          <td class="name">C3 High-CPU Double Extra Large</td>
+          <td class="name">
+            C3 High-CPU Double Extra Large
+            <span class="instance-name">c3.2xlarge</span>
+          </td>
           <td class="memory"><span sort="15.0">15.0 GB</span></td>
           <td class="computeunits">
             <span sort="28.0">28
@@ -876,7 +948,10 @@
           </td>
         </tr>
         <tr class='instance' id="c3.4xlarge">
-          <td class="name">C3 High-CPU Quadruple Extra Large</td>
+          <td class="name">
+            C3 High-CPU Quadruple Extra Large
+            <span class="instance-name">c3.4xlarge</span>
+          </td>
           <td class="memory"><span sort="30.0">30.0 GB</span></td>
           <td class="computeunits">
             <span sort="55.0">55
@@ -909,7 +984,10 @@
           </td>
         </tr>
         <tr class='instance' id="c3.8xlarge">
-          <td class="name">C3 High-CPU Eight Extra Large</td>
+          <td class="name">
+            C3 High-CPU Eight Extra Large
+            <span class="instance-name">c3.8xlarge</span>
+          </td>
           <td class="memory"><span sort="60.0">60.0 GB</span></td>
           <td class="computeunits">
             <span sort="108.0">108
@@ -941,7 +1019,10 @@
           </td>
         </tr>
         <tr class='instance' id="g2.2xlarge">
-          <td class="name">G2 Double Extra Large</td>
+          <td class="name">
+            G2 Double Extra Large
+            <span class="instance-name">g2.2xlarge</span>
+          </td>
           <td class="memory"><span sort="15.0">15.0 GB</span></td>
           <td class="computeunits">
             <span sort="26.0">26
@@ -974,7 +1055,10 @@
           </td>
         </tr>
         <tr class='instance' id="r3.large">
-          <td class="name">R3 High-Memory Large</td>
+          <td class="name">
+            R3 High-Memory Large
+            <span class="instance-name">r3.large</span>
+          </td>
           <td class="memory"><span sort="15.25">15.25 GB</span></td>
           <td class="computeunits">
             <span sort="6.5">6.5
@@ -1006,7 +1090,10 @@
           </td>
         </tr>
         <tr class='instance' id="r3.xlarge">
-          <td class="name">R3 High-Memory Extra Large</td>
+          <td class="name">
+            R3 High-Memory Extra Large
+            <span class="instance-name">r3.xlarge</span>
+          </td>
           <td class="memory"><span sort="30.5">30.5 GB</span></td>
           <td class="computeunits">
             <span sort="13.0">13
@@ -1039,7 +1126,10 @@
           </td>
         </tr>
         <tr class='instance' id="r3.2xlarge">
-          <td class="name">R3 High-Memory Double Extra Large</td>
+          <td class="name">
+            R3 High-Memory Double Extra Large
+            <span class="instance-name">r3.2xlarge</span>
+          </td>
           <td class="memory"><span sort="61.0">61.0 GB</span></td>
           <td class="computeunits">
             <span sort="26.0">26
@@ -1072,7 +1162,10 @@
           </td>
         </tr>
         <tr class='instance' id="r3.4xlarge">
-          <td class="name">R3 High-Memory Quadruple Extra Large</td>
+          <td class="name">
+            R3 High-Memory Quadruple Extra Large
+            <span class="instance-name">r3.4xlarge</span>
+          </td>
           <td class="memory"><span sort="122.0">122.0 GB</span></td>
           <td class="computeunits">
             <span sort="52.0">52
@@ -1105,7 +1198,10 @@
           </td>
         </tr>
         <tr class='instance' id="r3.8xlarge">
-          <td class="name">R3 High-Memory Eight Extra Large</td>
+          <td class="name">
+            R3 High-Memory Eight Extra Large
+            <span class="instance-name">r3.8xlarge</span>
+          </td>
           <td class="memory"><span sort="244.0">244.0 GB</span></td>
           <td class="computeunits">
             <span sort="104.0">104
@@ -1137,7 +1233,10 @@
           </td>
         </tr>
         <tr class='instance' id="i2.xlarge">
-          <td class="name">I2 Extra Large</td>
+          <td class="name">
+            I2 Extra Large
+            <span class="instance-name">i2.xlarge</span>
+          </td>
           <td class="memory"><span sort="30.5">30.5 GB</span></td>
           <td class="computeunits">
             <span sort="14.0">14
@@ -1170,7 +1269,10 @@
           </td>
         </tr>
         <tr class='instance' id="i2.2xlarge">
-          <td class="name">I2 Double Extra Large</td>
+          <td class="name">
+            I2 Double Extra Large
+            <span class="instance-name">i2.2xlarge</span>
+          </td>
           <td class="memory"><span sort="61.0">61.0 GB</span></td>
           <td class="computeunits">
             <span sort="27.0">27
@@ -1203,7 +1305,10 @@
           </td>
         </tr>
         <tr class='instance' id="i2.4xlarge">
-          <td class="name">I2 Quadruple Extra Large</td>
+          <td class="name">
+            I2 Quadruple Extra Large
+            <span class="instance-name">i2.4xlarge</span>
+          </td>
           <td class="memory"><span sort="122.0">122.0 GB</span></td>
           <td class="computeunits">
             <span sort="53.0">53
@@ -1236,7 +1341,10 @@
           </td>
         </tr>
         <tr class='instance' id="i2.8xlarge">
-          <td class="name">I2 Eight Extra Large</td>
+          <td class="name">
+            I2 Eight Extra Large
+            <span class="instance-name">i2.8xlarge</span>
+          </td>
           <td class="memory"><span sort="244.0">244.0 GB</span></td>
           <td class="computeunits">
             <span sort="104.0">104
@@ -1268,7 +1376,10 @@
           </td>
         </tr>
         <tr class='instance' id="hs1.8xlarge">
-          <td class="name">High Storage Eight Extra Large</td>
+          <td class="name">
+            High Storage Eight Extra Large
+            <span class="instance-name">hs1.8xlarge</span>
+          </td>
           <td class="memory"><span sort="117.0">117.0 GB</span></td>
           <td class="computeunits">
             <span sort="35.0">35
@@ -1281,9 +1392,9 @@
           </td>
           <td class="storage">
             
-            <span sort="49152">
-              49152 GB
-              (24 * 2048 GB)
+            <span sort="48000">
+              48000 GB
+              (24 * 2000 GB)
             </span>
           </td>
           <td class="architecture">
@@ -1311,7 +1422,7 @@
       <p>It was started by <a href="http://twitter.com/powdahound" target="_blank">@powdahound</a>, contributed to by <a href="https://github.com/powdahound/ec2instances.info/contributors" target="_blank">many</a>, is <a href="http://powdahound.com/2011/03/hosting-a-static-site-on-amazon-s3-ec2instances-info" target="_blank">hosted on S3</a>, and awaits your improvements <a href="https://github.com/powdahound/ec2instances.info" target="_blank">on GitHub</a>.</p>
     </div>
     <div class="well-small">
-      <p class="small">Generated at: 2014-07-27 23:25:01 UTC</p>
+      <p class="small">Generated at: 2014-10-01 03:50:29 UTC</p>
     </div>
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js" type="text/javascript" charset="utf-8"></script>


### PR DESCRIPTION
I got tired of looking at the source to get the actual instance type name AWS uses.
