### PR TITLE
should fix #615 and #554

### DIFF
--- a/www/default.js
+++ b/www/default.js
@@ -136,15 +136,16 @@ function init_data_table() {
     stateDuration: 0,
 
     // Allow export to CSV: only visible columns and only current filtered data
-    buttons: [{
-      extend: 'csv',
-      text: 'CSV',
-      exportOptions: {
-        modifier: { search: 'applied' },
-        columns: ':visible'
-      }
-    }],
-
+    buttons: [
+      {
+        extend: 'csv',
+        text: 'CSV',
+        exportOptions: {
+          modifier: {search: 'applied'},
+          columns: ':visible',
+        },
+      },
+    ],
   });
 
   g_data_table

--- a/www/default.js
+++ b/www/default.js
@@ -135,8 +135,16 @@ function init_data_table() {
     stateSave: true,
     stateDuration: 0,
 
-    // Allow export to CSV
-    buttons: ['csv'],
+    // Allow export to CSV: only visible columns and only current filtered data
+    buttons: [{
+      extend: 'csv',
+      text: 'CSV',
+      exportOptions: {
+        modifier: { search: 'applied' },
+        columns: ':visible'
+      }
+    }],
+
   });
 
   g_data_table


### PR DESCRIPTION
also addresses closed issues #274, #353, #385, #426, #529, and #543

We can also upgrade https://cdn.datatables.net/buttons/ which is now on version 2.2.3 and we are using version 1.2.4 (see `base.mako`)

There are still state management issues. For availability zones, you must have it as a showing column first. Then when you change the region the AZ will change. If you have the AZ column hidden, change the reason, then show it, the AZ will be us-east-1