### PR TITLE
fix(ec2): add GPU specs for G7 family

### DIFF
--- a/scraper/aws/ec2/gpu_data.go
+++ b/scraper/aws/ec2/gpu_data.go
@@ -361,37 +361,37 @@ var GPU_DATA = map[string]gpuData{
 	// https://aws.amazon.com/blogs/aws/announcing-amazon-ec2-g7-instances-accelerated-by-nvidia-rtx-pro-4500-blackwell-server-edition-gpus/
 	"g7.2xlarge": {
 		gpuModel:          "NVIDIA RTX PRO 4500 Blackwell",
-		computeCapability: 10.0,
+		computeCapability: 12.0,
 		gpuCount:          1,
 		gpuMemory:         32,
 	},
 	"g7.4xlarge": {
 		gpuModel:          "NVIDIA RTX PRO 4500 Blackwell",
-		computeCapability: 10.0,
+		computeCapability: 12.0,
 		gpuCount:          1,
 		gpuMemory:         32,
 	},
 	"g7.8xlarge": {
 		gpuModel:          "NVIDIA RTX PRO 4500 Blackwell",
-		computeCapability: 10.0,
+		computeCapability: 12.0,
 		gpuCount:          1,
 		gpuMemory:         32,
 	},
 	"g7.12xlarge": {
 		gpuModel:          "NVIDIA RTX PRO 4500 Blackwell",
-		computeCapability: 10.0,
+		computeCapability: 12.0,
 		gpuCount:          2,
 		gpuMemory:         64,
 	},
 	"g7.24xlarge": {
 		gpuModel:          "NVIDIA RTX PRO 4500 Blackwell",
-		computeCapability: 10.0,
+		computeCapability: 12.0,
 		gpuCount:          4,
 		gpuMemory:         128,
 	},
 	"g7.48xlarge": {
 		gpuModel:          "NVIDIA RTX PRO 4500 Blackwell",
-		computeCapability: 10.0,
+		computeCapability: 12.0,
 		gpuCount:          8,
 		gpuMemory:         256,
 	},

--- a/scraper/aws/ec2/gpu_data.go
+++ b/scraper/aws/ec2/gpu_data.go
@@ -355,6 +355,46 @@ var GPU_DATA = map[string]gpuData{
 		gpuCount:          8,
 		gpuMemory:         768,
 	},
+	// g7 uses NVIDIA RTX PRO 4500 Blackwell Server Edition GPUs (GB203 die,
+	// 32 GB per GPU). Same per-size GPU scaling as g7e.
+	// https://aws.amazon.com/ec2/instance-types/g7/
+	// https://aws.amazon.com/blogs/aws/announcing-amazon-ec2-g7-instances-accelerated-by-nvidia-rtx-pro-4500-blackwell-server-edition-gpus/
+	"g7.2xlarge": {
+		gpuModel:          "NVIDIA RTX PRO 4500 Blackwell",
+		computeCapability: 10.0,
+		gpuCount:          1,
+		gpuMemory:         32,
+	},
+	"g7.4xlarge": {
+		gpuModel:          "NVIDIA RTX PRO 4500 Blackwell",
+		computeCapability: 10.0,
+		gpuCount:          1,
+		gpuMemory:         32,
+	},
+	"g7.8xlarge": {
+		gpuModel:          "NVIDIA RTX PRO 4500 Blackwell",
+		computeCapability: 10.0,
+		gpuCount:          1,
+		gpuMemory:         32,
+	},
+	"g7.12xlarge": {
+		gpuModel:          "NVIDIA RTX PRO 4500 Blackwell",
+		computeCapability: 10.0,
+		gpuCount:          2,
+		gpuMemory:         64,
+	},
+	"g7.24xlarge": {
+		gpuModel:          "NVIDIA RTX PRO 4500 Blackwell",
+		computeCapability: 10.0,
+		gpuCount:          4,
+		gpuMemory:         128,
+	},
+	"g7.48xlarge": {
+		gpuModel:          "NVIDIA RTX PRO 4500 Blackwell",
+		computeCapability: 10.0,
+		gpuCount:          8,
+		gpuMemory:         256,
+	},
 	"p4d.24xlarge": {
 		gpuModel:          "NVIDIA A100",
 		computeCapability: 8.0,


### PR DESCRIPTION
## Root cause

The G7 EC2 instance family was entirely absent from the `GPU_DATA` map in
`scraper/aws/ec2/gpu_data.go`. The map contained `g7e.*` entries but no
`g7.*` entries. In `addGpuInfo`, instance types not present in the map are
skipped (only a warning is logged), so G7 instances kept their default
empty/zero GPU model, memory, and compute capability. The frontend
(`next/utils/colunnData/ec2/columns.tsx`) renders whatever the scraper
emits for `GPU`, `GPU_model`, `GPU_memory`, and `compute_capability`, so the
columns showed empty/N/A for G7 while G7e worked.

## Fix

Added the six generally available G7 sizes to `GPU_DATA`, mirroring the G7e
per-size GPU scaling (1 GPU for 2xl/4xl/8xl, 2 for 12xl, 4 for 24xl, 8 for
48xl):

| Size | GPUs | GPU memory (GiB) |
|------|------|------------------|
| g7.2xlarge | 1 | 32 |
| g7.4xlarge | 1 | 32 |
| g7.8xlarge | 1 | 32 |
| g7.12xlarge | 2 | 64 |
| g7.24xlarge | 4 | 128 |
| g7.48xlarge | 8 | 256 |

GPU model: **NVIDIA RTX PRO 4500 Blackwell Server Edition** (GB203 die,
32 GB GDDR7 per GPU), compute capability 10.0 (Blackwell), consistent with
how the existing G7e and P6 Blackwell entries set 10.0.

`g7.metal` is intentionally omitted because AWS lists it as "coming soon" /
not generally available; it can be added once it launches (the scraper logs
a warning for any GA GPU instance missing from the map).

### AWS sources

- https://aws.amazon.com/ec2/instance-types/g7/
- https://aws.amazon.com/blogs/aws/announcing-amazon-ec2-g7-instances-accelerated-by-nvidia-rtx-pro-4500-blackwell-server-edition-gpus/
- GB203 die confirmation: https://www.techpowerup.com/347466/nvidia-launches-rtx-pro-4500-blackwell-server-edition-gpu

## Verification

- `go build ./...` in `scraper/`: success.
- `go test ./...` in `scraper/`: no tests exist in the scraper module (no test file asserts GPU data, so none to extend).
- `gofmt -l` on the changed file: clean.
- Confirmed all 6 `g7.*` keys are present and structurally identical to the
  `gpuData` struct shape, and that the existing `g7e.*` entries are
  unchanged. After the next scrape, `addGpuInfo` will populate
  `GPU`/`GPUModel`/`GPUMemory`/`ComputeCapability` for G7, which the
  unchanged frontend columns render directly.

Closes #907
