### PR TITLE
Avoid creation of empty data for Chinese regions

### DIFF
--- a/ec2.py
+++ b/ec2.py
@@ -172,6 +172,11 @@ def add_pricing(imap):
                 continue
 
             region = descriptions[location]
+
+            # Skip Chinese regions because they generate incorrect pricing data
+            if region.startswith('cn-'):
+                continue
+
             terms = offer.get("terms")
 
             operating_system = product_attributes.get("operatingSystem")


### PR DESCRIPTION
This helps remove this workaround https://github.com/LeanerCloud/ec2-instances-info/blob/master/Makefile#L21 and also makes the data file slightly smaller.


```
root@bfcdece0c60e:/opt/app# curl -s localhost:8080/instances.json  | grep eu-west | wc -l
2585
root@bfcdece0c60e:/opt/app# curl -s localhost:8080/instances.json  | grep cn | wc -l
0
```