### PR TITLE
fix(elasticache): amortize reserved upfront fees into hourly rate

### DIFF
--- a/scraper/aws/elasticache.go
+++ b/scraper/aws/elasticache.go
@@ -91,7 +91,15 @@ func processElastiCacheOnDemandDimension(attributes map[string]string, priceDime
 	}
 	// Extended support is an optional surcharge and should not be mixed into
 	// baseline on-demand node pricing.
-	if strings.Contains(strings.ToLower(attributes["usagetype"]), "extendedsupport") {
+	usagetypeLower := strings.ToLower(attributes["usagetype"])
+	if strings.Contains(usagetypeLower, "extendedsupport") {
+		return
+	}
+	// SyncDurability is a Multi-AZ sync-durability add-on (a separate
+	// "SyncDurability-NodeUsage" SKU), not the base node price. Letting it
+	// through would overwrite the real NodeUsage on-demand rate (last-wins),
+	// which made Valkey on-demand look cheaper than reserved (issue #909).
+	if strings.Contains(usagetypeLower, "syncdurability") {
 		return
 	}
 

--- a/scraper/aws/rds.go
+++ b/scraper/aws/rds.go
@@ -169,23 +169,13 @@ func processRDSAndElastiCacheReservedOffer(
 	offer awsutils.RegionTerm,
 	currency string,
 ) {
+	effectiveHourly := effectiveReservedHourly(offer, termCode, currency)
+	if effectiveHourly <= 0 {
+		return
+	}
 	for _, data := range data {
-		for _, offer := range offer.PriceDimensions {
-			usd := offer.PricePerUnit[currency]
-			if usd != "" && usd != "0" {
-				f := awsutils.Floaty(usd)
-				switch termCode {
-				case "yrTerm1Standard.partialUpfront", "yrTerm1Standard.allUpfront":
-					f = f / 365 / 24
-				case "yrTerm3Standard.partialUpfront", "yrTerm3Standard.allUpfront":
-					f = f / (365 * 3) / 24
-				}
-				if f != 0 && f > data.Reserved[termCode] {
-					data.Reserved[termCode] = f
-				}
-			} else {
-				log.Fatalln("RDS or ElastiCache Reserved pricing data has no price", offer)
-			}
+		if effectiveHourly > data.Reserved[termCode] {
+			data.Reserved[termCode] = effectiveHourly
 		}
 	}
 }

--- a/scraper/aws/reserved_pricing_test.go
+++ b/scraper/aws/reserved_pricing_test.go
@@ -116,6 +116,43 @@ func TestNoUpfrontReservedKeepsHourly(t *testing.T) {
 	}
 }
 
+// TestSyncDurabilityExcludedFromOnDemand reproduces the remaining half of issue
+// #909: Valkey on-demand for cache.r7g.large in ap-southeast-1 has two on-demand
+// SKUs - the real "NodeUsage" node rate ($0.2104/hr) and a Multi-AZ
+// "SyncDurability-NodeUsage" add-on ($0.0379/hr). The add-on must not overwrite
+// the base node price (last-wins), otherwise on-demand collapses to $0.0379 and
+// reserved looks more expensive than on-demand.
+func TestSyncDurabilityExcludedFromOnDemand(t *testing.T) {
+	const cacheEngine = "Valkey"
+	pd := &genericAwsPricingData{}
+	getPricingData := func(platform string) *genericAwsPricingData { return pd }
+
+	nodeUsage := awsutils.RegionPriceDimension{
+		Description:  "$0.2104 per Memory optimized r7g.large node hour running Valkey",
+		Unit:         "Hrs",
+		PricePerUnit: map[string]string{"USD": "0.2104"},
+	}
+	syncDurability := awsutils.RegionPriceDimension{
+		Description:  "$0.0379 per Hr for SyncDurability-NodeUsage:cache.r7g.large in Asia Pacific (Singapore)",
+		Unit:         "Hrs",
+		PricePerUnit: map[string]string{"USD": "0.0379"},
+	}
+
+	// Feed both dimensions, add-on last so the bug (last-wins) would surface.
+	processElastiCacheOnDemandDimension(
+		map[string]string{"cacheEngine": cacheEngine, "usagetype": "APS1-NodeUsage:cache.r7g.large"},
+		nodeUsage, getPricingData, "USD",
+	)
+	processElastiCacheOnDemandDimension(
+		map[string]string{"cacheEngine": cacheEngine, "usagetype": "APS1-SyncDurability-NodeUsage:cache.r7g.large"},
+		syncDurability, getPricingData, "USD",
+	)
+
+	if !approxEqual(pd.OnDemand, 0.2104) {
+		t.Fatalf("Valkey on-demand = %v, want 0.2104 (SyncDurability add-on must be excluded)", pd.OnDemand)
+	}
+}
+
 // TestGenericHalfReservedAmortizesPartialUpfront covers the OpenSearch/Redshift
 // path (processGenericHalfReservedOffer), which shares the same amortization
 // helper. It uses real AWS OpenSearch pricing for a Partial Upfront offer and

--- a/scraper/aws/reserved_pricing_test.go
+++ b/scraper/aws/reserved_pricing_test.go
@@ -1,0 +1,149 @@
+package aws
+
+import (
+	"math"
+	"scraper/aws/awsutils"
+	"testing"
+)
+
+// newReservedOffer builds a RegionTerm with the given hourly recurring fee and
+// one-time upfront fee, mirroring how AWS structures reserved price dimensions
+// ("Hrs" for the recurring fee, "Quantity" for the upfront fee).
+func newReservedOffer(hourly, upfront string) awsutils.RegionTerm {
+	dims := map[string]awsutils.RegionPriceDimension{}
+	if hourly != "" {
+		dims["hrs"] = awsutils.RegionPriceDimension{
+			Unit:         "Hrs",
+			PricePerUnit: map[string]string{"USD": hourly},
+		}
+	}
+	if upfront != "" {
+		dims["upfront"] = awsutils.RegionPriceDimension{
+			Unit:         "Quantity",
+			PricePerUnit: map[string]string{"USD": upfront},
+		}
+	}
+	return awsutils.RegionTerm{PriceDimensions: dims}
+}
+
+func computeReserved(termCode, hourly, upfront string) float64 {
+	pd := &genericAwsPricingData{Reserved: map[string]float64{}}
+	processRDSAndElastiCacheReservedOffer(
+		[]*genericAwsPricingData{pd},
+		termCode,
+		newReservedOffer(hourly, upfront),
+		"USD",
+	)
+	return pd.Reserved[termCode]
+}
+
+func approxEqual(a, b float64) bool {
+	return math.Abs(a-b) < 1e-9
+}
+
+// TestPartialUpfrontReservedNotUnderstated reproduces the ElastiCache pricing
+// bug from issue #909 using the real AWS pricing for cache.r7g.large Valkey in
+// ap-southeast-1. A Partial Upfront reserved offer combines a recurring hourly
+// fee with an amortized upfront fee. The old code took the max of the two
+// dimensions (after wrongly dividing the hourly fee), dropping the hourly fee
+// entirely and producing a per-hour rate of ~0.0684 instead of the correct
+// ~0.1364, which made Partial Upfront look cheaper than All Upfront.
+func TestPartialUpfrontReservedNotUnderstated(t *testing.T) {
+	const hoursPerMonth = 365.0 * 24 / 12
+
+	onDemand := 0.2104
+
+	// Real AWS reserved dimensions for the example instance.
+	noUpfront1yr := computeReserved("yrTerm1Standard.noUpfront", "0.1432", "")
+	partial1yr := computeReserved("yrTerm1Standard.partialUpfront", "0.0680", "599.0088")
+	allUpfront1yr := computeReserved("yrTerm1Standard.allUpfront", "0.0000", "1179.5864")
+	partial3yr := computeReserved("yrTerm3Standard.partialUpfront", "0.0504", "1327.0352")
+
+	// Effective hourly rate = hourly fee + upfront/hoursInTerm.
+	wantPartial1yr := 0.0680 + 599.0088/(1*365*24)
+	if !approxEqual(partial1yr, wantPartial1yr) {
+		t.Fatalf("1yr partial upfront effective hourly = %v, want %v", partial1yr, wantPartial1yr)
+	}
+	wantPartial3yr := 0.0504 + 1327.0352/(3*365*24)
+	if !approxEqual(partial3yr, wantPartial3yr) {
+		t.Fatalf("3yr partial upfront effective hourly = %v, want %v", partial3yr, wantPartial3yr)
+	}
+
+	// Every reserved rate must be cheaper than on demand.
+	for name, v := range map[string]float64{
+		"noUpfront1yr":  noUpfront1yr,
+		"partial1yr":    partial1yr,
+		"allUpfront1yr": allUpfront1yr,
+	} {
+		if v >= onDemand {
+			t.Errorf("%s reserved hourly %v is not cheaper than on demand %v", name, v, onDemand)
+		}
+	}
+
+	// Partial Upfront must sit between No Upfront and All Upfront, not below
+	// All Upfront (the inverted ordering the bug produced).
+	if !(allUpfront1yr <= partial1yr && partial1yr <= noUpfront1yr) {
+		t.Errorf("1yr ordering broken: allUpfront=%v partial=%v noUpfront=%v",
+			allUpfront1yr, partial1yr, noUpfront1yr)
+	}
+
+	// The buggy value was ~0.0684/hr (49.92/mo); the correct value is
+	// ~0.1364/hr (~99.6/mo). Guard against regressing to the understated value.
+	buggyMonthly := 0.0684 * hoursPerMonth
+	correctMonthly := partial1yr * hoursPerMonth
+	if correctMonthly <= buggyMonthly+1 {
+		t.Errorf("1yr partial upfront monthly %v did not rise above the buggy value %v",
+			correctMonthly, buggyMonthly)
+	}
+}
+
+// TestAllUpfrontReservedAmortizesUpfront verifies an All Upfront offer (zero
+// hourly fee) amortizes the upfront fee over the full lease.
+func TestAllUpfrontReservedAmortizesUpfront(t *testing.T) {
+	got := computeReserved("yrTerm3Standard.allUpfront", "0.0000", "2488.1904")
+	want := 2488.1904 / (3 * 365 * 24)
+	if !approxEqual(got, want) {
+		t.Fatalf("3yr all upfront effective hourly = %v, want %v", got, want)
+	}
+}
+
+// TestNoUpfrontReservedKeepsHourly verifies a No Upfront offer (single hourly
+// dimension) is stored as-is.
+func TestNoUpfrontReservedKeepsHourly(t *testing.T) {
+	got := computeReserved("yrTerm1Standard.noUpfront", "0.1432", "")
+	if !approxEqual(got, 0.1432) {
+		t.Fatalf("1yr no upfront effective hourly = %v, want 0.1432", got)
+	}
+}
+
+// TestGenericHalfReservedAmortizesPartialUpfront covers the OpenSearch/Redshift
+// path (processGenericHalfReservedOffer), which shares the same amortization
+// helper. It uses real AWS OpenSearch pricing for a Partial Upfront offer and
+// confirms the hourly fee is summed with the amortized upfront fee rather than
+// one dimension overwriting the other.
+func TestGenericHalfReservedAmortizesPartialUpfront(t *testing.T) {
+	offer := awsutils.RegionTerm{
+		TermAttributes: map[string]string{
+			"LeaseContractLength": "1yr",
+			"PurchaseOption":      "Partial Upfront",
+		},
+		PriceDimensions: map[string]awsutils.RegionPriceDimension{
+			"hrs": {
+				Unit:         "Hrs",
+				PricePerUnit: map[string]string{"USD": "0.8820"},
+			},
+			"upfront": {
+				Unit:         "Quantity",
+				PricePerUnit: map[string]string{"USD": "7730"},
+			},
+		},
+	}
+	pd := &genericAwsPricingData{Reserved: map[string]float64{}}
+	processGenericHalfReservedOffer(offer, func() *genericAwsPricingData { return pd }, "USD")
+
+	got := pd.Reserved["yrTerm1Standard.partialUpfront"]
+	want := 0.8820 + 7730.0/(1*365*24)
+	if !approxEqual(got, want) {
+		t.Fatalf("1yr partial upfront effective hourly = %v, want %v", got, want)
+	}
+}

--- a/scraper/aws/utils.go
+++ b/scraper/aws/utils.go
@@ -34,33 +34,60 @@ func cleanEmptyRegions(pricing map[string]map[string]any, regionDescriptions map
 	return regions
 }
 
-func processGenericHalfReservedOffer(offer awsutils.RegionTerm, getPricingData func() *genericAwsPricingData, currency string) {
-	termCode := translateGenericAwsReservedTermAttributes(offer.TermAttributes)
-	for _, offer := range offer.PriceDimensions {
-		descLower := strings.ToLower(offer.Description)
+// hoursInReservedTerm returns the number of hours in the lease for a reserved
+// term code (e.g. "yrTerm1Standard.allUpfront" -> 1 year). It is used to
+// amortize the one-time upfront fee into an effective hourly rate.
+func hoursInReservedTerm(termCode string) int {
+	switch {
+	case strings.HasPrefix(termCode, "yrTerm1"):
+		return 1 * 365 * 24
+	case strings.HasPrefix(termCode, "yrTerm3"):
+		return 3 * 365 * 24
+	default:
+		log.Fatalln("Reserved pricing data has unknown lease length", termCode)
+		return 0
+	}
+}
+
+// effectiveReservedHourly combines a reserved offer's recurring hourly fee
+// (Unit == "Hrs") with its one-time upfront fee (any other unit, e.g.
+// "Quantity") into a single effective hourly rate, amortizing the upfront fee
+// over the lease. This mirrors how EC2 reserved pricing is computed and ensures
+// Partial Upfront rates are not understated by dropping the hourly fee. It
+// returns -1 if the offer should be skipped (a description chunk was filtered).
+func effectiveReservedHourly(offer awsutils.RegionTerm, termCode, currency string) float64 {
+	hourlyPrice := 0.0
+	upfrontPrice := 0.0
+	for _, priceDimension := range offer.PriceDimensions {
+		descLower := strings.ToLower(priceDimension.Description)
 		for _, chunk := range BAD_DESCRIPTION_CHUNKS {
 			if strings.Contains(descLower, chunk) {
 				// Skip these for now
-				return
+				return -1
 			}
 		}
 
-		usd := offer.PricePerUnit[currency]
-		if usd != "" && usd != "0" {
-			f := awsutils.Floaty(usd)
-			switch termCode {
-			case "yrTerm1Standard.partialUpfront", "yrTerm1Standard.allUpfront":
-				f = f / 365 / 24
-			case "yrTerm3Standard.partialUpfront", "yrTerm3Standard.allUpfront":
-				f = f / (365 * 3) / 24
-			}
-			if f != 0 {
-				getPricingData().Reserved[termCode] = f
-			}
+		usd := priceDimension.PricePerUnit[currency]
+		if usd == "" {
+			log.Fatalln("Reserved pricing data has no price", priceDimension)
+		}
+		f := awsutils.Floaty(usd)
+		if priceDimension.Unit == "Hrs" {
+			hourlyPrice = f
 		} else {
-			log.Fatalln("Reserved pricing data has no price", offer)
+			upfrontPrice = f
 		}
 	}
+	return hourlyPrice + upfrontPrice/float64(hoursInReservedTerm(termCode))
+}
+
+func processGenericHalfReservedOffer(offer awsutils.RegionTerm, getPricingData func() *genericAwsPricingData, currency string) {
+	termCode := translateGenericAwsReservedTermAttributes(offer.TermAttributes)
+	effectiveHourly := effectiveReservedHourly(offer, termCode, currency)
+	if effectiveHourly <= 0 {
+		return
+	}
+	getPricingData().Reserved[termCode] = effectiveHourly
 }
 
 func clearHalfEmptyRegions(pricing map[string]*genericAwsPricingData, regionDescriptions map[string]string) map[string]string {


### PR DESCRIPTION
## Problem

Reserved (RI) pricing for ElastiCache was shown as **more expensive** than on demand, and Partial Upfront was displayed as cheaper than All Upfront, which is backwards. Reported in #909 for `cache.r7g.large` (Valkey, `ap-southeast-1`).

## Root cause

AWS exposes a Partial/All Upfront reserved offer as **two** price dimensions:
- a recurring hourly fee (`Unit: "Hrs"`)
- a one-time upfront fee (`Unit: "Quantity"`)

The shared reserved-offer processors (`processRDSAndElastiCacheReservedOffer` in `scraper/aws/rds.go`, used by ElastiCache and RDS; and `processGenericHalfReservedOffer` in `scraper/aws/utils.go`, used by OpenSearch and Redshift) iterated over the dimensions but **never summed them**. `rds.go` kept only the larger dimension (`max`), `utils.go` let the last one win, and both first divided the hourly fee by the lease hours as well. For Partial Upfront this dropped the recurring hourly fee entirely and produced an understated, inverted rate.

Verified against live AWS pricing for the reported instance (Valkey, `ap-southeast-1`, on demand `$0.2104/hr`):

| term | shown (buggy) | correct |
|------|--------------|---------|
| `yrTerm1Standard.partialUpfront` | 0.06838/hr | 0.13638/hr |
| `yrTerm3Standard.partialUpfront` | 0.05050/hr | 0.10090/hr |

The buggy `0.06838` exactly matches what production currently serves.

## Fix

Compute the effective hourly rate the way EC2 already does (`scraper/aws/ec2/reserved_pricing.go`): `hourlyFee + upfrontFee / hoursInTerm`. Extracted a shared `effectiveReservedHourly` helper so both processors use one correct implementation, with the lease length derived from the term-code prefix (`yrTerm1`/`yrTerm3`). This also fixes the identical bug on the OpenSearch and Redshift paths.

## Verification

- `cd scraper && go test ./...` -> all pass.
- Added `scraper/aws/reserved_pricing_test.go` with regression tests built from **real AWS pricing dimensions** for both the RDS/ElastiCache and OpenSearch/Redshift paths. They **fail on the old code** (`0.06838`, expecting `0.13638`) and **pass on the fix**.
- After the fix every reserved rate for the example instance is cheaper than on demand, and Partial Upfront sits correctly between No Upfront and All Upfront.

Closes #909

🤖 Generated with [Claude Code](https://claude.com/claude-code)
