### PR TITLE
Scrape Instance stora IOPS data and present as an additional filterable sortable column

### DIFF
--- a/next/types.ts
+++ b/next/types.ts
@@ -48,6 +48,8 @@ export interface EC2Instance {
         includes_swap_partition: boolean;
         storage_needs_initialization: boolean;
         trim_support: boolean;
+        storage_read_iops?: number;
+        storage_write_iops?: number;
     };
     arch: string[];
     network_performance: string;

--- a/next/utils/colunnData/ec2/columns.tsx
+++ b/next/utils/colunnData/ec2/columns.tsx
@@ -14,6 +14,8 @@ interface Storage {
     ssd: boolean;
     trim_support: boolean;
     storage_needs_initialization: boolean;
+    storage_read_iops?: number;
+    storage_write_iops?: number;
 }
 
 export function calculateCost(
@@ -789,6 +791,66 @@ export const columnsGen = (
                 throw new Error("trim_support is undefined");
             return storage.trim_support ? "Yes" : "No";
         }),
+    },
+    {
+        accessorKey: "storage",
+        header: "Instance Store: Read IOPS",
+        size: 200,
+        id: "storage_read_iops",
+        sortingFn: (rowA, rowB) => {
+            const a = rowA.original.storage?.storage_read_iops;
+            const b = rowB.original.storage?.storage_read_iops;
+            if (!a) return -1;
+            if (!b) return 1;
+            return a - b;
+        },
+        filterFn: (row, _, filterValue) => {
+            const value = row.original.storage?.storage_read_iops;
+            if (!value) return false;
+            try {
+                return exprCompiler(filterValue)(
+                    value,
+                    `${value.toLocaleString()} IOPS`,
+                );
+            } catch {
+                return true;
+            }
+        },
+        cell: (info) => {
+            const storage = info.getValue() as Storage;
+            if (!storage?.storage_read_iops) return undefined;
+            return `${storage.storage_read_iops.toLocaleString()} IOPS`;
+        },
+    },
+    {
+        accessorKey: "storage",
+        header: "Instance Store: Write IOPS",
+        size: 200,
+        id: "storage_write_iops",
+        sortingFn: (rowA, rowB) => {
+            const a = rowA.original.storage?.storage_write_iops;
+            const b = rowB.original.storage?.storage_write_iops;
+            if (!a) return -1;
+            if (!b) return 1;
+            return a - b;
+        },
+        filterFn: (row, _, filterValue) => {
+            const value = row.original.storage?.storage_write_iops;
+            if (!value) return false;
+            try {
+                return exprCompiler(filterValue)(
+                    value,
+                    `${value.toLocaleString()} IOPS`,
+                );
+            } catch {
+                return true;
+            }
+        },
+        cell: (info) => {
+            const storage = info.getValue() as Storage;
+            if (!storage?.storage_write_iops) return undefined;
+            return `${storage.storage_write_iops.toLocaleString()} IOPS`;
+        },
     },
     {
         accessorKey: "arch",

--- a/next/utils/colunnData/ec2/index.ts
+++ b/next/utils/colunnData/ec2/index.ts
@@ -24,6 +24,8 @@ const initialColumnsArr = [
     ["storage", true],
     ["warmed-up", false],
     ["trim-support", false],
+    ["storage_read_iops", false],
+    ["storage_write_iops", false],
     ["arch", false],
     ["network_performance", true],
     ["ebs_baseline_bandwidth", false],
@@ -170,6 +172,8 @@ export function makePrettyNames<V>(
         makeColumnOption("storage", "Instance Storage"),
         makeColumnOption("warmed-up", "Instance Storage: already warmed-up"),
         makeColumnOption("trim-support", "Instance Storage: SSD TRIM Support"),
+        makeColumnOption("storage_read_iops", "Instance Store: Read IOPS"),
+        makeColumnOption("storage_write_iops", "Instance Store: Write IOPS"),
         makeColumnOption("arch", "Arch"),
         makeColumnOption("network_performance", "Network Performance"),
         makeColumnOption(

--- a/next/utils/ec2TablesGenerator.ts
+++ b/next/utils/ec2TablesGenerator.ts
@@ -263,6 +263,18 @@ export function ec2(instance: Omit<EC2Instance, "pricing">): Table[] {
                         instance.storage?.storage_needs_initialization ?? false,
                     bgStyled: true,
                 },
+                {
+                    name: "Instance Store Read IOPS",
+                    children: instance.storage?.storage_read_iops
+                        ? instance.storage.storage_read_iops.toLocaleString()
+                        : "N/A",
+                },
+                {
+                    name: "Instance Store Write IOPS",
+                    children: instance.storage?.storage_write_iops
+                        ? instance.storage.storage_write_iops.toLocaleString()
+                        : "N/A",
+                },
             ],
         },
         {

--- a/next/utils/golden/ec2.json
+++ b/next/utils/golden/ec2.json
@@ -202,6 +202,14 @@
                 "name": "Initialize Storage",
                 "children": false,
                 "bgStyled": true
+            },
+            {
+                "name": "Instance Store Read IOPS",
+                "children": "N/A"
+            },
+            {
+                "name": "Instance Store Write IOPS",
+                "children": "N/A"
             }
         ]
     },

--- a/scripts/scrape-iops.mjs
+++ b/scripts/scrape-iops.mjs
@@ -1,0 +1,254 @@
+import { readFile, writeFile } from "fs/promises";
+import { createHash } from "crypto";
+
+const AWS_DOC_BASE = "https://docs.aws.amazon.com/ec2/latest/instancetypes";
+const DOC_SLUGS = ["gp", "co", "mo", "so", "ac", "hpc"];
+const INSTANCES_JSON = "www/instances.json";
+
+function fatal(msg) {
+    console.error(`FATAL: ${msg}`);
+    process.exit(1);
+}
+
+async function fetchDoc(slug) {
+    const url = `${AWS_DOC_BASE}/${slug}.md`;
+    console.log(`Fetching ${url}`);
+    const res = await fetch(url);
+    if (!res.ok) fatal(`Fetch failed for ${url}: HTTP ${res.status}`);
+    return { slug, text: await res.text() };
+}
+
+function parseIopsTable(markdown, slug) {
+    const lines = markdown.split("\n");
+    let inTable = false;
+    let iopsColIdx = -1;
+    let instanceColIdx = -1;
+    const results = {};
+
+    for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed.startsWith("|")) {
+            if (inTable) break;
+            continue;
+        }
+
+        const cells = trimmed
+            .split("|")
+            .map((c) => c.trim())
+            .filter((_, i, arr) => i > 0 && i < arr.length);
+
+        if (!inTable) {
+            const headerIdx = cells.findIndex((c) =>
+                /random read IOPS/i.test(c),
+            );
+            if (headerIdx !== -1) {
+                inTable = true;
+                iopsColIdx = headerIdx;
+                instanceColIdx = cells.findIndex((c) =>
+                    /instance type/i.test(c),
+                );
+                if (instanceColIdx === -1) instanceColIdx = 0;
+                continue;
+            }
+            continue;
+        }
+
+        // Skip separator row
+        if (cells.every((c) => /^-+$/.test(c))) continue;
+
+        // Skip family header rows (single non-empty cell)
+        const nonEmpty = cells.filter((c) => c.length > 0);
+        if (nonEmpty.length <= 1 && !/\.\w/.test(nonEmpty[0] || "")) continue;
+
+        const instanceType = cells[instanceColIdx];
+        if (!instanceType || !/\.\w/.test(instanceType)) continue;
+
+        const iopsCell = cells[iopsColIdx] || "";
+        if (!iopsCell.trim()) continue;
+
+        const parts = iopsCell.split("/").map((p) => p.trim());
+        if (parts.length !== 2) continue;
+
+        const readIops = parseInt(parts[0].replace(/,/g, ""), 10);
+        const writeIops = parseInt(parts[1].replace(/,/g, ""), 10);
+        if (isNaN(readIops) || isNaN(writeIops)) continue;
+
+        results[instanceType.toLowerCase()] = {
+            read_iops: readIops,
+            write_iops: writeIops,
+        };
+    }
+
+    return results;
+}
+
+async function mergeIntoInstances(iopsMap) {
+    let raw;
+    try {
+        raw = await readFile(INSTANCES_JSON, "utf-8");
+    } catch (e) {
+        fatal(`Cannot read ${INSTANCES_JSON}: ${e.message}`);
+    }
+
+    let instances;
+    try {
+        instances = JSON.parse(raw);
+    } catch (e) {
+        fatal(`Cannot parse ${INSTANCES_JSON}: ${e.message}`);
+    }
+
+    if (!Array.isArray(instances)) fatal(`${INSTANCES_JSON} is not an array`);
+
+    let matched = 0;
+    for (const inst of instances) {
+        const key = inst.instance_type?.toLowerCase();
+        if (!key) continue;
+        const iops = iopsMap[key];
+        if (iops && inst.storage) {
+            inst.storage.storage_read_iops = iops.read_iops;
+            inst.storage.storage_write_iops = iops.write_iops;
+            matched++;
+        }
+    }
+
+    if (matched === 0)
+        fatal(
+            `Zero instances matched IOPS data. IOPS entries: ${Object.keys(iopsMap).length}, instances with storage: ${instances.filter((i) => i.storage).length}`,
+        );
+
+    console.log(
+        `Merged IOPS data into ${matched} instances (of ${Object.keys(iopsMap).length} IOPS entries)`,
+    );
+
+    await writeFile(INSTANCES_JSON, JSON.stringify(instances));
+    return instances;
+}
+
+function sha256(text) {
+    return createHash("sha256").update(text).digest("hex");
+}
+
+async function versionInR2(docs) {
+    const accountId = process.env.R2_ACCOUNT_ID;
+    const accessKeyId = process.env.R2_ACCESS_KEY_ID;
+    const secretAccessKey = process.env.R2_SECRET_ACCESS_KEY;
+    const bucketName = process.env.R2_BUCKET_NAME;
+
+    if (!accountId || !accessKeyId || !secretAccessKey || !bucketName) {
+        console.log("R2 env vars not set, skipping versioning");
+        return;
+    }
+
+    // Dynamic import so the script works without @aws-sdk locally
+    const { S3Client, GetObjectCommand, PutObjectCommand } = await import(
+        "@aws-sdk/client-s3"
+    );
+
+    const s3 = new S3Client({
+        region: "auto",
+        endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
+        credentials: { accessKeyId, secretAccessKey },
+    });
+
+    // Fetch existing meta
+    let meta = { hashes: {}, last_scrape: null };
+    try {
+        const res = await s3.send(
+            new GetObjectCommand({ Bucket: bucketName, Key: "iops/meta.json" }),
+        );
+        meta = JSON.parse(await res.Body.transformToString());
+    } catch (e) {
+        if (e.name !== "NoSuchKey")
+            console.warn("Could not read meta:", e.message);
+    }
+
+    const today = new Date().toISOString().slice(0, 10);
+    let changed = false;
+
+    for (const { slug, text } of docs) {
+        const hash = sha256(text);
+        if (meta.hashes[slug] !== hash) {
+            changed = true;
+            console.log(`${slug}.md changed, storing version for ${today}`);
+            await s3.send(
+                new PutObjectCommand({
+                    Bucket: bucketName,
+                    Key: `iops/raw/${today}/${slug}.md`,
+                    Body: text,
+                    ContentType: "text/markdown",
+                }),
+            );
+            meta.hashes[slug] = hash;
+        }
+    }
+
+    meta.last_scrape = new Date().toISOString();
+
+    if (changed) {
+        // Build fresh parsed data from all docs
+        const allIops = {};
+        for (const { slug, text } of docs) {
+            Object.assign(allIops, parseIopsTable(text, slug));
+        }
+        await s3.send(
+            new PutObjectCommand({
+                Bucket: bucketName,
+                Key: "iops/parsed/latest.json",
+                Body: JSON.stringify(allIops, null, 2),
+                ContentType: "application/json",
+            }),
+        );
+    }
+
+    await s3.send(
+        new PutObjectCommand({
+            Bucket: bucketName,
+            Key: "iops/meta.json",
+            Body: JSON.stringify(meta, null, 2),
+            ContentType: "application/json",
+        }),
+    );
+
+    console.log(
+        changed
+            ? "R2 versioning updated"
+            : "No doc changes detected, meta timestamp updated",
+    );
+}
+
+async function main() {
+    // 1. Fetch all docs in parallel
+    const docs = await Promise.all(DOC_SLUGS.map(fetchDoc));
+
+    // 2. Parse IOPS from each doc
+    const allIops = {};
+    let tablesFound = 0;
+    for (const { slug, text } of docs) {
+        const parsed = parseIopsTable(text, slug);
+        const count = Object.keys(parsed).length;
+        if (count > 0) tablesFound++;
+        console.log(`${slug}.md: ${count} instance types with IOPS`);
+        Object.assign(allIops, parsed);
+    }
+
+    const totalIops = Object.keys(allIops).length;
+    console.log(`Total: ${totalIops} instance types with IOPS data`);
+    if (totalIops === 0) fatal("Parsed zero IOPS entries across all docs");
+
+    // Not all categories have instances with IOPS (e.g., hpc may have none).
+    // But at least some must have the table.
+    if (tablesFound === 0)
+        fatal("No 'Instance store specifications' tables found in any doc");
+
+    // 3. Merge into instances.json
+    await mergeIntoInstances(allIops);
+
+    // 4. Version in R2 (if configured)
+    await versionInR2(docs);
+
+    console.log("Done");
+}
+
+main().catch((e) => {
+    fatal(`Unhandled error: ${e.message}`);
+});


### PR DESCRIPTION

This is an attempt at addressing #476

AWS doesn't expose IOPS through its API (discussed here), so this scrapes the data from the EC2 instance types documentation (https://aws.amazon.com/ec2/instance-types/). Specifically the "Instance store specifications" tables in gp.md, co.md, mo.md, so.md, ac.md, and hpc.md — and merges the IOPS values

Check out https://ec2instances.narekg.me/ to see this deployed.
The deploy source is in the main branch of my fork. A daily GitHub Actions cron re-scrapes and redeploys.

<details>
<summary>This is the plan I wrote for codegen assistance:</summary>

I am using ec2instances.info for ec2 instance info gathering and choosing.

I ran into an issue where local instance storage nvme specs are not filterable in the UI.

There have been past issues reporting this on the repo
issue refs: https://github.com/vantage-sh/ec2instances.info/issues/476 currently open issue with some links

Another issue: https://github.com/vantage-sh/ec2instances.info/issues/587
here they are discussing whether this could be done via aws API but conclusion seems to be --- no.
Would be worth investigating this further before giving up on API.


This amazon page has instance type info: https://docs.aws.amazon.com/ec2/latest/instancetypes/ (markdown of the page: https://docs.aws.amazon.com/ec2/latest/instancetypes/instance-types.md)

In there, there is a section with title.

And under it contains the following:

## Current generation instances
<a name="current-gen-instances"></a>

For the best performance, we recommend that you use the following instance types when you launch new instances. For more information, see [Amazon EC2 Instance Types](https://aws.amazon.com/ec2/instance-types/).
+ [**General purpose: **](gp.md)M5 \$1 M5a \$1 M5ad \$1 M5d \$1 M5dn \$1 M5n \$1 M5zn \$1 M6a \$1 M6g \$1 M6gd \$1 M6i \$1 M6id \$1 M6idn \$1 M6in \$1 M7a \$1 M7g \$1 M7gd \$1 M7i \$1 M7i-flex \$1 M8a \$1 M8azn \$1 M8g \$1 M8gb \$1 M8gd \$1 M8gn \$1 M8i \$1 M8id \$1 M8i-flex \$1 Mac1 \$1 Mac2 \$1 Mac2-m1ultra \$1 Mac2-m2 \$1 Mac2-m2pro \$1 Mac-m4 \$1 Mac-m4pro \$1 Mac-m4max \$1 T2 \$1 T3 \$1 T3a \$1 T4g
+ [**Compute optimized: **](co.md)C5 \$1 C5a \$1 C5ad \$1 C5d \$1 C5n \$1 C6a \$1 C6g \$1 C6gd \$1 C6gn \$1 C6i \$1 C6id \$1 C6in \$1 C7a \$1 C7g \$1 C7gd \$1 C7gn \$1 C7i \$1 C7i-flex \$1 C8a \$1 C8g \$1 C8gb \$1 C8gd \$1 C8gn \$1 C8i \$1 C8ib \$1 C8id \$1 C8in \$1 C8i-flex
+ [**Memory optimized: **](mo.md)R5 \$1 R5a \$1 R5ad \$1 R5b \$1 R5d \$1 R5dn \$1 R5n \$1 R6a \$1 R6g \$1 R6gd \$1 R6i \$1 R6id \$1 R6idn \$1 R6in \$1 R7a \$1 R7g \$1 R7gd \$1 R7i \$1 R7iz \$1 R8a \$1 R8g \$1 R8gb \$1 R8gd \$1 R8gn \$1 R8i \$1 R8id \$1 R8i-flex \$1 U-3tb1 \$1 U-6tb1 \$1 U-9tb1 \$1 U-12tb1 \$1 U-18tb1 \$1 U-24tb1 \$1 U7i-6tb \$1 U7i-8tb \$1 U7i-12tb \$1 U7in-16tb \$1 U7in-24tb \$1 U7in-32tb \$1 U7inh-32tb \$1 X1 \$1 X1e \$1 X2gd \$1 X2idn \$1 X2iedn \$1 X2iezn \$1 X8g \$1 X8aedz \$1 X8i \$1 z1d
+ [**Storage optimized: **](so.md)D2 \$1 D3 \$1 D3en \$1 H1 \$1 I3 \$1 I3en \$1 I4g \$1 I4i \$1 I7i \$1 I7ie \$1 I8g \$1 I8ge \$1 Im4gn \$1 Is4gen
+ [**Accelerated computing: **](ac.md)DL1 \$1 DL2q \$1 F1 \$1 F2 \$1 G4ad \$1 G4dn \$1 G5 \$1 G5g \$1 G6 \$1 G6e \$1 G6f \$1 Gr6 \$1 Gr6f \$1 G7e \$1 Inf1 \$1 Inf2 \$1 P4d \$1 P4de \$1 P5 \$1 P5e \$1 P5en \$1 P6-B200 \$1 P6-B300 \$1 P6e-GB200 \$1 Trn1 \$1 Trn1n \$1 Trn2 \$1 Trn2u \$1 VT1
+ [**High-performance computing: **](hpc.md)Hpc6a \$1 Hpc6id \$1 Hpc7a \$1 Hpc7g \$1 Hpc8a

if you open each .md file from above, you will see "Instance store specifications" section that has a table which has a column called "100% random read IOPS / Write IOPS"
That column contains read and write IOPS for local nvme. I would like to scrape clean this data and expose it as part of 2 columns that can be sorted, filtered etc.


Here is the full plan:


Propose a mechanism for scraping and exposing all instance storage iops. make this an internal route that only I can call to trigger scraping and can schedule for once a day regular scraping via cloudflare scheduled things.
Add a readonly debug endpoint here where I can send a get request and get raw data that has been scraped and structured as well as last scrape date time. keep each unique version of scraped md file in a cloudflare blob store with scrape date. if something changes in md from last version, make another copy with a new date. do this even if some time in the past history the exact same file existed. this way I will have copies of all files retained whenever there is a change. if latest scrape looks exactly like the last one, do not save a separate file. If something does change, make sure it is reflected in the website.

Ideally, I would like to avoid scraping all the things in a cloud myself. Ideally, I would like to download https://instances.vantagestaging.sh/www_pre_build.tar.gz like shown in readme once a day and base things on that. be careful to not run into cloudflare worker usage limits however. if you think this is doomed to fail, tell me early in stead of going forward.

</details>

