### PR TITLE
Fix sort order per Issue #305 (Fixes #305)

### DIFF
--- a/render.py
+++ b/render.py
@@ -12,11 +12,16 @@ def network_sort(inst):
         'Very Low',
         'Low',
         'Low to Moderate',
-        'Moderate',
-        'High',
         'Up to 10 Gigabit',
+        'Moderate',
         '10 Gigabit',
-        '20 Gigabit'
+        '12 Gigabit',
+        'High',
+        '20 Gigabit',
+        'Up to 25 Gigabit',
+        '25 Gigabit', 
+        '50 Gigabit',
+        '100 Gigabit' 
     ]
     try:
         sort = network_rank.index(perf)


### PR DESCRIPTION
https://github.com/powdahound/ec2instances.info/issues/350#issue-330821801

Note that as new levels of network performance are released (e.g. if AWS releases an instance type with Network performance "Up to 50 Gigbit," this will break the sort order again.  So this piece of code needs to be maintained.