### PR TITLE
Add new OS available from EC2 + make translate_platform_name a little more robust

### DIFF
--- a/ec2.py
+++ b/ec2.py
@@ -27,6 +27,7 @@ def translate_platform_name(operating_system, preinstalled_software):
         # Spot products
         "Linux/UNIX": "linux",
         "Red Hat Enterprise Linux": "rhel",
+        "Red Hat Enterprise Linux (Amazon VPC)": "rhel",
         "SUSE Linux": "sles",
     }
     software = {
@@ -35,7 +36,7 @@ def translate_platform_name(operating_system, preinstalled_software):
         "SQL Web": "SQLWeb",
         "SQL Ent": "SQLEnterprise",
     }
-    return os[operating_system] + software[preinstalled_software]
+    return os.get(operating_system, 'unknown') + software.get(preinstalled_software, 'unknown')
 
 
 # Translate between the API and what is used locally


### PR DESCRIPTION
Addresses the following exception when running `python3 ./scrape.py`:

```
Traceback (most recent call last):
  File "./scrape.py", line 1054, in <module>
    scrape("www/instances.json")
  File "./scrape.py", line 1018, in scrape
    add_pricing_info(all_instances)
  File "./scrape.py", line 234, in add_pricing_info
    ec2.add_pricing(by_type)
  File "/home/dghai/ec2instances.info/ec2.py", line 198, in add_pricing
    add_spot_pricing(imap)
  File "/home/dghai/ec2instances.info/ec2.py", line 269, in add_spot_pricing
    price["ProductDescription"], "NA"
  File "/home/dghai/ec2instances.info/ec2.py", line 38, in translate_platform_name
    return os[operating_system] + software[preinstalled_software]
KeyError: 'Red Hat Enterprise Linux (Amazon VPC)'
```