### PR TITLE
INP optimization

### DIFF
--- a/in/index.html.mako
+++ b/in/index.html.mako
@@ -163,6 +163,7 @@
     <table cellspacing="0" style="border-bottom: 0 !important; margin-bottom: 0 !important;" id="data" width="100%" class="table">
       <thead>
         <tr>
+          <!-- TODO: only render the default columns here. Use the column().nodes() API to set the header name and class -->
           <th class="name all" data-priority="1"><div class="d-none d-md-block">Name</div></th>
           <th class="apiname" data-priority="1">API Name</th>
           <th class="memory">Instance Memory</th>
@@ -282,6 +283,8 @@
 
       <tbody>
         % for inst in instances:
+          <!-- TODO: convert most of this logic into javascript. Use g_data_table.column(i).visible(true).draw() -->
+          <!-- TODO: alternatively, we could create a specifications.json file where this logic can still be done in python -->
           <tr class='instance' id="${inst['instance_type']}">
             <td class="name all"><div class="d-none d-md-block">${inst['pretty_name']}</div></td>
             <td class="apiname"><a href="/aws/ec2/${inst['instance_type']}">${inst['instance_type']}</a></td>

--- a/www/default.js
+++ b/www/default.js
@@ -144,6 +144,7 @@ function init_data_table() {
   }
 
   g_data_table = $('#data').DataTable({
+    // TODO: this object can be used for loading the initial data but will be augmented
     bPaginate: false,
     bInfo: false,
     orderCellsTop: true,
@@ -186,6 +187,8 @@ function init_data_table() {
       },
       {
         // The columns below are hidden by default
+        // TODO: remove this. No need to write pricing columns to specifications.json
+        // since that data is already available in pricing.json
         aTargets: [
           'architecture',
           'computeunits',
@@ -606,6 +609,9 @@ function redraw_costs() {
   g_data_table.rows().invalidate().draw();
 }
 
+// TODO: This function will need to populate the column dropdown based on
+// the data in g_data_table.columns().data() instead of reading it from the
+// HTML page.
 function setup_column_toggle() {
   $.each(g_data_table.columns().indexes(), function (i, idx) {
     var column = g_data_table.column(idx);


### PR DESCRIPTION
The site feels slow and records low core web vitals scores because of how we render data into the datatables object.
![image](https://github.com/vantage-sh/ec2instances.info/assets/3907080/00915cbe-3b50-4317-8206-dfa86dac0aef)

What happens today is that all the data is rendered into a <table> element server side and then most of the columns of the table are hidden in Javascript. This act of hiding most of the data greatly impacts the interaction time for the user and responsiveness of the page. It also results in 17K elements being rendered onto the page.

![image](https://github.com/vantage-sh/ec2instances.info/assets/3907080/e557f0d1-d2cb-424f-a60b-e51c2b1b1b17)

This in turn impacts what jobs are done by the main thread, where we spend a lot of time on layout, script evaluation, and rendering.

![image](https://github.com/vantage-sh/ec2instances.info/assets/3907080/f1d5de25-e885-4ee6-a318-4a06902ca425)

Instead, we can invert the work done here, and only render the default columns onto the page in HTML. We can store the rest of the column data directly in the g_data_tables object and only add a column to the page if the user selects it from the columns dropdown or has it saved in their user preferences.

We may need to use [null values](https://datatables.net/examples/ajax/null_data_source.html) for the hidden columns initially. However, the rows().data() [method](https://datatables.net/reference/api/row().data()) seemingly provides a clean way to update data in the table.
 
At the end of the update operation, `g_data_table.columns(columnIndex).data(data);` should return the updated column values and it should be visible on the table. We ought to be able to use our existing code for making columns visible and invisible using `g_data_table.columns([2, 3]).visible(true);`.

We can modify the headers for the columns using jQuery and the [nodes API](https://datatables.net/reference/api/column().nodes()):

```
table
    .column( -1 )
    .nodes()
    .to$()      // Convert to a jQuery object
    .addClass( 'ready' );
);
```

Further example of how we might implement show/hide columns once the data is stored.

```
$('#show-column-btn').click(function () {
  var selectedColumn = $('#column-dropdown select').val();
  var columnIndex = g_data_table.column('.' + selectedColumn).index();

  // Set the text and class for the header
  var headerCell = $(g_data_table.column(columnIndex).header());
  headerCell.text('New Header Text');
  headerCell.addClass('new-class');

  // Show the column
  g_data_table.column(columnIndex).visible(true).draw();
});
```

A look at the data structure of the columns object.

![image](https://github.com/vantage-sh/ec2instances.info/assets/3907080/5fdc2e7f-92d8-4d46-818b-b0bc3e407376)

