### PR TITLE
Changed currency number format

### DIFF
--- a/www/default.js
+++ b/www/default.js
@@ -163,7 +163,7 @@ function change_cost(duration) {
     elem = $(elem);
     per_time = elem.data("pricing")[g_settings.region];
     if (per_time && !isNaN(per_time)) {
-      per_time = (per_time * multiplier).toFixed(6);
+      per_time = (per_time * multiplier).toLocaleString();
       elem.html('<span sort="' + per_time + '">$' + per_time + ' ' + duration + '</span>');
     } else {
       elem.html('<span sort="999999">unavailable</span>');
@@ -182,7 +182,7 @@ function change_cost(duration) {
     per_time = per_time[g_settings.reserved_term];
 
     if (per_time && !isNaN(per_time)) {
-      per_time = (per_time * multiplier).toFixed(6);
+      per_time = (per_time * multiplier).toLocaleString();
       elem.html('<span sort="' + per_time + '">$' + per_time + ' ' + duration + '</span>');
     } else {
       elem.html('<span sort="999999">unavailable</span>');
@@ -193,7 +193,7 @@ function change_cost(duration) {
     elem = $(elem);
     per_time = elem.data("pricing")[g_settings.region];
     if (per_time && !isNaN(per_time)) {
-      per_time = (per_time * multiplier).toFixed(6);
+      per_time = (per_time * multiplier).toLocaleString();
       elem.html('<span sort="' + per_time + '">$' + per_time + ' ' + duration + '</span>');
     } else {
       elem.html('<span sort="999999">unavailable</span>');


### PR DESCRIPTION
Locale string is more readable. Displays to 3dp. This should be sufficient. If not, the could be a condition that this is only for multiplier > 1.
NOT TESTED.