### PR TITLE
chore: removed duplication condition when parsing RDS's reserved price

### DIFF
--- a/rds.py
+++ b/rds.py
@@ -175,10 +175,6 @@ def scrape(output_file, input_file=None):
                     # print(f"WARNING: Received reserved pricing info for unknown sku={sku}")
                     continue
 
-                # skip multi-az
-                if instance['deploymentOption'] != 'Single-AZ':
-                    continue
-
                 region = instance['region']
 
                 # create a regional hash


### PR DESCRIPTION
This condition has already been applied to the instance at [this line](https://sourcegraph.com/github.com/vantage-sh/ec2instances.info/-/blob/rds.py?L80).