### PR TITLE
a couple of minor UI add-ons: pricing by more than just instance, filter by mem/vCPU profile 

### DIFF
--- a/in/index.html.mako
+++ b/in/index.html.mako
@@ -124,6 +124,7 @@
       <strong> Filter:</strong>
       Min Memory (GiB): <input data-action="datafilter" data-type="memory" class="form-control" />
       Min vCPUs: <input data-action="datafilter" data-type="vcpus" class="form-control" />
+      Min Memory/vCPU (Gib/vCPU): <input data-action="datafilter" data-type="memory-per-vcpu" class="form-control" />
       Min Storage (GiB): <input data-action="datafilter" data-type="storage" class="form-control" />
     </div>
 
@@ -139,6 +140,7 @@
           <th class="vcpus">
             <abbr title="Each virtual CPU is a hyperthread of an Intel Xeon core for M3, C4, C3, R3, HS1, G2, I2, and D2">vCPUs</abbr>
           </th>
+          <th class="memory-per-vcpu">GiB of Memory per vCPU</th>
           <th class="gpus">GPUs</th>
           <th class="gpu_model">GPU model</th>
           <th class="gpu_memory">GPU memory</th>
@@ -258,6 +260,13 @@
                 </a></abbr>
                 % endif
             </span>
+          </td>
+          <td class="memory-per-vcpu">
+            % if inst['memory_per_vcpu'] == 'unknown':
+            <span sort="999999">unknown</span>
+            % else:
+            <span sort="${inst['memory_per_vcpu']}">${"{:.2f}".format(inst['memory_per_vcpu'])} GiB/vCPU</span>
+            % endif
           </td>
           <td class="gpus">${inst['GPU']}</td>
           <td class="gpu_model">${inst['GPU_model']}</td>

--- a/in/index.html.mako
+++ b/in/index.html.mako
@@ -45,6 +45,20 @@
           </ul>
         </div>
 
+        <div class="btn-group" id="pricing-unit-dropdown">
+          <a class="btn dropdown-toggle btn-primary" data-toggle="dropdown" href="#">
+            <i class="icon-shopping-cart icon-white"></i>
+            Pricing Unit: <span class="text"></span>
+            <span class="caret"></span>
+          </a>
+          <ul class="dropdown-menu" role="menu">
+            <li><a href="javascript:;" pricing-unit="instance">Instance</a></li>
+            <li><a href="javascript:;" pricing-unit="vcpu">vCPU</a></li>
+            <li><a href="javascript:;" pricing-unit="ecu">ECU</a></li>
+            <li><a href="javascript:;" pricing-unit="memory">Memory</a></li>
+           </ul>
+        </div>
+
         <div class="btn-group" id="cost-dropdown">
           <a class="btn dropdown-toggle btn-primary" data-toggle="dropdown" href="#">
             <i class="icon-shopping-cart icon-white"></i>
@@ -376,7 +390,7 @@
           ## note that the contents in these cost cells are overwritten by the JS change_cost() func, but the initial
           ## data here is used for sorting (and anyone with JS disabled...)
           ## for more info, see https://github.com/powdahound/ec2instances.info/issues/140
-          <td class="cost-ondemand cost-ondemand-${platform}" data-platform="${platform}">
+          <td class="cost-ondemand cost-ondemand-${platform}" data-platform="${platform}" data-vcpu="${inst['vCPU']}" data-ecu="${inst['ECU']}" data-memory="${inst['memory']}">
             % if inst['pricing'].get('us-east-1', {}).get(platform, {}).get('ondemand', 'N/A') != "N/A":
               <span sort="${inst['pricing']['us-east-1'][platform]['ondemand']}">
                 $${inst['pricing']['us-east-1'][platform]['ondemand']} hourly
@@ -385,7 +399,7 @@
               <span sort="999999">unavailable</span>
             % endif
           </td>
-          <td class="cost-reserved cost-reserved-${platform}" data-platform="${platform}">
+          <td class="cost-reserved cost-reserved-${platform}" data-platform="${platform}" data-vcpu="${inst['vCPU']}" data-ecu="${inst['ECU']}" data-memory="${inst['memory']}">
             % if inst['pricing'].get('us-east-1', {}).get(platform, {}).get('reserved', 'N/A') != "N/A" and inst['pricing']['us-east-1'][platform]['reserved'].get('yrTerm1Standard.noUpfront', 'N/A') != "N/A":
               <span sort="${inst['pricing']['us-east-1'][platform]['reserved']['yrTerm1Standard.noUpfront']}">
                 $${inst['pricing']['us-east-1'][platform]['reserved']['yrTerm1Standard.noUpfront']} hourly
@@ -395,7 +409,7 @@
             % endif
           </td>
           % endfor
-          <td class="cost-ebs-optimized">
+          <td class="cost-ebs-optimized" data-vcpu="${inst['vCPU']}" data-ecu="${inst['ECU']}" data-memory="${inst['memory']}">
            % if inst['ebs_max_bandwidth']:
               % if inst['pricing'].get('us-east-1', {}).get('ebs', 'N/A') != "N/A":
                 <span sort="${inst['pricing']['us-east-1']['ebs']}">
@@ -408,7 +422,7 @@
               <span sort="999999">unavailable</span>
             % endif
           </td>
-          <td class="cost-emr">
+          <td class="cost-emr" data-vcpu="${inst['vCPU']}" data-ecu="${inst['ECU']}" data-memory="${inst['memory']}">
             % if inst['pricing'].get('us-east-1', {}).get("emr", {}):
               <span sort="${inst['pricing']['us-east-1']["emr"]['emr']}">
                 $${inst['pricing']['us-east-1']["emr"]['emr']} hourly

--- a/in/rds.html.mako
+++ b/in/rds.html.mako
@@ -44,6 +44,19 @@
           </ul>
         </div>
 
+        <div class="btn-group" id="pricing-unit-dropdown">
+          <a class="btn dropdown-toggle btn-primary" data-toggle="dropdown" href="#">
+            <i class="icon-shopping-cart icon-white"></i>
+            Pricing Unit: <span class="text"></span>
+            <span class="caret"></span>
+          </a>
+          <ul class="dropdown-menu" role="menu">
+            <li><a href="javascript:;" pricing-unit="instance">Instance</a></li>
+            <li><a href="javascript:;" pricing-unit="vcpu">vCPU</a></li>
+            <li><a href="javascript:;" pricing-unit="memory">Memory</a></li>
+          </ul>
+        </div>
+
         <div class="btn-group" id="cost-dropdown">
           <a class="btn dropdown-toggle btn-primary" data-toggle="dropdown" href="#">
             <i class="icon-shopping-cart icon-white"></i>
@@ -165,7 +178,7 @@
             % endif
           </td>
           % for platform in ['Aurora PostgreSQL', 'Aurora MySQL', 'MariaDB', 'MySQL', 'Oracle','PostgreSQL', 'SQL Server']:
-          <td class="cost-ondemand cost-ondemand-${platform}" data-platform='${platform}'>
+          <td class="cost-ondemand cost-ondemand-${platform}" data-platform='${platform}' data-vcpu='${inst['vcpu']}' data-memory='${inst['memory']}'>
             % if inst['pricing'].get('us-east-1', {}).get(platform, {}).get('ondemand', 'N/A') != "N/A":
               <span sort="${inst['pricing']['us-east-1'][platform]['ondemand']}">
                 $${inst['pricing']['us-east-1'][platform]['ondemand']} per hour
@@ -174,7 +187,7 @@
               <span sort="0">unavailable</span>
             % endif
           </td>
-          <td class="cost-reserved cost-reserved-${platform}" data-platform='${platform}'>
+          <td class="cost-reserved cost-reserved-${platform}" data-platform='${platform}' data-vcpu='${inst['vcpu']}' data-memory='${inst['memory']}'>
             % if inst['pricing'].get('us-east-1', {}).get(platform, {}).get('reserved', 'N/A') != "N/A":
               <span sort="${inst['pricing']['us-east-1'][platform]['reserved'].get('yrTerm1.noUpfront')}">
                 $${inst['pricing']['us-east-1'][platform]['reserved'].get('yrTerm1.noUpfront')} per hour

--- a/render.py
+++ b/render.py
@@ -41,6 +41,13 @@ def add_cpu_detail(i):
     except:
         # these will be instances with variable/burstable ECU
         i['ECU_per_vcpu'] = 'unknown'
+
+    try:
+        i['memory_per_vcpu'] = round(i['memory'] / i['vCPU'], 2)
+    except:
+        # just to be safe...
+        i['memory_per_vcpu'] = 'unknown'
+
     if 'physical_processor' in i:
         i['physical_processor'] = (i['physical_processor'] or '').replace('*', '')
         i['intel_avx'] = 'Yes' if i['intel_avx'] else ''

--- a/www/default.css
+++ b/www/default.css
@@ -59,6 +59,7 @@ body {
 
 #data td {
   font-size: 13px;
+   text-align: right;
 }
 
 #data td.name {

--- a/www/default.js
+++ b/www/default.js
@@ -11,6 +11,7 @@ var g_settings_defaults = {
   reserved_term: 'yrTerm1Standard.noUpfront',
   min_memory: 0,
   min_vcpus: 0,
+  min_memory_per_vcpu: 0,
   min_storage: 0,
   selected: '',
   compare_on: false
@@ -61,6 +62,7 @@ function init_data_table() {
         "aTargets": [
           "architecture",
           "computeunits",
+          "memory-per-vcpu",
           "ecu-per-vcpu",
           "emr-support",
           "gpus",
@@ -360,6 +362,7 @@ function url_for_selections() {
   var params = {
     min_memory: g_settings.min_memory,
     min_vcpus: g_settings.min_vcpus,
+    min_memory_per_vcpu: g_settings.min_memory_per_vcpu,
     min_storage: g_settings.min_storage,
     filter: g_data_table.settings()[0].oPreviousSearch['sSearch'],
     region: g_settings.region,
@@ -428,7 +431,7 @@ var apply_min_values = function () {
     var filter_val = parseFloat($(this).val()) || 0;
 
     // update global variable for dynamic URL
-    g_settings["min_" + filter_on] = filter_val;
+    g_settings["min_" + filter_on.replace('-', '_')] = filter_val;
 
     var match_fail = data_rows.filter(function () {
       var row_val;
@@ -452,6 +455,7 @@ function on_data_table_initialized() {
   // populate filter inputs
   $('[data-action="datafilter"][data-type="memory"]').val(g_settings['min_memory']);
   $('[data-action="datafilter"][data-type="vcpus"]').val(g_settings['min_vcpus']);
+  $('[data-action="datafilter"][data-type="memory-per-vcpu"]').val(g_settings['min_memory_per_vcpu']);
   $('[data-action="datafilter"][data-type="storage"]').val(g_settings['min_storage']);
   g_data_table.search(g_settings['filter']);
   apply_min_values();

--- a/www/rds/index.html
+++ b/www/rds/index.html
@@ -17,9 +17,9 @@
         <iframe src="https://ghbtns.com/github-btn.html?user=powdahound&repo=ec2instances.info&type=star&count=true" frameborder="0" scrolling="0" width="100px" height="20px"></iframe>
       </span>
 
-      
+
     <h1>EC2Instances.info <small>Easy Amazon <b>RDS</b> Instance Comparison</small></h1>
-    
+
 
       <p class="pull-right label label-info">Last Update: 2020-11-15 19:21:05 UTC</p>
       <ul class="nav nav-tabs">
@@ -30,10 +30,10 @@
 
     <div class="clear-fix"></div>
 
-    
 
 
-    
+
+
 
     <div class="row" id="menu">
       <div class="col-sm-12">
@@ -68,6 +68,19 @@
             <li><a href="javascript:;" data-region='us-gov-west-1'>AWS GovCloud (US-West)</a></li>
             <li><a href="javascript:;" data-region='us-gov-east-1'>AWS GovCloud (US-East)</a></li>
           </ul>
+        </div>
+
+        <div class="btn-group" id="pricing-unit-dropdown">
+          <a class="btn dropdown-toggle btn-primary" data-toggle="dropdown" href="#">
+            <i class="icon-shopping-cart icon-white"></i>
+            Pricing Unit: <span class="text"></span>
+            <span class="caret"></span>
+          </a>
+          <ul class="dropdown-menu" role="menu">
+            <li><a href="javascript:;" pricing-unit="instance">Instance</a></li>
+            <li><a href="javascript:;" pricing-unit="vcpu">vCPU</a></li>
+            <li><a href="javascript:;" pricing-unit="memory">Memory</a></li>
+           </ul>
         </div>
 
         <div class="btn-group" id="cost-dropdown">
@@ -178,7 +191,7 @@
           <td class="apiname">db.t3.xlarge</td>
           <td class="memory"><span sort="16">16 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -257,7 +270,7 @@
           <td class="apiname">db.m5.24xlarge</td>
           <td class="memory"><span sort="384">384 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -336,7 +349,7 @@
           <td class="apiname">db.r4.16xlarge</td>
           <td class="memory"><span sort="488">488 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -419,7 +432,7 @@
           <td class="apiname">db.t2.small</td>
           <td class="memory"><span sort="2">2 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -498,7 +511,7 @@
           <td class="apiname">db.r6g.12xlarge</td>
           <td class="memory"><span sort="384">384 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -571,7 +584,7 @@
           <td class="apiname">db.r5.xlarge</td>
           <td class="memory"><span sort="32">32 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -654,7 +667,7 @@
           <td class="apiname">db.r3.4xlarge</td>
           <td class="memory"><span sort="122">122 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">1 x 320 SSD</span>
           </td>
           <td class="ebs-throughput">
@@ -735,7 +748,7 @@
           <td class="apiname">db.r3.xlarge</td>
           <td class="memory"><span sort="30.5">30.5 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">1 x 80 SSD</span>
           </td>
           <td class="ebs-throughput">
@@ -816,7 +829,7 @@
           <td class="apiname">db.m4.xlarge</td>
           <td class="memory"><span sort="16">16 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -895,7 +908,7 @@
           <td class="apiname">db.t2.medium</td>
           <td class="memory"><span sort="4">4 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -974,7 +987,7 @@
           <td class="apiname">db.m1.small</td>
           <td class="memory"><span sort="1.7">1.7 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">1 x 160</span>
           </td>
           <td class="ebs-throughput">
@@ -1047,7 +1060,7 @@
           <td class="apiname">db.t3.medium</td>
           <td class="memory"><span sort="4">4 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -1128,7 +1141,7 @@
           <td class="apiname">db.m5.4xlarge</td>
           <td class="memory"><span sort="64">64 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -1207,7 +1220,7 @@
           <td class="apiname">db.m4.10xlarge</td>
           <td class="memory"><span sort="160">160 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -1286,7 +1299,7 @@
           <td class="apiname">db.r5.16xlarge</td>
           <td class="memory"><span sort="512">512 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -1367,7 +1380,7 @@
           <td class="apiname">db.t3.small</td>
           <td class="memory"><span sort="2">2 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -1446,7 +1459,7 @@
           <td class="apiname">db.m2.2xlarge</td>
           <td class="memory"><span sort="34.2">34.2 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">1 x 850</span>
           </td>
           <td class="ebs-throughput">
@@ -1521,7 +1534,7 @@
           <td class="apiname">db.r5.2xlarge</td>
           <td class="memory"><span sort="64">64 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -1604,7 +1617,7 @@
           <td class="apiname">db.x1e.32xlarge</td>
           <td class="memory"><span sort="3904">3904 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">2 x 1920 SSD</span>
           </td>
           <td class="ebs-throughput">
@@ -1675,7 +1688,7 @@
           <td class="apiname">db.m5.xlarge</td>
           <td class="memory"><span sort="16">16 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -1754,7 +1767,7 @@
           <td class="apiname">db.r5.large</td>
           <td class="memory"><span sort="16">16 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -1837,7 +1850,7 @@
           <td class="apiname">db.m2.4xlarge</td>
           <td class="memory"><span sort="68.4">68.4 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">2 x 840</span>
           </td>
           <td class="ebs-throughput">
@@ -1912,7 +1925,7 @@
           <td class="apiname">db.z1d.2xlarge</td>
           <td class="memory"><span sort="64">64 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">1 x 300 NVMe SSD</span>
           </td>
           <td class="ebs-throughput">
@@ -1983,7 +1996,7 @@
           <td class="apiname">db.t3.micro</td>
           <td class="memory"><span sort="1">1 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -2058,7 +2071,7 @@
           <td class="apiname">db.t1.micro</td>
           <td class="memory"><span sort="0.613">0.613 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -2131,7 +2144,7 @@
           <td class="apiname">db.m5.large</td>
           <td class="memory"><span sort="8">8 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -2210,7 +2223,7 @@
           <td class="apiname">db.m1.xlarge</td>
           <td class="memory"><span sort="15">15 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">4 x 420</span>
           </td>
           <td class="ebs-throughput">
@@ -2285,7 +2298,7 @@
           <td class="apiname">db.r4.2xlarge</td>
           <td class="memory"><span sort="61">61 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -2368,7 +2381,7 @@
           <td class="apiname">db.r4.large</td>
           <td class="memory"><span sort="15.25">15.25 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -2451,7 +2464,7 @@
           <td class="apiname">db.r4.4xlarge</td>
           <td class="memory"><span sort="122">122 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -2534,7 +2547,7 @@
           <td class="apiname">db.m4.2xlarge</td>
           <td class="memory"><span sort="32">32 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -2613,7 +2626,7 @@
           <td class="apiname">db.r3.large</td>
           <td class="memory"><span sort="15.25">15.25 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">1 x 32 SSD</span>
           </td>
           <td class="ebs-throughput">
@@ -2692,7 +2705,7 @@
           <td class="apiname">db.r3.2xlarge</td>
           <td class="memory"><span sort="61">61 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">1 x 160 SSD</span>
           </td>
           <td class="ebs-throughput">
@@ -2773,7 +2786,7 @@
           <td class="apiname">db.m3.xlarge</td>
           <td class="memory"><span sort="15">15 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">2 x 40 SSD</span>
           </td>
           <td class="ebs-throughput">
@@ -2852,7 +2865,7 @@
           <td class="apiname">db.m5.2xlarge</td>
           <td class="memory"><span sort="32">32 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -2931,7 +2944,7 @@
           <td class="apiname">db.t3.2xlarge</td>
           <td class="memory"><span sort="32">32 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -3008,7 +3021,7 @@
           <td class="apiname">db.m5.12xlarge</td>
           <td class="memory"><span sort="192">192 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -3087,7 +3100,7 @@
           <td class="apiname">db.m4.4xlarge</td>
           <td class="memory"><span sort="64">64 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -3166,7 +3179,7 @@
           <td class="apiname">db.z1d.6xlarge</td>
           <td class="memory"><span sort="192">192 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">1 x 900 NVMe SSD</span>
           </td>
           <td class="ebs-throughput">
@@ -3237,7 +3250,7 @@
           <td class="apiname">db.m6g.16xlarge</td>
           <td class="memory"><span sort="256">256 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -3310,7 +3323,7 @@
           <td class="apiname">db.r4.xlarge</td>
           <td class="memory"><span sort="30.5">30.5 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -3393,7 +3406,7 @@
           <td class="apiname">db.r5.4xlarge</td>
           <td class="memory"><span sort="128">128 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -3476,7 +3489,7 @@
           <td class="apiname">db.m4.large</td>
           <td class="memory"><span sort="8">8 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -3555,7 +3568,7 @@
           <td class="apiname">db.r5.8xlarge</td>
           <td class="memory"><span sort="256">256 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -3636,7 +3649,7 @@
           <td class="apiname">db.t2.micro</td>
           <td class="memory"><span sort="1">1 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -3713,7 +3726,7 @@
           <td class="apiname">db.m6g.12xlarge</td>
           <td class="memory"><span sort="192">192 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -3786,7 +3799,7 @@
           <td class="apiname">db.z1d.xlarge</td>
           <td class="memory"><span sort="32">32 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">1 x 150 NVMe SSD</span>
           </td>
           <td class="ebs-throughput">
@@ -3857,7 +3870,7 @@
           <td class="apiname">db.r6g.2xlarge</td>
           <td class="memory"><span sort="64">64 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -3930,7 +3943,7 @@
           <td class="apiname">db.m5.8xlarge</td>
           <td class="memory"><span sort="128">128 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -4007,7 +4020,7 @@
           <td class="apiname">db.r4.8xlarge</td>
           <td class="memory"><span sort="244">244 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -4090,7 +4103,7 @@
           <td class="apiname">db.r5.24xlarge</td>
           <td class="memory"><span sort="768">768 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -4173,7 +4186,7 @@
           <td class="apiname">db.r3.8xlarge</td>
           <td class="memory"><span sort="244">244 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">2 x 320 SSD</span>
           </td>
           <td class="ebs-throughput">
@@ -4250,7 +4263,7 @@
           <td class="apiname">db.m6g.large</td>
           <td class="memory"><span sort="8">8 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -4323,7 +4336,7 @@
           <td class="apiname">db.t2.large</td>
           <td class="memory"><span sort="8">8 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -4398,7 +4411,7 @@
           <td class="apiname">db.t3.large</td>
           <td class="memory"><span sort="8">8 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -4477,7 +4490,7 @@
           <td class="apiname">db.m5.16xlarge</td>
           <td class="memory"><span sort="256">256 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -4554,7 +4567,7 @@
           <td class="apiname">db.m3.large</td>
           <td class="memory"><span sort="7.5">7.5 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">1 x 32 SSD</span>
           </td>
           <td class="ebs-throughput">
@@ -4631,7 +4644,7 @@
           <td class="apiname">db.r5.12xlarge</td>
           <td class="memory"><span sort="384">384 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -4714,7 +4727,7 @@
           <td class="apiname">db.t2.2xlarge</td>
           <td class="memory"><span sort="32">32 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -4789,7 +4802,7 @@
           <td class="apiname">db.cv11.medium</td>
           <td class="memory"><span sort="2">2 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -4864,7 +4877,7 @@
           <td class="apiname">db.x1.16xlarge</td>
           <td class="memory"><span sort="976">976 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">1 x 1920 SSD</span>
           </td>
           <td class="ebs-throughput">
@@ -4935,7 +4948,7 @@
           <td class="apiname">db.m3.2xlarge</td>
           <td class="memory"><span sort="30">30 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">2 x 80 SSD</span>
           </td>
           <td class="ebs-throughput">
@@ -5014,7 +5027,7 @@
           <td class="apiname">db.x1e.8xlarge</td>
           <td class="memory"><span sort="976">976 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">1 x 960 SSD</span>
           </td>
           <td class="ebs-throughput">
@@ -5085,7 +5098,7 @@
           <td class="apiname">db.x1e.2xlarge</td>
           <td class="memory"><span sort="244">244 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">1 x 240 SSD</span>
           </td>
           <td class="ebs-throughput">
@@ -5156,7 +5169,7 @@
           <td class="apiname">db.z1d.3xlarge</td>
           <td class="memory"><span sort="96">96 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">1 x 450 NVMe SSD</span>
           </td>
           <td class="ebs-throughput">
@@ -5227,7 +5240,7 @@
           <td class="apiname">db.m4.16xlarge</td>
           <td class="memory"><span sort="256">256 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -5306,7 +5319,7 @@
           <td class="apiname">db.x1.32xlarge</td>
           <td class="memory"><span sort="1952">1952 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">1 x 1920 SSD</span>
           </td>
           <td class="ebs-throughput">
@@ -5377,7 +5390,7 @@
           <td class="apiname">db.m6g.8xlarge</td>
           <td class="memory"><span sort="128">128 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -5450,7 +5463,7 @@
           <td class="apiname">db.r6g.4xlarge</td>
           <td class="memory"><span sort="128">128 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -5523,7 +5536,7 @@
           <td class="apiname">db.m3.medium</td>
           <td class="memory"><span sort="3.75">3.75 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">1 x 4 SSD</span>
           </td>
           <td class="ebs-throughput">
@@ -5600,7 +5613,7 @@
           <td class="apiname">db.t2.xlarge</td>
           <td class="memory"><span sort="16">16 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -5675,7 +5688,7 @@
           <td class="apiname">db.r6g.large</td>
           <td class="memory"><span sort="16">16 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -5748,7 +5761,7 @@
           <td class="apiname">db.m6g.xlarge</td>
           <td class="memory"><span sort="16">16 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -5821,7 +5834,7 @@
           <td class="apiname">db.x1e.16xlarge</td>
           <td class="memory"><span sort="1952">1952 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">1 x 1920 SSD</span>
           </td>
           <td class="ebs-throughput">
@@ -5892,7 +5905,7 @@
           <td class="apiname">db.m6g.4xlarge</td>
           <td class="memory"><span sort="64">64 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -5965,7 +5978,7 @@
           <td class="apiname">db.z1d.12xlarge</td>
           <td class="memory"><span sort="384">384 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">2 x 900 NVMe SSD</span>
           </td>
           <td class="ebs-throughput">
@@ -6036,7 +6049,7 @@
           <td class="apiname">db.m1.large</td>
           <td class="memory"><span sort="7.5">7.5 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">2 x 420</span>
           </td>
           <td class="ebs-throughput">
@@ -6109,7 +6122,7 @@
           <td class="apiname">db.z1d.large</td>
           <td class="memory"><span sort="16">16 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">1 x 75 NVMe SSD</span>
           </td>
           <td class="ebs-throughput">
@@ -6180,7 +6193,7 @@
           <td class="apiname">db.m1.medium</td>
           <td class="memory"><span sort="3.75">3.75 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">1 x 410</span>
           </td>
           <td class="ebs-throughput">
@@ -6253,7 +6266,7 @@
           <td class="apiname">db.x1e.4xlarge</td>
           <td class="memory"><span sort="488">488 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">1 x 480 SSD</span>
           </td>
           <td class="ebs-throughput">
@@ -6324,7 +6337,7 @@
           <td class="apiname">db.x1e.xlarge</td>
           <td class="memory"><span sort="122">122 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">1 x 120 SSD</span>
           </td>
           <td class="ebs-throughput">
@@ -6395,7 +6408,7 @@
           <td class="apiname">db.r6g.8xlarge</td>
           <td class="memory"><span sort="256">256 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -6468,7 +6481,7 @@
           <td class="apiname">db.m6g.2xlarge</td>
           <td class="memory"><span sort="32">32 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -6541,7 +6554,7 @@
           <td class="apiname">db.r6g.16xlarge</td>
           <td class="memory"><span sort="512">512 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -6614,7 +6627,7 @@
           <td class="apiname">db.cv11.small</td>
           <td class="memory"><span sort="1">1 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -6689,7 +6702,7 @@
           <td class="apiname">db.cv11.9xlarge</td>
           <td class="memory"><span sort="72">72 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -6764,7 +6777,7 @@
           <td class="apiname">db.r6g.xlarge</td>
           <td class="memory"><span sort="32">32 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -6837,7 +6850,7 @@
           <td class="apiname">db.cv11.xlarge</td>
           <td class="memory"><span sort="8">8 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -6912,7 +6925,7 @@
           <td class="apiname">db.m2.xlarge</td>
           <td class="memory"><span sort="17.1">17.1 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">1 x 420</span>
           </td>
           <td class="ebs-throughput">
@@ -6987,7 +7000,7 @@
           <td class="apiname">db.rv11.large</td>
           <td class="memory"><span sort="16">16 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -7062,7 +7075,7 @@
           <td class="apiname">db.mv11.xlarge</td>
           <td class="memory"><span sort="16">16 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -7137,7 +7150,7 @@
           <td class="apiname">db.cv11.4xlarge</td>
           <td class="memory"><span sort="32">32 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -7212,7 +7225,7 @@
           <td class="apiname">db.rv11.12xlarge</td>
           <td class="memory"><span sort="384">384 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -7287,7 +7300,7 @@
           <td class="apiname">db.mv11.medium</td>
           <td class="memory"><span sort="4">4 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -7362,7 +7375,7 @@
           <td class="apiname">db.rv11.2xlarge</td>
           <td class="memory"><span sort="64">64 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -7437,7 +7450,7 @@
           <td class="apiname">db.cv11.large</td>
           <td class="memory"><span sort="4">4 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -7512,7 +7525,7 @@
           <td class="apiname">db.mv11.2xlarge</td>
           <td class="memory"><span sort="32">32 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -7587,7 +7600,7 @@
           <td class="apiname">db.rv11.xlarge</td>
           <td class="memory"><span sort="32">32 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -7662,7 +7675,7 @@
           <td class="apiname">db.cv11.2xlarge</td>
           <td class="memory"><span sort="16">16 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -7737,7 +7750,7 @@
           <td class="apiname">db.cv11.18xlarge</td>
           <td class="memory"><span sort="144">144 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -7812,7 +7825,7 @@
           <td class="apiname">db.rv11.4xlarge</td>
           <td class="memory"><span sort="128">128 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -7887,7 +7900,7 @@
           <td class="apiname">db.mv11.4xlarge</td>
           <td class="memory"><span sort="64">64 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -7962,7 +7975,7 @@
           <td class="apiname">db.mv11.24xlarge</td>
           <td class="memory"><span sort="384">384 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -8037,7 +8050,7 @@
           <td class="apiname">db.rv11.24xlarge</td>
           <td class="memory"><span sort="768">768 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -8112,7 +8125,7 @@
           <td class="apiname">db.mv11.large</td>
           <td class="memory"><span sort="8">8 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">
@@ -8187,7 +8200,7 @@
           <td class="apiname">db.mv11.12xlarge</td>
           <td class="memory"><span sort="192">192 GiB</span></td>
           <td class="storage">
-          
+
           <span sort="0">0 GiB (EBS only)</span>
           </td>
           <td class="ebs-throughput">


### PR DESCRIPTION
This PR adds a couple of UI tweaks that were useful to me recently:
- added menu to render costs by more than just instance, i.e. vCPU, ECU, etc.
- added column and filter to more conveniently visualize the mem/vCPU profiles

if this goes through, i also have a branch with an additional button to hide/show the units suffixes to reduce the visual noise.  