### PR TITLE
Add EC2 Spot pricing information

### DIFF
--- a/ec2.py
+++ b/ec2.py
@@ -236,10 +236,14 @@ def add_spot_pricing(imap):
                     inst = imap[price['InstanceType']]
                     platform = translate_platform_name(price['ProductDescription'], 'NA')
                     region = price['AvailabilityZone'][0:-1]
-                    # define empty values to avoid dictionary exception for missing instance types
+                    # define some empty/meaningful default values to avoid dictionary exception for missing instance types
                     inst.pricing[region].setdefault(platform,{})
                     inst.pricing[region][platform].setdefault('spot',[])
+                    inst.pricing[region][platform].setdefault('spot_min','N/A')
+                    inst.pricing[region][platform].setdefault('spot_max','N/A')
                     insort(inst.pricing[region][platform]['spot'], price['SpotPrice'])
+                    inst.pricing[region][platform]['spot_min'] = inst.pricing[region][platform]['spot'][0]
+                    inst.pricing[region][platform]['spot_max'] = inst.pricing[region][platform]['spot'][-1]
         except Exception as e:
             # print more details about the instance for debugging
             print(f"ERROR: Exception adding Spot pricing for {region}: {e}")

--- a/ec2.py
+++ b/ec2.py
@@ -1,6 +1,7 @@
 import botocore
 import botocore.exceptions
 import boto3
+from bisect import insort
 from datetime import datetime
 import locale
 import json
@@ -235,7 +236,10 @@ def add_spot_pricing(imap):
                     inst = imap[price['InstanceType']]
                     platform = translate_platform_name(price['ProductDescription'], 'NA')
                     region = price['AvailabilityZone'][0:-1]
-                    inst.pricing[region][platform]['spot'] = price['SpotPrice']
+                    # define empty values to avoid dictionary exception for missing instance types
+                    inst.pricing[region].setdefault('platform',{})
+                    inst.pricing[region][platform].setdefault('spot',[])
+                    insort(inst.pricing[region][platform]['spot'], price['SpotPrice'])
         except Exception as e:
             # print more details about the instance for debugging
             print(f"ERROR: Exception adding Spot pricing for {region}: {e}")

--- a/ec2.py
+++ b/ec2.py
@@ -237,7 +237,7 @@ def add_spot_pricing(imap):
                     platform = translate_platform_name(price['ProductDescription'], 'NA')
                     region = price['AvailabilityZone'][0:-1]
                     # define empty values to avoid dictionary exception for missing instance types
-                    inst.pricing[region].setdefault('platform',{})
+                    inst.pricing[region].setdefault(platform,{})
                     inst.pricing[region][platform].setdefault('spot',[])
                     insort(inst.pricing[region][platform]['spot'], price['SpotPrice'])
         except Exception as e:

--- a/in/index.html.mako
+++ b/in/index.html.mako
@@ -166,18 +166,26 @@
           <th class="cost-reserved cost-reserved-linux">
             <abbr title='Reserved costs are an "effective" hourly rate, calculated by hourly rate + (upfront cost / hours in reserved term).  Actual hourly rates may vary.'>Linux Reserved cost</abbr>
           </th>
+          <th class="cost-spot cost-spot-linux">Linux Spot cost</th>
+
           <th class="cost-ondemand cost-ondemand-rhel">RHEL On Demand cost</th>
           <th class="cost-reserved cost-reserved-rhel">
             <abbr title='Reserved costs are an "effective" hourly rate, calculated by hourly rate + (upfront cost / hours in reserved term).  Actual hourly rates may vary.'>RHEL Reserved cost</abbr>
           </th>
+          <th class="cost-spot cost-spot-rhel">RHEL Spot cost</th>
+
           <th class="cost-ondemand cost-ondemand-sles">SLES On Demand cost</th>
           <th class="cost-reserved cost-reserved-sles">
             <abbr title='Reserved costs are an "effective" hourly rate, calculated by hourly rate + (upfront cost / hours in reserved term).  Actual hourly rates may vary.'>SLES Reserved cost</abbr>
           </th>
+          <th class="cost-spot cost-spot-sles">SLES Spot cost</th>
+
           <th class="cost-ondemand cost-ondemand-mswin">Windows On Demand cost</th>
           <th class="cost-reserved cost-reserved-mswin">
             <abbr title='Reserved costs are an "effective" hourly rate, calculated by hourly rate + (upfront cost / hours in reserved term).  Actual hourly rates may vary.'>Windows Reserved cost</abbr>
           </th>
+          <th class="cost-spot cost-spot-mswin">Windows Spot cost</th>
+
           <th class="cost-ondemand cost-ondemand-mswinSQLWeb">Windows SQL Web On Demand cost</th>
           <th class="cost-reserved cost-reserved-mswinSQLWeb">
             <abbr title='Reserved costs are an "effective" hourly rate, calculated by hourly rate + (upfront cost / hours in reserved term).  Actual hourly rates may vary.'>Windows SQL Web Reserved cost</abbr>
@@ -394,6 +402,25 @@
               <span sort="999999">unavailable</span>
             % endif
           </td>
+          % if platform in ['linux', 'rhel', 'sles', 'mswin']:
+          <td class="cost-spot cost-spot-${platform}" data-platform="${platform}">
+            % if inst['pricing'].get('us-east-1', {}).get(platform, {}).get('spot', []) != []:
+              <span sort="${inst['pricing']['us-east-1'][platform]['spot'][0]}">
+              <%
+              min_spot = inst['pricing']['us-east-1'][platform]['spot'][0]
+              max_spot = inst['pricing']['us-east-1'][platform]['spot'][-1]
+              %>
+              % if min_spot == max_spot:
+                $${min_spot} hourly
+              % else:
+                $${min_spot} - $${max_spot} hourly
+              % endif
+              </span>
+            % else:
+              <span sort="999999">unavailable</span>
+            % endif
+          </td>
+          % endif
           % endfor
           <td class="cost-ebs-optimized">
            % if inst['ebs_max_bandwidth']:

--- a/in/index.html.mako
+++ b/in/index.html.mako
@@ -419,6 +419,8 @@
             % else:
               <span sort="999999">unavailable</span>
             % endif
+          % else:
+            <span sort="999999">unavailable</span>
           </td>
           % endif
           % endfor

--- a/in/index.html.mako
+++ b/in/index.html.mako
@@ -166,25 +166,29 @@
           <th class="cost-reserved cost-reserved-linux">
             <abbr title='Reserved costs are an "effective" hourly rate, calculated by hourly rate + (upfront cost / hours in reserved term).  Actual hourly rates may vary.'>Linux Reserved cost</abbr>
           </th>
-          <th class="cost-spot cost-spot-linux">Linux Spot cost</th>
+          <th class="cost-spot-min cost-spot-min-linux">Linux Spot Minimum cost</th>
+          <th class="cost-spot-max cost-spot-max-linux">Linux Spot Maximum cost</th>
 
           <th class="cost-ondemand cost-ondemand-rhel">RHEL On Demand cost</th>
           <th class="cost-reserved cost-reserved-rhel">
             <abbr title='Reserved costs are an "effective" hourly rate, calculated by hourly rate + (upfront cost / hours in reserved term).  Actual hourly rates may vary.'>RHEL Reserved cost</abbr>
           </th>
-          <th class="cost-spot cost-spot-rhel">RHEL Spot cost</th>
+          <th class="cost-spot-min cost-spot-min-rhel">RHEL Spot Minimum cost</th>
+          <th class="cost-spot-max cost-spot-max-rhel">RHEL Spot Maximum cost</th>
 
           <th class="cost-ondemand cost-ondemand-sles">SLES On Demand cost</th>
           <th class="cost-reserved cost-reserved-sles">
             <abbr title='Reserved costs are an "effective" hourly rate, calculated by hourly rate + (upfront cost / hours in reserved term).  Actual hourly rates may vary.'>SLES Reserved cost</abbr>
           </th>
-          <th class="cost-spot cost-spot-sles">SLES Spot cost</th>
+          <th class="cost-spot-min cost-spot-min-sles">SLES Spot Minimum cost</th>
+          <th class="cost-spot-max cost-spot-max-sles">SLES Spot Maximum cost</th>
 
           <th class="cost-ondemand cost-ondemand-mswin">Windows On Demand cost</th>
           <th class="cost-reserved cost-reserved-mswin">
             <abbr title='Reserved costs are an "effective" hourly rate, calculated by hourly rate + (upfront cost / hours in reserved term).  Actual hourly rates may vary.'>Windows Reserved cost</abbr>
           </th>
-          <th class="cost-spot cost-spot-mswin">Windows Spot cost</th>
+          <th class="cost-spot-min cost-spot-min-mswin">Windows Spot Minimum cost</th>
+          <th class="cost-spot-max cost-spot-max-mswin">Windows Spot Maximum cost</th>
 
           <th class="cost-ondemand cost-ondemand-mswinSQLWeb">Windows SQL Web On Demand cost</th>
           <th class="cost-reserved cost-reserved-mswinSQLWeb">
@@ -403,24 +407,30 @@
             % endif
           </td>
           % if platform in ['linux', 'rhel', 'sles', 'mswin']:
-          <td class="cost-spot cost-spot-${platform}" data-platform="${platform}">
-            % if inst['pricing'].get('us-east-1', {}).get(platform, {}).get('spot', []) != []:
-              <span sort="${inst['pricing']['us-east-1'][platform]['spot'][0]}">
-              <%
-              min_spot = inst['pricing']['us-east-1'][platform]['spot'][0]
-              max_spot = inst['pricing']['us-east-1'][platform]['spot'][-1]
-              %>
-              % if min_spot == max_spot:
-                $${min_spot} hourly
-              % else:
-                $${min_spot} - $${max_spot} hourly
-              % endif
+          <td class="cost-spot-min cost-spot-min-${platform}" data-platform="${platform}">
+            % if inst['pricing'].get('us-east-1', {}).get(platform, {}).get('spot_min', 'N/A') != 'N/A':
+            <%
+                spot_min = inst['pricing']['us-east-1'][platform]['spot_min']
+            %>
+              <span sort="${spot_min}">
+                $${spot_min} hourly
               </span>
             % else:
               <span sort="999999">unavailable</span>
             % endif
-          % else:
-            <span sort="999999">unavailable</span>
+          </td>
+
+          <td class="cost-spot-max cost-spot-max-${platform}" data-platform="${platform}">
+            %if inst['pricing'].get('us-east-1', {}).get(platform, {}).get('spot_max', 'N/A') != 'N/A':
+            <%
+              spot_max = inst['pricing']['us-east-1'][platform]['spot_max']
+            %>
+              <span sort="${spot_max}">
+                $${spot_max} hourly
+              </span>
+            % else:
+              <span sort="999999">unavailable</span>
+            % endif
           </td>
           % endif
           % endfor

--- a/www/default.js
+++ b/www/default.js
@@ -51,6 +51,8 @@ function init_data_table() {
           "networkperf",
           "cost-ondemand",
           "cost-reserved",
+          "cost-spot-min",
+          "cost-spot-max",
           "cost-ebs-optimized",
         ],
         "sType": "span-sort"
@@ -94,6 +96,13 @@ function init_data_table() {
           "cost-reserved-linuxSQL",
           "cost-reserved-linuxSQLEnterprise",
           "cost-reserved-linuxSQLWeb",
+          "cost-spot-min-mswin",
+          "cost-spot-min-rhel",
+          "cost-spot-min-sles",
+          "cost-spot-max-linux",
+          "cost-spot-max-mswin",
+          "cost-spot-max-rhel",
+          "cost-spot-max-sles",
           "ebs-throughput",
           "ebs-iops",
           "ebs-as-nvme",
@@ -193,6 +202,28 @@ function change_cost(duration) {
     elem = $(elem);
     per_time = get_pricing(elem.closest("tr").attr("id"), g_settings.region, elem.data("platform"), "reserved", g_settings.reserved_term);
 
+    if (per_time && !isNaN(per_time)) {
+      per_time = (per_time * multiplier).toFixed(6);
+      elem.html('<span sort="' + per_time + '">$' + per_time + ' ' + duration + '</span>');
+    } else {
+      elem.html('<span sort="999999">unavailable</span>');
+    }
+  });
+
+  $.each($("td.cost-spot-min"), function (i, elem) {
+    elem = $(elem);
+    per_time = get_pricing(elem.closest("tr").attr("id"), g_settings.region, elem.data("platform"), "spot_min");
+    if (per_time && !isNaN(per_time)) {
+      per_time = (per_time * multiplier).toFixed(6);
+      elem.html('<span sort="' + per_time + '">$' + per_time + ' ' + duration + '</span>');
+    } else {
+      elem.html('<span sort="999999">unavailable</span>');
+    }
+  });
+
+  $.each($("td.cost-spot-max"), function (i, elem) {
+    elem = $(elem);
+    per_time = get_pricing(elem.closest("tr").attr("id"), g_settings.region, elem.data("platform"), "spot_max");
     if (per_time && !isNaN(per_time)) {
       per_time = (per_time * multiplier).toFixed(6);
       elem.html('<span sort="' + per_time + '">$' + per_time + ' ' + duration + '</span>');


### PR DESCRIPTION
This implements #109.

Current status:
- adds Spot price to the EC2 pricing scraper
- data seems to be added correctly to `instances.json`, we now have a list of Spot prices within a region, as well as the min/max values saved as additional fields, which are also shown in the UI. The list can potentially be used for some automation use cases, but may need to be enriched a bit, maybe with some physical AZ information.
- data is exposed to the UI as shown in the screenshot below
- data is now shown for all instance types and seems correct

M5DN.xlarge in Frankfurt, compared to the AWS console pricing history view to see that data matches
![image](https://user-images.githubusercontent.com/95209/124898117-2f591380-dfdf-11eb-9fd1-a669e7a2fa53.png)

Same M5DN.xlarge in Frankfurt, but with monthly view:
![image](https://user-images.githubusercontent.com/95209/124898247-4ef03c00-dfdf-11eb-9028-5eb68145b3ea.png)

You can see this live at  https://spot-on-ec2-instances-info.netlify.app/

This work was contributed by Amazon AWS.