### PR TITLE
correction for g2.8xlarge total gpu mem

### DIFF
--- a/scrape.py
+++ b/scrape.py
@@ -559,7 +559,7 @@ def add_gpu_info(instances):
             'compute_capability': 3.0,
             'gpu_count': 4,
             'cuda_cores': 6144,
-            'gpu_memory': 32
+            'gpu_memory': 16
         },
         'g3s.xlarge': {
             'gpu_model': 'NVIDIA Tesla M60',


### PR DESCRIPTION
g2.8xlarge uses 4 instance of K250 gpu, each with 4GB memory.