### PR TITLE
Add expr mode

### DIFF
--- a/next/components/IndividualColumnFilter.tsx
+++ b/next/components/IndividualColumnFilter.tsx
@@ -1,68 +1,144 @@
 import GSettings from "@/utils/g_settings_port";
 import { Column } from "@tanstack/react-table";
-import { useEffect, useCallback, useState } from "react";
+import { useEffect, useCallback, useState, useId } from "react";
+import { FunctionSquare } from "lucide-react";
 
-function GSettingsNumberFilter<Instance>({
+const GTE_EXPR = /^[ \t\n]*>=[ \t\n]*([\d.]+)[ \t\n]*$/;
+
+function isGteExpr(expr: string): number | null {
+    const match = expr.match(GTE_EXPR);
+    if (!match) return null;
+
+    let num = match[1];
+    if (num.startsWith(".")) {
+        num = "0" + num;
+    } else if (num.endsWith(".")) {
+        num = num + "0";
+    }
+
+    const v = parseFloat(num);
+    if (isNaN(v)) return null;
+    return v;
+}
+
+function GSettingsExprFilter<Instance>({
     gSettingsSet,
     gSettingsFullMutations,
     column,
     initValue,
 }: {
-    gSettingsSet: (value: number) => void;
+    gSettingsSet: (value: string) => void;
     gSettingsFullMutations: number;
     column: Column<Instance>;
-    initValue: number;
+    initValue: string;
 }) {
     const [value, setValue] = useState(initValue);
+    const [exprMode, setExprMode] = useState(() => {
+        const v = isGteExpr(initValue);
+        return v === null;
+    });
+    const [numberValue, setNumberValue] = useState(() => {
+        const v = isGteExpr(initValue);
+        if (v !== null) return v;
+        return 0;
+    });
+    const id = useId();
 
     useEffect(() => {
         // Handle if we launched the page with a value or it reset.
         setValue(initValue);
+        const v = isGteExpr(initValue);
+        setNumberValue(v ?? 0);
+        if (v === null) setExprMode(true);
     }, [initValue]);
 
-    const onChange = useCallback(
+    const exprStringChange = useCallback(
         (e: React.ChangeEvent<HTMLInputElement>) => {
-            const v = e.target.valueAsNumber;
-            if (isNaN(v)) return;
+            const v = e.target.value;
             setValue(v);
             gSettingsSet(v);
             column.setFilterValue(v);
+            setNumberValue(isGteExpr(v) ?? 0);
+        },
+        [gSettingsFullMutations],
+    );
+
+    const numberChange = useCallback(
+        (e: React.ChangeEvent<HTMLInputElement>) => {
+            const v = e.target.valueAsNumber;
+            if (isNaN(v)) return;
+            setValue(`>=${v}`);
+            gSettingsSet(`>=${v}`);
+            column.setFilterValue(`>=${v}`);
+            setNumberValue(v);
         },
         [gSettingsFullMutations],
     );
 
     return (
-        <input
-            type="number"
-            value={value}
-            onChange={onChange}
-            placeholder={`Filter ${column.columnDef.header as string}...`}
-            className="w-full px-2 py-1 text-sm border border-gray-5 bg-white font-normal rounded"
-            min={0}
-            onKeyDown={(e) => {
-                // number inputs can be unintuitive when deleting the last digit. This helps with that.
-                if (e.key === "Backspace" && value < 10) {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    (e.target as HTMLInputElement).select();
-                }
-            }}
-        />
+        <div className="flex gap-1 w-full">
+            <div className="flex-col my-auto">
+                <button
+                    aria-selected={exprMode}
+                    onClick={() => setExprMode(!exprMode)}
+                    aria-label="Toggle expression mode"
+                    aria-controls={id}
+                    title="Toggle expression mode"
+                    className="text-black [&[aria-selected=true]]:text-purple-500 cursor-pointer mt-1"
+                >
+                    <FunctionSquare size={20} />
+                </button>
+            </div>
+
+            <div className="flex-col grow">
+                {exprMode ? (
+                    <input
+                        type="text"
+                        value={value}
+                        onChange={exprStringChange}
+                        placeholder={`Filter ${column.columnDef.header as string}...`}
+                        id={id}
+                        className="w-full px-2 py-1 text-sm border border-gray-5 bg-white font-normal rounded"
+                    />
+                ) : (
+                    <input
+                        type="number"
+                        value={numberValue}
+                        onChange={numberChange}
+                        placeholder={`Filter ${column.columnDef.header as string}...`}
+                        className="w-full px-2 py-1 text-sm border border-gray-5 bg-white font-normal rounded"
+                        min={0}
+                        id={id}
+                        onKeyDown={(e) => {
+                            // number inputs can be unintuitive when deleting the last digit. This helps with that.
+                            if (e.key === "Backspace" && numberValue < 10) {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                (e.target as HTMLInputElement).select();
+                            }
+                        }}
+                    />
+                )}
+            </div>
+        </div>
     );
 }
 
 type OnlyAllowedGSettingsKeys = {
-    [K in keyof GSettings]: GSettings[K] extends number ? K : never;
+    [K in keyof GSettings]: K extends `${string}Expr` ? K : never;
 }[keyof GSettings];
 
 const columnMapping: Record<string, OnlyAllowedGSettingsKeys> = {
-    memory: "minMemory",
-    vCPU: "minVcpus",
-    memory_per_vcpu: "minMemoryPerVcpu",
-    GPU: "minGpus",
-    GPU_memory: "minGpuMemory",
-    maxips: "minMaxips",
-    storage: "minStorage",
+    memory: "memoryExpr",
+    vCPU: "vcpuExpr",
+    vcpu: "vcpuExpr",
+    vcpus: "vcpuExpr",
+    memory_per_vcpu: "memoryPerVcpuExpr",
+    GPU: "gpusExpr",
+    GPU_memory: "gpuMemoryExpr",
+    maxips: "maxipsExpr",
+    storage: "storageExpr",
+    size: "storageExpr",
 };
 
 export default function IndividualColumnFilter<Instance>({
@@ -75,7 +151,7 @@ export default function IndividualColumnFilter<Instance>({
     column: Column<Instance>;
 }) {
     const set = useCallback(
-        (value: number) => {
+        (value: string) => {
             const key = columnMapping[column.columnDef.id!];
             if (key && gSettings) {
                 gSettings[key] = value;
@@ -88,7 +164,7 @@ export default function IndividualColumnFilter<Instance>({
     if (key && gSettings) {
         const value = gSettings[key];
         return (
-            <GSettingsNumberFilter
+            <GSettingsExprFilter
                 gSettingsFullMutations={gSettingsFullMutations}
                 gSettingsSet={set}
                 column={column}

--- a/next/components/IndividualColumnFilter.tsx
+++ b/next/components/IndividualColumnFilter.tsx
@@ -128,7 +128,7 @@ type OnlyAllowedGSettingsKeys = {
     [K in keyof GSettings]: K extends `${string}Expr` ? K : never;
 }[keyof GSettings];
 
-const columnMapping: Record<string, OnlyAllowedGSettingsKeys> = {
+const columnMapping: Record<string, OnlyAllowedGSettingsKeys | null> = {
     memory: "memoryExpr",
     vCPU: "vcpuExpr",
     vcpu: "vcpuExpr",
@@ -139,6 +139,9 @@ const columnMapping: Record<string, OnlyAllowedGSettingsKeys> = {
     maxips: "maxipsExpr",
     storage: "storageExpr",
     size: "storageExpr",
+    ecu: null,
+    ECU: null,
+    io: null,
 };
 
 export default function IndividualColumnFilter<Instance>({
@@ -169,6 +172,15 @@ export default function IndividualColumnFilter<Instance>({
                 gSettingsSet={set}
                 column={column}
                 initValue={value}
+            />
+        );
+    } else if (key === null) {
+        return (
+            <GSettingsExprFilter
+                gSettingsFullMutations={0}
+                gSettingsSet={() => {}}
+                column={column}
+                initValue={">=0"}
             />
         );
     }

--- a/next/components/InstanceTable.tsx
+++ b/next/components/InstanceTable.tsx
@@ -90,24 +90,24 @@ export default function InstanceTable<
         const a = [
             {
                 id: "memory",
-                value: gSettings.minMemory,
+                value: gSettings.memoryExpr,
             },
             {
                 id:
                     columns.find((v) => v.id === "vcpus" || v.id === "vcpu")
                         ?.id ?? "vCPU",
-                value: gSettings.minVcpus,
+                value: gSettings.vcpuExpr,
             },
         ];
         if (columnAtomKey === "ec2" || columnAtomKey === "azure") {
             a.push(
                 {
                     id: "memory_per_vcpu",
-                    value: gSettings.minMemoryPerVcpu,
+                    value: gSettings.memoryPerVcpuExpr,
                 },
                 {
                     id: "GPU",
-                    value: gSettings.minGpus,
+                    value: gSettings.gpusExpr,
                 },
             );
         }
@@ -115,18 +115,23 @@ export default function InstanceTable<
             a.push(
                 {
                     id: "GPU_memory",
-                    value: gSettings.minGpuMemory,
+                    value: gSettings.gpuMemoryExpr,
                 },
                 {
                     id: "maxips",
-                    value: gSettings.minMaxips,
+                    value: gSettings.maxipsExpr,
                 },
             );
         }
         if (columns.find((v) => v.id === "storage")) {
             a.push({
                 id: "storage",
-                value: gSettings.minStorage,
+                value: gSettings.storageExpr,
+            });
+        } else if (columnAtomKey === "azure") {
+            a.push({
+                id: "size",
+                value: gSettings.storageExpr,
             });
         }
 

--- a/next/utils/colunnData/azure.tsx
+++ b/next/utils/colunnData/azure.tsx
@@ -2,13 +2,14 @@ import { PricingUnit } from "@/types";
 import { ColumnDef } from "@tanstack/react-table";
 import {
     doAllDataTablesMigrations,
-    gt,
     regex,
     makeSchemaWithDefaults,
     makeCellWithRegexSorter,
+    expr,
 } from "./shared";
 import { CostDuration } from "@/types";
 import RegionLinkPreloader from "@/components/RegionLinkPreloader";
+import exprCompiler from "@/utils/expr";
 
 export interface AzurePricing {
     [region: string]: {
@@ -229,7 +230,7 @@ export const columnsGen = (
             size: 160,
             id: "memory",
             sortingFn: "alphanumeric",
-            filterFn: gt,
+            filterFn: expr,
             cell: (info) => `${info.getValue() as number} GiB`,
         },
         {
@@ -238,7 +239,7 @@ export const columnsGen = (
             size: 160,
             id: "vcpu",
             sortingFn: "alphanumeric",
-            filterFn: gt,
+            filterFn: expr,
         },
         {
             accessorKey: "memory",
@@ -248,7 +249,7 @@ export const columnsGen = (
             filterFn: (row, _, filterValue) => {
                 const value = row.original.memory;
                 const cpu = row.original.vcpu;
-                return value / cpu >= filterValue;
+                return exprCompiler(filterValue)(value / cpu);
             },
             cell: (info) => {
                 const value = info.getValue() as number;
@@ -261,14 +262,14 @@ export const columnsGen = (
             header: "GPUs",
             size: 160,
             id: "GPU",
-            filterFn: regex({ accessorKey: "GPU" }),
+            filterFn: expr,
         },
         {
             accessorKey: "size",
             header: "Storage",
             size: 160,
             id: "size",
-            filterFn: gt,
+            filterFn: expr,
             cell: (info) => `${info.getValue() as number} GiB`,
         },
         {

--- a/next/utils/colunnData/cache.tsx
+++ b/next/utils/colunnData/cache.tsx
@@ -2,10 +2,10 @@ import { ColumnDef } from "@tanstack/react-table";
 import {
     calculateCost,
     doAllDataTablesMigrations,
-    gt,
     makeSchemaWithDefaults,
     regex,
     makeCellWithRegexSorter,
+    expr,
 } from "./shared";
 import { EC2Instance, PricingUnit, CostDuration, Pricing } from "@/types";
 import RegionLinkPreloader from "@/components/RegionLinkPreloader";
@@ -105,7 +105,7 @@ export const columnsGen = (
     {
         accessorKey: "memory",
         id: "memory",
-        filterFn: gt,
+        filterFn: expr,
         sortingFn: "alphanumeric",
         header: "Memory",
         cell: (info) => {
@@ -116,7 +116,7 @@ export const columnsGen = (
     {
         accessorKey: "vcpu",
         id: "vcpus",
-        filterFn: (row, _, filterValue) => gt(row, "vcpu", filterValue),
+        filterFn: (row, _, filterValue) => expr(row, "vcpu", filterValue),
         sortingFn: "alphanumeric",
         header: "vCPUs",
         cell: (info) => {

--- a/next/utils/colunnData/ec2/columns.tsx
+++ b/next/utils/colunnData/ec2/columns.tsx
@@ -147,9 +147,7 @@ export const columnsGen = (
         size: 180,
         id: "ECU",
         sortingFn: "alphanumeric",
-        filterFn: regex({
-            accessorKey: "ECU",
-        }),
+        filterFn: expr,
         cell: (info) => {
             const value = info.getValue();
             if (value === "variable") {

--- a/next/utils/colunnData/ec2/columns.tsx
+++ b/next/utils/colunnData/ec2/columns.tsx
@@ -392,8 +392,7 @@ export const columnsGen = (
         filterFn: (row, _, filterValue) => {
             if (filterValue === 0) return true;
             const storage = row.original.storage;
-            if (!storage) return false;
-            const totalSize = storage.devices * storage.size;
+            const totalSize = (storage?.devices || 0) * (storage?.size || 0);
             return exprCompiler(filterValue)(totalSize);
         },
         cell: (info) => {
@@ -592,8 +591,7 @@ export const columnsGen = (
         },
         filterFn: (row, _, filterValue) => {
             const vpc = row.original.vpc;
-            if (!vpc) return false;
-            const maxIps = vpc.max_enis * vpc.ips_per_eni;
+            const maxIps = (vpc?.max_enis || 0) * (vpc?.ips_per_eni || 0);
             return exprCompiler(filterValue)(maxIps);
         },
         cell: (info) => {

--- a/next/utils/colunnData/opensearch.tsx
+++ b/next/utils/colunnData/opensearch.tsx
@@ -2,10 +2,10 @@ import { CostDuration, PricingUnit } from "@/types";
 import {
     makeSchemaWithDefaults,
     doAllDataTablesMigrations,
-    gt,
     calculateCost,
     regex,
     makeCellWithRegexSorter,
+    expr,
 } from "./shared";
 import { ColumnDef } from "@tanstack/react-table";
 import RegionLinkPreloader from "@/components/RegionLinkPreloader";
@@ -122,7 +122,7 @@ export const columnsGen = (
         accessorKey: "memoryGib",
         id: "memory",
         header: "Memory",
-        filterFn: gt,
+        filterFn: expr,
         sortingFn: "alphanumeric",
         cell: (info) => {
             const value = info.getValue() as string;
@@ -132,7 +132,7 @@ export const columnsGen = (
     {
         accessorKey: "vcpu",
         id: "vcpu",
-        filterFn: gt,
+        filterFn: expr,
         sortingFn: "alphanumeric",
         header: "vCPUs",
     },
@@ -140,7 +140,7 @@ export const columnsGen = (
         accessorKey: "storage",
         id: "storage",
         header: "Storage",
-        filterFn: gt,
+        filterFn: expr,
         sortingFn: "alphanumeric",
     },
     {

--- a/next/utils/colunnData/opensearch.tsx
+++ b/next/utils/colunnData/opensearch.tsx
@@ -148,7 +148,7 @@ export const columnsGen = (
         id: "ecu",
         header: "Elastic Compute Units",
         sortingFn: "alphanumeric",
-        filterFn: regex({ accessorKey: "ecu" }),
+        filterFn: expr,
     },
     {
         accessorKey: "pricing",

--- a/next/utils/colunnData/rds.tsx
+++ b/next/utils/colunnData/rds.tsx
@@ -2,9 +2,9 @@ import { CostDuration, EC2Instance, Pricing, PricingUnit } from "@/types";
 import {
     makeSchemaWithDefaults,
     doAllDataTablesMigrations,
-    gt,
     regex,
     makeCellWithRegexSorter,
+    expr,
 } from "./shared";
 import { ColumnDef } from "@tanstack/react-table";
 import RegionLinkPreloader from "@/components/RegionLinkPreloader";
@@ -189,14 +189,14 @@ export const columnsGen = (
         header: "Memory",
         id: "memory",
         accessorKey: "memory",
-        filterFn: gt,
+        filterFn: expr,
         sortingFn: "alphanumeric",
     },
     {
         header: "Storage",
         id: "storage",
         accessorKey: "storage",
-        filterFn: gt,
+        filterFn: expr,
         sortingFn: "alphanumeric",
     },
     {
@@ -218,7 +218,7 @@ export const columnsGen = (
         header: "vCPUs",
         id: "vcpu",
         accessorKey: "vcpu",
-        filterFn: gt,
+        filterFn: expr,
         sortingFn: "alphanumeric",
     },
     {

--- a/next/utils/colunnData/redshift.tsx
+++ b/next/utils/colunnData/redshift.tsx
@@ -3,10 +3,10 @@ import { CostDuration } from "@/types";
 import {
     makeSchemaWithDefaults,
     doAllDataTablesMigrations,
-    gt,
     calculateCost,
     regex,
     makeCellWithRegexSorter,
+    expr,
 } from "./shared";
 import { ColumnDef } from "@tanstack/react-table";
 import RegionLinkPreloader from "@/components/RegionLinkPreloader";
@@ -133,14 +133,14 @@ export const columnsGen = (
         header: "Instance Memory",
         id: "memory",
         sortingFn: "alphanumeric",
-        filterFn: gt,
+        filterFn: expr,
         cell: (info) => `${info.getValue()} GiB`,
     },
     {
         accessorKey: "vcpu",
         header: "vCPUs",
         id: "vCPU",
-        filterFn: gt,
+        filterFn: expr,
         cell: (info) => {
             const value = info.getValue();
             return `${value} vCPUs`;
@@ -151,21 +151,22 @@ export const columnsGen = (
         header: "Storage",
         id: "storage",
         sortingFn: "alphanumeric",
-        filterFn: gt,
+        filterFn: expr,
     },
     {
+        // TODO: this and ecu
         accessorKey: "io",
         header: "IO",
         id: "io",
         sortingFn: "alphanumeric",
-        filterFn: gt,
+        filterFn: expr,
     },
     {
         accessorKey: "ecu",
         header: "ECU",
         id: "ECU",
         sortingFn: "alphanumeric",
-        filterFn: gt,
+        filterFn: expr,
     },
     {
         accessorKey: "currentGeneration",

--- a/next/utils/colunnData/redshift.tsx
+++ b/next/utils/colunnData/redshift.tsx
@@ -154,7 +154,6 @@ export const columnsGen = (
         filterFn: expr,
     },
     {
-        // TODO: this and ecu
         accessorKey: "io",
         header: "IO",
         id: "io",

--- a/next/utils/expr/index.ts
+++ b/next/utils/expr/index.ts
@@ -1,0 +1,45 @@
+import { Tokens, tokenise } from "./tokeniser";
+
+function evaluate(token: Tokens, num: number): boolean {
+    let a: boolean;
+    let b: boolean;
+    for (;;) {
+        switch (token.type) {
+            case "brackets":
+                // Unneeded brackets.
+                token = token.inner;
+                continue;
+            case "or":
+                // Evaluate the left and right sides
+                a = evaluate(token.left, num);
+                b = evaluate(token.right, num);
+                return a || b;
+            case "and":
+                // Evaluate the left and right sides
+                a = evaluate(token.left, num);
+                b = evaluate(token.right, num);
+                return a && b;
+            case "not":
+                // Evaluate the inner side
+                a = evaluate(token.inner, num);
+                return !a;
+            case "number":
+                return num === token.value;
+            case "gt":
+                return num > token.value;
+            case "gte":
+                return num >= token.value;
+            case "lt":
+                return num < token.value;
+            case "lte":
+                return num <= token.value;
+            case "range":
+                return num >= token.start && num <= token.end;
+        }
+    }
+}
+
+export default (value: string) => {
+    const tokens = tokenise(value);
+    return (num: number) => evaluate(tokens, num);
+};

--- a/next/utils/expr/tokeniser.ts
+++ b/next/utils/expr/tokeniser.ts
@@ -1,0 +1,423 @@
+type TokenBase = {
+    startPos: number;
+};
+
+export type Tokens = TokenBase &
+    (
+        | {
+              type: "brackets";
+              inner: Tokens;
+          }
+        | {
+              type: "or";
+              left: Tokens;
+              right: Tokens;
+          }
+        | {
+              type: "and";
+              left: Tokens;
+              right: Tokens;
+          }
+        | {
+              type: "not";
+              inner: Tokens;
+          }
+        | {
+              type: "number";
+              value: number;
+          }
+        | {
+              type: "gt";
+              value: number;
+          }
+        | {
+              type: "gte";
+              value: number;
+          }
+        | {
+              type: "lt";
+              value: number;
+          }
+        | {
+              type: "lte";
+              value: number;
+          }
+        | {
+              type: "range";
+              start: number;
+              end: number;
+          }
+    );
+
+type NumberToken = TokenBase & {
+    type: "number";
+    value: number;
+};
+
+function parseNumber(value: string): number {
+    if (value.startsWith(".")) {
+        return parseFloat("0" + value);
+    }
+    if (value.endsWith(".")) {
+        return parseFloat(value.slice(0, -1));
+    }
+    const n = parseInt(value, 10);
+    if (isNaN(n)) {
+        throw new Error(`Invalid number: ${value}`);
+    }
+    return n;
+}
+
+function tokeniseNumber(value: string, offset: number): [NumberToken, number] {
+    let newOffset = offset;
+    const r = () => {
+        if (newOffset === offset) {
+            throw new Error(
+                "internal bug: tokeniseNumber called with no digits",
+            );
+        }
+        return [
+            {
+                type: "number",
+                value: parseNumber(value.slice(offset, newOffset)),
+            },
+            newOffset,
+        ] as [NumberToken, number];
+    };
+
+    const d = () => {
+        // Peak at the next character. If it's a dot, we are done, this is a range.
+        if (value[newOffset + 1] === ".") {
+            if (offset === newOffset) {
+                throw new Error(`Unexpected . at position ${offset}`);
+            }
+            return r();
+        }
+
+        // Add 1 to the offset.
+        newOffset++;
+    };
+
+    let dotToken: [NumberToken, number] | undefined;
+    for (;;) {
+        switch (value[newOffset]) {
+            case "0":
+            case "1":
+            case "2":
+            case "3":
+            case "4":
+            case "5":
+            case "6":
+            case "7":
+            case "8":
+            case "9":
+                newOffset++;
+                continue;
+            case ".":
+                dotToken = d();
+                if (dotToken) return dotToken;
+                continue;
+            default:
+                return r();
+        }
+    }
+}
+
+function unexpectedCharacter(value: string, offset: number): never {
+    if (value[offset] === undefined) {
+        throw new Error("Unexpected end of expression");
+    }
+    throw new Error(
+        `Unexpected character ${value[offset]} at position ${offset}`,
+    );
+}
+
+function tokeniseGtOrGteOrLtOrLte<TokenStart extends "gt" | "lt">(
+    value: string,
+    offsetAfterGtSymbol: number,
+    start: TokenStart,
+): [Tokens, number] {
+    // Check if the next character is a =
+    let gte = false;
+    if (value[offsetAfterGtSymbol] === "=") {
+        gte = true;
+        offsetAfterGtSymbol++;
+    }
+
+    // Make sure the next character is a number
+    gobble1: for (;;) {
+        switch (value[offsetAfterGtSymbol]) {
+            case "0":
+            case "1":
+            case "2":
+            case "3":
+            case "4":
+            case "5":
+            case "6":
+            case "7":
+            case "8":
+            case "9":
+            case ".":
+                break gobble1;
+            case " ":
+            case "\t":
+            case "\n":
+            case "\r":
+                offsetAfterGtSymbol++;
+                continue;
+            default:
+                unexpectedCharacter(value, offsetAfterGtSymbol);
+        }
+    }
+
+    // Parse the number
+    const [token, newOffset] = tokeniseNumber(value, offsetAfterGtSymbol);
+    return [
+        {
+            type: gte ? `${start}e` : `${start}`,
+            value: token.value,
+            startPos: offsetAfterGtSymbol - 1,
+        },
+        newOffset,
+    ] as [Tokens, number];
+}
+
+function tokeniseRange(
+    value: string,
+    offset: number,
+    left: Tokens,
+): [Tokens, number] {
+    // The offset should be another .
+    if (value[offset] !== ".") unexpectedCharacter(value, offset);
+
+    // Throw if the left is not a number
+    if (left.type !== "number") {
+        throw new Error("Left side of range must be a number");
+    }
+
+    // Add 1 to the offset, gobble whitespace, and make sure the next character is a number
+    offset++;
+    gobble1: for (;;) {
+        switch (value[offset]) {
+            case " ":
+            case "\t":
+            case "\n":
+            case "\r":
+                offset++;
+                continue gobble1;
+            case "0":
+            case "1":
+            case "2":
+            case "3":
+            case "4":
+            case "5":
+            case "6":
+            case "7":
+            case "8":
+            case "9":
+            case ".":
+                break gobble1;
+            default:
+                unexpectedCharacter(value, offset);
+        }
+    }
+
+    // Parse the number
+    const [token, newOffset] = tokeniseNumber(value, offset);
+    return [
+        {
+            type: "range",
+            start: left.value,
+            end: token.value,
+        },
+        newOffset,
+    ] as [Tokens, number];
+}
+
+function tokeniseBase(
+    value: string,
+    offset: number,
+    depth: number,
+): [Tokens, number] {
+    if (depth > 10) {
+        throw new Error("Expression too complex");
+    }
+    if (value[offset] === undefined) {
+        throw new Error("Unexpected end of expression");
+    }
+
+    let notMode: number | null = null;
+    let token: Tokens;
+    let newOffset = offset;
+    const consumeEndBracket = (value: string) => {
+        if (value[newOffset] !== ")") {
+            throw new Error(`Expected ) at position ${newOffset}`);
+        }
+        newOffset++;
+    };
+    parse1: for (;;) {
+        switch (value[newOffset]) {
+            case "(":
+                [token, newOffset] = tokeniseBase(
+                    value,
+                    newOffset + 1,
+                    depth + 1,
+                );
+                consumeEndBracket(value);
+                break;
+            case "!":
+                if (notMode !== null) {
+                    throw new Error(`Unexpected ! at position ${newOffset}`);
+                }
+                notMode = newOffset;
+                newOffset++;
+                continue parse1;
+            case " ":
+            case "\t":
+            case "\n":
+            case "\r":
+                newOffset++;
+                continue parse1;
+            case "0":
+            case "1":
+            case "2":
+            case "3":
+            case "4":
+            case "5":
+            case "6":
+            case "7":
+            case "8":
+            case "9":
+            case ".":
+                [token, newOffset] = tokeniseNumber(value, newOffset);
+                break;
+            case ">":
+                [token, newOffset] = tokeniseGtOrGteOrLtOrLte(
+                    value,
+                    newOffset + 1,
+                    "gt",
+                );
+                break;
+            case "<":
+                [token, newOffset] = tokeniseGtOrGteOrLtOrLte(
+                    value,
+                    newOffset + 1,
+                    "lt",
+                );
+                break;
+            default:
+                unexpectedCharacter(value, offset);
+        }
+        break;
+    }
+
+    // Not mode is always to the left token
+    if (notMode !== null) {
+        token = {
+            type: "not",
+            inner: token,
+            startPos: notMode,
+        };
+    }
+
+    joiners: for (;;) {
+        // Gobble up whitespace
+        gobble1: for (;;) {
+            switch (value[newOffset]) {
+                case " ":
+                case "\t":
+                case "\n":
+                case "\r":
+                    newOffset++;
+                    continue;
+                default:
+                    break gobble1;
+            }
+        }
+
+        // Look ahead for a or/and/range
+        switch (value[newOffset]) {
+            case "|":
+                [token, newOffset] = tokeniseJoiner(
+                    value,
+                    token,
+                    newOffset + 1,
+                    depth + 1,
+                    "or",
+                    "|",
+                );
+                break;
+            case "&":
+                [token, newOffset] = tokeniseJoiner(
+                    value,
+                    token,
+                    newOffset + 1,
+                    depth + 1,
+                    "and",
+                    "&",
+                );
+                break;
+            case ".":
+                [token, newOffset] = tokeniseRange(value, newOffset + 1, token);
+                break;
+            default:
+                break joiners;
+        }
+    }
+
+    // Gobble up whitespace
+    gobble2: for (;;) {
+        switch (value[newOffset]) {
+            case " ":
+            case "\t":
+            case "\n":
+            case "\r":
+                newOffset++;
+                continue;
+            default:
+                break gobble2;
+        }
+    }
+
+    if (depth === 0) {
+        // Make sure the expression is complete
+        if (value[newOffset] !== undefined)
+            unexpectedCharacter(value, newOffset);
+    }
+
+    return [token, newOffset];
+}
+
+function tokeniseJoiner(
+    value: string,
+    left: Tokens,
+    offsetAfterFirstJoiner: number,
+    depth: number,
+    type: "or" | "and",
+    joiner: "|" | "&",
+): [Tokens, number] {
+    // Make sure the second joiner is there
+    if (value[offsetAfterFirstJoiner] !== joiner) {
+        throw new Error(
+            `Expected ${value[offsetAfterFirstJoiner]} at position ${offsetAfterFirstJoiner}`,
+        );
+    }
+
+    // Parse the right hand side
+    const [right, newOffset] = tokeniseBase(
+        value,
+        offsetAfterFirstJoiner + 1,
+        depth,
+    );
+
+    return [
+        {
+            type,
+            left,
+            right,
+        },
+        newOffset,
+    ] as [Tokens, number];
+}
+
+export const tokenise = (value: string) => tokeniseBase(value, 0, 0)[0];


### PR DESCRIPTION
Fixes: #791 #784 

Adds a mode for doing expr, supports the following:

- `>=1`: all instances where the column value is greater than or equal to 1 (this also works with less than or without the equals)
- `1`: all instances where the column value is exactly 1
- `!1`: all instances where the column value is not 1
- `!(1||2)`: all instances where the column value is not 1 or 2
- `2..6&&!5`: all instances where the column value is between 2 and 6 and not 5
- `1 || 5..8`: all instances where the column value is 1 or between 5 and 8

defaults to >= mode (unless a expr is added that isn't `>=<number>`), but clicking the function turns on expression mode

![gte mode](https://github.com/user-attachments/assets/07b61926-04c2-45bd-bfdb-d2a59a12cf8f)
![expr mode](https://github.com/user-attachments/assets/9409cb48-dc26-4e16-b388-4e6e8c1cc74a)

I can't find a way to nicely show compile errors sadly, maybe we should add the syntax to the docs?