### PR TITLE
Fix scraper for burst credits

### DIFF
--- a/scrape.py
+++ b/scrape.py
@@ -436,7 +436,7 @@ def add_t2_credits(instances):
     # It seems it's no longer dynamically loaded
     url = "http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/t2-credits-baseline-concepts.html"
     tree = etree.parse(urllib2.urlopen(url), etree.HTMLParser())
-    table = tree.xpath('//div[@class="table-contents"]//table')[0]
+    table = tree.xpath('//div[@class="table-contents"]//table')[1]
     rows = table.xpath('.//tr[./td]')
     assert len(rows) > 0, "Failed to find T2 CPU credit info"
 


### PR DESCRIPTION
There were some changes on the page detailing burst credits, including the addition of a new table, which broke the scraper, causing base_performance and burst_minutes to be null for all burstable instances. This updates the xpath so those fields are set again.