### PR TITLE
add spot interrupt info to linux/windows instances where applicable

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,6 +25,6 @@ jobs:
           key: ${{ runner.os }}-npm-prettier
           restore-keys: |
             ${{ runner.os }}-npm-
-      - run: npm install -g prettier@2.6.2
+      - run: npm install -g prettier@2.7.1
       - run: |-
           prettier --check .

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # EC2Instances.info
 
 [![uses aws](https://img.shields.io/badge/uses-AWS-yellow)](https://aws.amazon.com/)
-[![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/release/python-380/)
+[![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/release/python-380/)
 [![python style: black](https://img.shields.io/badge/python%20style-black-000000.svg?style=flat-square)](https://github.com/psf/black)
 
 ![Vantage Picture](https://uploads-ssl.webflow.com/5f9ba05ba40d6414f341df34/5f9bb1764b6670c6f7739564_moutain-scene.svg)

--- a/default.nix
+++ b/default.nix
@@ -2,9 +2,9 @@ with builtins;
 { pkgs ? import
     (
       fetchTarball {
-        name = "nixpkgs-unstable-2022-04-21";
-        url = "https://github.com/NixOS/nixpkgs/archive/76b68621e88f674922aa70276a8333f319ce9c05.tar.gz";
-        sha256 = "0c02rxy51jyvmim3h394xjxb6wmnla52mdx1h7rq8x0cf47wmfq4";
+        name = "nixpkgs-unstable-2022-08-17";
+        url = "https://github.com/NixOS/nixpkgs/archive/6c6409e965a6c883677be7b9d87a95fab6c3472e.tar.gz";
+        sha256 = "0l1py0rs1940wx76gpg66wn1kgq2rv2m9hzrhq5isz42hdpf4q6r";
       }
     )
     {
@@ -28,18 +28,19 @@ let
       jq
     ];
     formatters = [
-      black
       nixpkgs-fmt
       nodePackages.prettier
     ];
     python = [
-      (python39.withPackages (p: with p; lib.flatten [
+      (python39.withPackages (p: with p; [
+        black
         boto
         boto3
         (invocations.overridePythonAttrs (old: { propagatedBuildInputs = old.propagatedBuildInputs ++ [ tqdm ]; }))
         invoke
         lxml
         Mako
+        pyyaml
         requests
         six
       ]))


### PR DESCRIPTION
This PR adds some spot interrupt advisor information to the instances where we can access that info!

Currently, these are added as the literal associated with the enum on their resource for `pct_interrupt`, but we can adjust if we'd like. This also adds a `pct_savings_od` representing the percentage savings over On Demand for that instance type in the given region.

I'm not super tied to any particular naming convention for these, so I'm open to suggestions!