### PR TITLE
fix: rename link class

### DIFF
--- a/in/cache.html.mako
+++ b/in/cache.html.mako
@@ -11,7 +11,7 @@
     </%block>
 
     <%block name="header">
-      <h1 class="banner-ad d-none d-xl-block">EC2Instances.info Easy Amazon <b>ElastiCache</b> Instance Comparison</h1>
+      <h1 class="vantage-link d-none d-xl-block">EC2Instances.info Easy Amazon <b>ElastiCache</b> Instance Comparison</h1>
     </%block>
 
     <div class="row mt-3 me-2" id="menu">

--- a/in/index.html.mako
+++ b/in/index.html.mako
@@ -11,7 +11,7 @@
     </%block>
     
     <%block name="header">
-        <h1 class="banner-ad d-none d-xl-block">EC2Instances.info - Easy Amazon <b>EC2</b> Instance Comparison</h1>
+        <h1 class="vantage-link d-none d-xl-block">EC2Instances.info - Easy Amazon <b>EC2</b> Instance Comparison</h1>
     </%block>
 
     <div class="row mt-3 me-2" id="menu">

--- a/in/opensearch.html.mako
+++ b/in/opensearch.html.mako
@@ -11,7 +11,7 @@
     </%block>
 
     <%block name="header">
-      <h1 class="banner-ad d-none d-xl-block">EC2Instances.info Easy Amazon <b>OpenSearch</b> Instance Comparison</h1>
+      <h1 class="vantage-link d-none d-xl-block">EC2Instances.info Easy Amazon <b>OpenSearch</b> Instance Comparison</h1>
     </%block>
 
     <div class="row mt-3 me-2" id="menu">

--- a/in/rds.html.mako
+++ b/in/rds.html.mako
@@ -11,7 +11,7 @@
     </%block>
 
     <%block name="header">
-      <h1 class="banner-ad d-none d-xl-block">EC2Instances.info Easy Amazon <b>RDS</b> Instance Comparison</h1>
+      <h1 class="vantage-link d-none d-xl-block">EC2Instances.info Easy Amazon <b>RDS</b> Instance Comparison</h1>
     </%block>
 
     <div class="row mt-3 me-2" id="menu">

--- a/in/redshift.html.mako
+++ b/in/redshift.html.mako
@@ -11,7 +11,7 @@
     </%block>
 
     <%block name="header">
-      <h1 class="banner-ad d-none d-xl-block">EC2Instances.info Easy Amazon <b>Redshift</b> Instance Comparison</h1>
+      <h1 class="vantage-link d-none d-xl-block">EC2Instances.info Easy Amazon <b>Redshift</b> Instance Comparison</h1>
     </%block>
 
     <div class="row mt-3 me-2" id="menu">

--- a/www/default.css
+++ b/www/default.css
@@ -347,7 +347,7 @@ input.search {
   font-size: 14px !important;
 }
 
-.banner-ad {
+.vantage-link {
   font-size: 14px;
   color: white;
   margin: 0;


### PR DESCRIPTION
This pull request includes changes to update the class name used for headers across multiple HTML files and the corresponding CSS styling. The most important changes include the following:

Updates to HTML files:

* [`in/cache.html.mako`](diffhunk://#diff-71caa50210b86b30c0e347c3279f8bf6ea84a73616327c328d4957cdf441c303L14-R14): Changed the class name from `banner-ad` to `vantage-link` in the header.
* [`in/index.html.mako`](diffhunk://#diff-4841500383059817aec9e489a56e4b62eb0e88773a1e90fdcc39b59e13016a5cL14-R14): Changed the class name from `banner-ad` to `vantage-link` in the header.
* [`in/opensearch.html.mako`](diffhunk://#diff-a1bb0813c9a7bb5411319f4b30b6aa2cf284c5138e61ae704ed4eb4c0c3e460aL14-R14): Changed the class name from `banner-ad` to `vantage-link` in the header.
* [`in/rds.html.mako`](diffhunk://#diff-6f2b9af2b7e6a409b2ede62fce65f4731eebcc7ab5bb090b705e56a7f9e05e79L14-R14): Changed the class name from `banner-ad` to `vantage-link` in the header.
* [`in/redshift.html.mako`](diffhunk://#diff-a3b829f8ee819bd90fc2ab7b2f42fb3cd3691fc4aecba26a7dc423146e0087b9L14-R14): Changed the class name from `banner-ad` to `vantage-link` in the header.

Updates to CSS file:

* [`www/default.css`](diffhunk://#diff-d238468b8801a65432d270f6ad8dae63bb2346bd3e79b3a29ff139c5e8eceb3cL350-R350): Renamed the CSS class from `.banner-ad` to `.vantage-link` and retained the existing styling.