### PR TITLE
Individual Instance Inspection

### DIFF
--- a/detail_pages_rds.py
+++ b/detail_pages_rds.py
@@ -33,6 +33,8 @@ rds_engine_mapping = {
     "230": "SQL Server Enterprise (Outpost On-Prem)",
     "231": "SQL Server (Outpost On-Prem)",
     "232": "SQL Server Web (Outpost On-Prem)",
+    "405": "SQL Server Standard BYOM",
+    "406": "SQL Server Enterprise BYOM",
 }
 
 

--- a/in/instance-type-rds.html.mako
+++ b/in/instance-type-rds.html.mako
@@ -151,6 +151,8 @@
                   <option value="SQL Server Enterprise (Outpost On-Prem)">SQL Server Enterprise (Outpost On-Prem)</option>
                   <option value="SQL Server (Outpost On-Prem)">SQL Server (Outpost On-Prem)</option>
                   <option value="SQL Server Web (Outpost On-Prem)">SQL Server Web (Outpost On-Prem)</option>
+                  <option value="SQL Server Standard BYOM">SQL Server Standard BYOM</option>
+                  <option value="SQL Server Enterprise BYOM">SQL Server Enterprise BYOM</option>
                 </select>
               </div>
               <div class="col-6 pe-2">

--- a/tasks.py
+++ b/tasks.py
@@ -47,7 +47,7 @@ def build(c):
     scrape_rds(c)
     scrape_cache(c)
     scrape_redshift(c)
-    # scrape_opensearch(c)
+    scrape_opensearch(c)
     render_html(c)
 
 
@@ -147,13 +147,13 @@ def render_html(c):
             "www/redshift/index.html",
         )
     )
-    # sitemap.extend(
-    #     render(
-    #         "www/opensearch/instances.json",
-    #         "in/opensearch.html.mako",
-    #         "www/opensearch/index.html",
-    #     )
-    # )
+    sitemap.extend(
+        render(
+            "www/opensearch/instances.json",
+            "in/opensearch.html.mako",
+            "www/opensearch/index.html",
+        )
+    )
     sitemap.append(about_page())
     build_sitemap(sitemap)
 


### PR DESCRIPTION
There's a need to be able to trace the data and rendering for just 1 instance type to more rapidly fix data issues that occur for that instance. The following instances have had issues reported:

| Instance | Issue |
| - | - |
| mac1.metal | billing is a 24 hour period | 
| ra3.16xlarge | memory and node range stats should be different |
| cache.t4g.micro | add cpu credits |
| p4de.24xlarge | network performance column doesn't sort properly |
| t3a.large | add hibernation stats |
| m5d.large | add number of ENIs |
| db.r6i.2xlarge | pricing is off by $1k/mo |
| ra3.xplus | network details |
| r6i.2xlarge | max pods on EKS |
| g5.12xlarge | compute capability is 8.6 | 
| db.r6g.16xlarge | RDS max throughput |
| t3.large | Intel extensions such as AVX512 |
| trn1.32xlarge | missing GPU info #689 |
| r6i.4xlarge | wrong CPU speed #688  |
| trn1.32xlarge | network data inconsistency #686 | 
| hpc6a | not showing in oregon region #614 | 
| m5.2xlarge | incorrect rate in signapore #604 | 
| m6g.medium | clock speed is unknown #542 | 

This should be a command line switch that can be added to the `build invoke` set of scripts. When specified, the code should only get pricing data for the one instance. Raw pricing data from AWS should be printed to the console at every step. The final data that will be rendered onto the page should be printed as well. Since running the entire scraping process can take up to 10 minutes, this will significantly shorten development cycles.

This is most useful for EC2 which is the longest script that needs to run - `scrape.py`.