### PR TITLE
Add Valkey engine pricing data for Elasticache

### DIFF
--- a/detail_pages_cache.py
+++ b/detail_pages_cache.py
@@ -14,6 +14,7 @@ import re
 cache_engine_mapping = {
     "Memcached": "Memcached",
     "Redis": "Redis",
+    "Valkey": "Valkey",
 }
 
 

--- a/in/cache.html.mako
+++ b/in/cache.html.mako
@@ -141,7 +141,7 @@
             <abbr title="Each virtual CPU is a hyperthread of an Intel Xeon core for M3, C4, C3, R3, HS1, G2, I2, and D2">vCPUs</abbr>
           </th>
           <th class="networkperf">Network Performance</th>
-          % for cache_engine in {'Redis', 'Memcached'}:
+          % for cache_engine in {'Redis', 'Memcached', 'Valkey'}:
           % if cache_engine == 'Redis':
           <th class="cost-ondemand cost-ondemand-${cache_engine} all" data-priority="1">${cache_engine} Cost</th>
           % else:
@@ -171,7 +171,7 @@
               ${inst['network_performance']}
             </span>
           </td>
-          % for cache_engine in {'Redis', 'Memcached'}:
+          % for cache_engine in {'Redis', 'Memcached', 'Valkey'}:
           <td class="cost-ondemand cost-ondemand-${cache_engine}" data-platform='${cache_engine}' data-vcpu='${inst['vcpu']}' data-memory='${inst['memory']}'>
             % if inst['pricing'].get('us-east-1', {}).get(cache_engine, {}).get('ondemand', 'N/A') != "N/A":
               <span sort="${inst['pricing']['us-east-1'][cache_engine]['ondemand']}">

--- a/in/instance-type-cache.html.mako
+++ b/in/instance-type-cache.html.mako
@@ -112,7 +112,8 @@
               <div class="col-6 mb-2">
                 <select class="form-select form-select-sm" id="os">
                   <option value="Redis">Redis</option>
-                  <option value="Memcached">Memcached</option> 
+                  <option value="Memcached">Memcached</option>
+                  <option value="Valkey">Valkey</option>
                 </select>
               </div>
               <div class="col-6 pe-2">


### PR DESCRIPTION
Turns out we already had the data in the JSON file, just needed to show it in the UI

<img width="1175" alt="image" src="https://github.com/user-attachments/assets/5b93526d-d3d9-465c-828a-c2f45fc4ee36">

Fixes #760 