### PR TITLE
Fix Spot instance pricing for instances such as p3.16xlarge

### DIFF
--- a/ec2.py
+++ b/ec2.py
@@ -236,7 +236,8 @@ def add_spot_pricing(imap):
                     inst.pricing[region][platform].setdefault('spot',[])
                     inst.pricing[region][platform].setdefault('spot_min','N/A')
                     inst.pricing[region][platform].setdefault('spot_max','N/A')
-                    insort(inst.pricing[region][platform]['spot'], price['SpotPrice'])
+                    inst.pricing[region][platform]['spot'].append(price['SpotPrice'])
+                    inst.pricing[region][platform]['spot'].sort(key=float)
                     inst.pricing[region][platform]['spot_min'] = inst.pricing[region][platform]['spot'][0]
                     inst.pricing[region][platform]['spot_max'] = inst.pricing[region][platform]['spot'][-1]
         except Exception as e:


### PR DESCRIPTION
This was caused by the use of `insort`, which legitimately considers the
Spot data as strings, as per instances.json, essentially giving us string
alphabetic sorting instead of numeric sorting.

The sorting is now done after each insert, costing us a few more cycles,
but this way we can force the sorting to be done by numerical value.

Fixes #578.