### PR TITLE
fix(ec2): hide instances not offered in the selected region

### DIFF
--- a/next/components/InstanceTable.tsx
+++ b/next/components/InstanceTable.tsx
@@ -33,6 +33,7 @@ import SortToggle from "./SortToggle";
 import * as columnData from "@/utils/colunnData";
 import { usePathname } from "next/navigation";
 import DragDetector from "./DragDetector";
+import isAvailableInRegion from "@/utils/isAvailableInRegion";
 
 export type AtomKeyWhereInstanceIs<Instance> = {
     [AtomKey in keyof typeof columnData]: (typeof columnData)[AtomKey]["columnsGen"] extends (
@@ -125,8 +126,16 @@ export default function InstanceTable<
         if (compareOn) {
             return instances.filter((i) => selected.includes(i.instance_type));
         }
-        return instances;
-    }, [compareOn, instances, selected]);
+        // Hide instances that the selected region does not offer. Availability
+        // is derived from the per-region pricing map, the same signal the
+        // instance detail page uses to disable a region (see
+        // components/PricingCalculator.tsx). Without this, an instance such as
+        // m8i.2xlarge still rendered (with empty pricing cells) when a region
+        // it is not offered in, e.g. eu-north-1, was selected.
+        return instances.filter((i) =>
+            isAvailableInRegion(i as Record<string, unknown>, selectedRegion),
+        );
+    }, [compareOn, instances, selected, selectedRegion]);
 
     const rowSelectionRemapped = useMemo(() => {
         const res: RowSelectionState = {};

--- a/next/utils/isAvailableInRegion.test.ts
+++ b/next/utils/isAvailableInRegion.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "vitest";
+import isAvailableInRegion from "./isAvailableInRegion";
+
+// Reproduces the real scenario from issue #908: m8i.2xlarge is not offered in
+// eu-north-1 (Stockholm), so the scraper emits no pricing entry for that region.
+// The listing table must treat it as unavailable there (and hide it), while the
+// detail page already shows the region as disabled.
+const m8i2xlarge = {
+    instance_type: "m8i.2xlarge",
+    pricing: {
+        "us-east-1": {
+            linux: { ondemand: "0.4032" },
+            mswin: { ondemand: "0.776" },
+        },
+        "eu-west-1": {
+            linux: { ondemand: "0.4435" },
+        },
+        // Intentionally no "eu-north-1" entry: not offered in Stockholm.
+    },
+};
+
+test("instance offered in the selected region is available", () => {
+    expect(isAvailableInRegion(m8i2xlarge, "us-east-1")).toBe(true);
+    expect(isAvailableInRegion(m8i2xlarge, "eu-west-1")).toBe(true);
+});
+
+test("instance not offered in the selected region is unavailable", () => {
+    // This is the assertion that fails before the fix is wired into the table:
+    // the instance must be reported as unavailable in eu-north-1.
+    expect(isAvailableInRegion(m8i2xlarge, "eu-north-1")).toBe(false);
+});
+
+test("empty region pricing object counts as unavailable", () => {
+    const instance = {
+        instance_type: "foo.large",
+        pricing: {
+            "us-east-1": { linux: { ondemand: "1" } },
+            "eu-north-1": {},
+        },
+    };
+    expect(isAvailableInRegion(instance, "eu-north-1")).toBe(false);
+});
+
+test("instances without a pricing map are never filtered out", () => {
+    expect(isAvailableInRegion({ instance_type: "bar" }, "eu-north-1")).toBe(
+        true,
+    );
+    expect(
+        isAvailableInRegion({ instance_type: "bar", pricing: {} }, "us-east-1"),
+    ).toBe(true);
+});
+
+// RDS nests an extra engine/version level under the region key. The region key
+// is still absent when the instance is not offered, so the presence check holds.
+test("handles the nested RDS pricing shape", () => {
+    const rdsInstance = {
+        instance_type: "db.m5.large",
+        pricing: {
+            "us-east-1": {
+                "2": { ondemand: "0.1" },
+                "14": { ondemand: "0.2" },
+            },
+        },
+    };
+    expect(isAvailableInRegion(rdsInstance, "us-east-1")).toBe(true);
+    expect(isAvailableInRegion(rdsInstance, "eu-north-1")).toBe(false);
+});

--- a/next/utils/isAvailableInRegion.ts
+++ b/next/utils/isAvailableInRegion.ts
@@ -1,0 +1,44 @@
+// Region availability predicate shared by the listing table.
+//
+// An instance is offered in a region if, and only if, the scraper produced a
+// pricing entry for that region. This mirrors the instance detail page's
+// pricing calculator, which disables a region option with `disabled={!pricing[code]}`
+// (see components/PricingCalculator.tsx). The listing table reuses the same
+// notion so that selecting a region hides instances that region does not offer
+// (e.g. m8i.2xlarge is not available in eu-north-1 / Stockholm).
+//
+// The check is intentionally tolerant of the differing pricing shapes across
+// providers: EC2/Azure/GCP key `pricing[region]` directly by platform, while
+// RDS nests an extra engine/version level. In every case the region key is
+// absent when the instance is not offered there, so a presence check on
+// `pricing[region]` is sufficient and provider-agnostic.
+
+type MaybePricedInstance = {
+    pricing?: { [region: string]: unknown };
+    [key: string]: unknown;
+};
+
+export default function isAvailableInRegion(
+    instance: MaybePricedInstance,
+    region: string,
+): boolean {
+    const pricing = instance.pricing;
+    // Instances with no pricing map at all (e.g. providers that do not carry
+    // region pricing) are never filtered out, so the table keeps its previous
+    // behaviour for them.
+    if (!pricing || Object.keys(pricing).length === 0) return true;
+
+    const regionPricing = pricing[region];
+    if (!regionPricing) return false;
+
+    // Guard against an empty object being present for a region the instance is
+    // not actually offered in.
+    if (
+        typeof regionPricing === "object" &&
+        Object.keys(regionPricing as object).length === 0
+    ) {
+        return false;
+    }
+
+    return true;
+}


### PR DESCRIPTION
## Problem

On the main EC2 instances table, selecting a region only re-prices the visible
rows; it does not filter rows by region availability. Instances that AWS does
not offer in the selected region still appear, with empty pricing cells.

Example from #908: with region set to Stockholm (`eu-north-1`), `m8i.2xlarge`
still shows up even though it is not offered there. The instance detail page
(`/aws/ec2/m8i.2xlarge`) already correctly marks Stockholm as disabled, so the
underlying per-instance, per-region availability data is present and correct.
Only the listing table was ignoring it.

## Root cause

`next/components/InstanceTable.tsx` builds its row data from the full instance
list and uses `selectedRegion` solely to generate the pricing columns. There is
no row-level availability filter. An instance not offered in a region simply has
no `pricing[region]` entry (`next/types.ts` `Pricing` is keyed by region), so its
cost cells render blank while the row still shows.

The detail page already encodes the correct predicate: the pricing calculator
disables a region with `disabled={!pricing[code]}`
(`next/components/PricingCalculator.tsx`). Availability == a per-region pricing
entry exists.

## Fix

- Extract that predicate into a shared, provider-agnostic helper
  `next/utils/isAvailableInRegion.ts`. It reports an instance as available in a
  region when a non-empty `pricing[region]` entry exists. Instances that carry no
  pricing map at all are never filtered (table keeps prior behaviour for them),
  and it tolerates the nested RDS pricing shape (extra engine/version level) since
  the region key is still absent when the instance is not offered.
- Apply the filter in `InstanceTable`'s row-data memo so selecting a region hides
  instances that region does not offer. The `compareOn` branch is intentionally
  left unchanged: in compare mode the user explicitly pins instances and should
  not have them silently dropped by a region change.

**Behaviour chosen: (a) hide unavailable rows.** The region selector's existing
semantics are "show me this region," and the detail page already treats a missing
region as not-offered/disabled. There is no existing availability column or filter
UX to surface a "show but mark unavailable" mode, so hiding is the minimal change
consistent with the current region selector and with the reporter's expectation.

## Verification

New regression test `next/utils/isAvailableInRegion.test.ts` replicates the real
scenario (m8i.2xlarge with no `eu-north-1` entry) plus edge cases (empty region
object, no pricing map, nested RDS shape).

- Before the fix (predicate stubbed to the old always-true behaviour): the key
  assertions fail — `expected true to be false` for `eu-north-1`.
- After the fix: `5 passed`.
- `PricingCalculator` (detail page) suite still green: `24 passed`.
- `tsc --noEmit`: no errors introduced (the only remaining errors are pre-existing
  and come from test files importing data JSON that is produced by a data build).

End-to-end: selecting Stockholm now removes `m8i.2xlarge` (and any other instance
without `eu-north-1` pricing) from the table, matching the detail page.

Closes #908
