### PR TITLE
added multiregion support

### DIFF
--- a/scraper/gcp/api.go
+++ b/scraper/gcp/api.go
@@ -222,6 +222,17 @@ func parseMachineTypeFromSKU(sku SKU) (machineFamily string, resourceType string
 	// Get region from geo taxonomy - fix the condition
 	if sku.GeoTaxonomy.RegionalMetadata != nil {
 		region = sku.GeoTaxonomy.RegionalMetadata.Region.Region
+	} else if sku.GeoTaxonomy.Type == "TYPE_MULTI_REGIONAL" {
+		// Use multi-regional as a special "region" identifier
+		// Extract the location from display name (e.g., "running in Americas")
+		displayLower := strings.ToLower(displayName)
+		if strings.Contains(displayLower, "americas") {
+			region = "multi-americas"
+		} else if strings.Contains(displayLower, "europe") {
+			region = "multi-europe"
+		} else if strings.Contains(displayLower, "asia") {
+			region = "multi-asia"
+		}
 	}
 
 	return


### PR DESCRIPTION
Hello,
I've noticed that machine types with sku.GeoTaxonomy.Type == "TYPE_MULTI_REGIONAL" are skipped entirely as TYPE_MULTI_REGIONAL is not supported.
So I've added support for these instance types, as some regions like us-central1 were skipped entirely.