### PR TITLE
Improve sorting for Low  to Moderate network instances

### DIFF
--- a/render.py
+++ b/render.py
@@ -44,18 +44,18 @@ def pretty_name(inst):
 
 def network_sort(inst):
     perf = inst['network_performance']
-    if perf == 'Very Low':
-        sort = 0
-    elif perf == 'Low':
-        sort = 1
-    elif perf == 'Moderate':
-        sort = 2
-    elif perf == 'High':
-        sort = 3
-    elif perf == '10 Gigabit':
-        sort = 4
-    else:  ## unknown value
-        sort = 5
+    network_rank = [
+        'Very Low',
+        'Low',
+        'Low to Moderate',
+        'Moderate',
+        'High',
+        '10 Gigabit'
+        ]
+    try:
+        sort = network_rank.index(perf)
+    except ValueError:
+        sort = len(network_rank)
     sort *= 2
     if inst['ebs_optimized']:
         sort += 1


### PR DESCRIPTION
I also removed the if-else, as introducing the new network instance could be easier, and it is likely there will be more network types in the future.

Happy to remove and simply add the if-else, if you would prefer?  

Before:
![image](https://cloud.githubusercontent.com/assets/446889/5321380/976822d4-7c88-11e4-8ad1-8588776a5663.png)

After:
![image](https://cloud.githubusercontent.com/assets/446889/5321371/8576d4da-7c88-11e4-8561-7204f11aee9e.png)
