### PR TITLE
Hard code 32-bit/64-bit architecture of t2.micro and t2.small.

### DIFF
--- a/scrape.py
+++ b/scrape.py
@@ -72,6 +72,8 @@ def parse_instance(tr):
     assert len(cols) == 12, "Expected 12 columns in the table, but got %d" % len(cols)
     i.family = "Unknown" # totext(cols[0])
     i.instance_type = totext(cols[0])
+    if i.instance_type in ('t2.micro', 't2.small'):
+        i.arch.append('i386')
     i.vCPU = int(totext(cols[1]))
     i.memory = float(totext(cols[2]))
     storage = totext(cols[3])


### PR DESCRIPTION
Looks like the 32-bit/64-bit architecture cannot be scraped from the current generation instances page, so this change hard-codes the 32-bit capability to the ones that are known to support 32-bit: t2.micro and t2.small.
