### PR TITLE
Add a Family filter for faster finding of your favorite family

### DIFF
--- a/in/index.html.mako
+++ b/in/index.html.mako
@@ -102,6 +102,10 @@
       Min Memory (GiB): <input data-action="datafilter" data-type="memory" class="form-control" />
       Min vCPUs: <input data-action="datafilter" data-type="vcpus" class="form-control" />
       Min Storage (GiB): <input data-action="datafilter" data-type="storage" class="form-control" />
+      Family:
+      <select data-action="datafilter" data-type="family" class="form-control">
+        <option selected></option>
+      </select>
     </div>
 
     <table cellspacing="0" class="table table-bordered table-hover table-condensed" id="data">

--- a/www/default.js
+++ b/www/default.js
@@ -364,15 +364,17 @@ var apply_min_values = function () {
     var filter_on = $(this).data('type');
     var filter_val = $(this).val();
     
-    if (filter_on == 'family' && filter_val != "") {
+    if (filter_on == 'family') {
       g_settings["family"] = filter_val;
 
-      var match_fail = data_rows.filter(function () {
-        var row_val = $(this).find('td[class~="apiname"]').text();
-        return row_val.split('.')[0] != filter_val;
-      });
+      if (filter_val != "") {
+        var match_fail = data_rows.filter(function () {
+          var row_val = $(this).find('td[class~="apiname"]').text();
+          return row_val.split('.')[0] != filter_val;
+        });
 
-      match_fail.hide();
+        match_fail.hide();
+      }
     } else {
       filter_val = parseFloat(filter_val) || 0;
 


### PR DESCRIPTION
I often find myself scrolling through the list just because I want to find the r5 family... this adds a quick-pick dropdown menu to the filter section to select your desired instance family.

RDS is not supported at this time but should be easy to add if necessary.