### PR TITLE
fix(ec2): correct Mac dedicated host pricing parse

### DIFF
--- a/scraper/aws/ec2/dedicated_host_pricing.go
+++ b/scraper/aws/ec2/dedicated_host_pricing.go
@@ -13,6 +13,26 @@ import (
 	"sync"
 )
 
+// dedicatedHostInstanceTypeMatches reports whether an EC2 instance type
+// (e.g. "mac2-m1ultra.metal") corresponds to a Dedicated Host pricing SKU
+// (e.g. "mac2-m1ultra"). The match is on the family/base portion of the
+// instance type (the part before the first ".") compared for exact equality
+// with the SKU instance type.
+//
+// A plain strings.HasPrefix is incorrect here: many Dedicated Host SKU names
+// are prefixes of one another (e.g. "mac2" is a prefix of "mac2-m1ultra",
+// "mac-m4" of "mac-m4max", "m5" of "m5d"), so prefix matching lets the wrong
+// SKU's price overwrite an instance's price depending on Go map iteration
+// order, producing intermittently incorrect prices (issue #896, follow-up to
+// #893).
+func dedicatedHostInstanceTypeMatches(instanceType, sku string) bool {
+	base := instanceType
+	if i := strings.IndexByte(instanceType, '.'); i != -1 {
+		base = instanceType[:i]
+	}
+	return base == sku
+}
+
 type dedicatedHostOnDemandPrice struct {
 	InstanceType string `json:"Instance Type"`
 	Price        string `json:"price"`
@@ -203,7 +223,7 @@ func loadDedicatedHostReservedData(
 
 			instancesMu.Lock()
 			for instanceType, instance := range instances {
-				if strings.HasPrefix(instanceType, reservedPrice.InstanceType) {
+				if dedicatedHostInstanceTypeMatches(instanceType, reservedPrice.InstanceType) {
 					pricingData := instance.Pricing[regionSlug]
 					if pricingData == nil {
 						pricingData = make(map[OS]any)
@@ -255,7 +275,7 @@ func addDedicatedHostPricingUs(instances map[string]*EC2Instance, regionsInverte
 
 		for _, price := range instanceData {
 			for instanceType, instance := range instances {
-				if strings.HasPrefix(instanceType, price.InstanceType) {
+				if dedicatedHostInstanceTypeMatches(instanceType, price.InstanceType) {
 					addDedicatedHostOnDemandPrice(instance, region, price.Price)
 				}
 			}
@@ -310,7 +330,7 @@ func addDedicatedHostPricingCn(instances map[string]*EC2Instance, regionsInverte
 			for _, regionData := range dedicatedHostOnDemandData.Regions {
 				for _, price := range regionData {
 					for instanceType, instance := range instances {
-						if strings.HasPrefix(instanceType, price.InstanceType) {
+						if dedicatedHostInstanceTypeMatches(instanceType, price.InstanceType) {
 							addDedicatedHostOnDemandPrice(instance, regionSlug, price.Price)
 						}
 					}

--- a/scraper/aws/ec2/dedicated_host_pricing_test.go
+++ b/scraper/aws/ec2/dedicated_host_pricing_test.go
@@ -1,0 +1,102 @@
+package ec2
+
+import (
+	"scraper/aws/awsutils"
+	"testing"
+)
+
+// TestDedicatedHostInstanceTypeMatches guards against the prefix-matching bug
+// from issue #896 (follow-up to #893): Dedicated Host SKU names are frequently
+// prefixes of one another (e.g. "mac2" of "mac2-m1ultra", "mac-m4" of
+// "mac-m4max", "m5" of "m5d"), so a strings.HasPrefix-based match let the wrong
+// SKU's price overwrite an instance's price. Matching must be on the exact
+// family base (the part before the first ".") of the instance type.
+func TestDedicatedHostInstanceTypeMatches(t *testing.T) {
+	cases := []struct {
+		instanceType string
+		sku          string
+		want         bool
+	}{
+		// Exact family matches.
+		{"mac2.metal", "mac2", true},
+		{"mac2-m1ultra.metal", "mac2-m1ultra", true},
+		{"mac-m4max.metal", "mac-m4max", true},
+		{"m5d.metal", "m5d", true},
+
+		// The buggy prefix collisions that must NOT match.
+		{"mac2-m1ultra.metal", "mac2", false},
+		{"mac2-m2.metal", "mac2", false},
+		{"mac2-m2pro.metal", "mac2", false},
+		{"mac2-m2pro.metal", "mac2-m2", false},
+		{"mac-m4max.metal", "mac-m4", false},
+		{"mac-m4pro.metal", "mac-m4", false},
+		{"m5d.metal", "m5", false},
+		{"m5dn.metal", "m5d", false},
+
+		// A SKU must never match a longer instance family.
+		{"mac2.metal", "mac2-m1ultra", false},
+	}
+	for _, c := range cases {
+		if got := dedicatedHostInstanceTypeMatches(c.instanceType, c.sku); got != c.want {
+			t.Errorf("dedicatedHostInstanceTypeMatches(%q, %q) = %v, want %v",
+				c.instanceType, c.sku, got, c.want)
+		}
+	}
+}
+
+// TestDedicatedHostOnDemandAssignment replicates the real us-east-1 Mac
+// Dedicated Host on-demand assignment loop and asserts every Mac instance ends
+// up with its correct AWS price regardless of SKU iteration order. With the old
+// strings.HasPrefix match, the "mac2" SKU ($0.65) would overwrite
+// mac2-m1ultra.metal ($5.00), mac2-m2.metal ($0.878) and mac2-m2pro.metal
+// ($1.56), and the "mac-m4" SKU ($1.23) would overwrite mac-m4max.metal ($6.25)
+// and mac-m4pro.metal ($1.97), depending on Go map iteration order.
+func TestDedicatedHostOnDemandAssignment(t *testing.T) {
+	const region = "us-east-1"
+
+	// Authoritative us-east-1 prices from the AWS Dedicated Host on-demand
+	// pricing feed (dedicatedhost-ondemand.json).
+	skuPrices := map[string]string{
+		"mac1":         "1.083",
+		"mac2":         "0.65",
+		"mac2-m1ultra": "5.0",
+		"mac2-m2":      "0.878",
+		"mac2-m2pro":   "1.56",
+		"mac-m3ultra":  "12.5",
+		"mac-m4":       "1.23",
+		"mac-m4max":    "6.25",
+		"mac-m4pro":    "1.97",
+	}
+
+	// want maps each instance type to the formatted price it must receive.
+	want := map[string]string{}
+	instances := map[string]*EC2Instance{}
+	for sku, price := range skuPrices {
+		it := sku + ".metal"
+		instances[it] = &EC2Instance{
+			InstanceType: it,
+			Pricing:      make(map[Region]map[OS]any),
+		}
+		want[it] = formatPrice(awsutils.Floaty(price))
+	}
+
+	// Replicate the assignment loop from addDedicatedHostPricingUs. We assign
+	// every SKU to every matching instance, mirroring the scraper.
+	for sku, price := range skuPrices {
+		for instanceType, instance := range instances {
+			if dedicatedHostInstanceTypeMatches(instanceType, sku) {
+				addDedicatedHostOnDemandPrice(instance, region, price)
+			}
+		}
+	}
+
+	for it, instance := range instances {
+		dedicated, ok := instance.Pricing[region]["dedicated"].(*EC2PricingData)
+		if !ok {
+			t.Fatalf("%s: no dedicated pricing assigned", it)
+		}
+		if dedicated.OnDemand != want[it] {
+			t.Errorf("%s: on-demand price = %s, want %s", it, dedicated.OnDemand, want[it])
+		}
+	}
+}


### PR DESCRIPTION
## Root cause

Mac Dedicated Host prices were still wrong for several types in us-east-1 (follow-up to #893). The scraper matched a Dedicated Host pricing SKU to an EC2 instance with `strings.HasPrefix(instanceType, sku)` in `scraper/aws/ec2/dedicated_host_pricing.go`.

The problem: many Dedicated Host SKU names are prefixes of one another, so an instance matched several SKUs and the value actually stored was whichever SKU was iterated **last** in the randomly-ordered Go map. The collisions for Mac are:

- `mac2` is a prefix of `mac2-m1ultra`, `mac2-m2`, `mac2-m2pro`
- `mac2-m2` is a prefix of `mac2-m2pro`
- `mac-m4` is a prefix of `mac-m4max`, `mac-m4pro`

(the same class of bug also affects non-Mac families like `m5`/`m5d`, `c5`/`c5n`, etc.)

So depending on map iteration order, us-east-1 prices came out intermittently wrong, e.g.:

| Instance | Correct (AWS) | Buggy value it could get |
|---|---|---|
| `mac2-m1ultra.metal` | $5.00 | $0.65 (from `mac2`) |
| `mac2-m2.metal` | $0.878 | $0.65 (from `mac2`) |
| `mac2-m2pro.metal` | $1.56 | $0.65 / $0.878 |
| `mac-m4max.metal` | $6.25 | $1.23 (from `mac-m4`) |
| `mac-m4pro.metal` | $1.97 | $1.23 (from `mac-m4`) |

Prices verified against the AWS `dedicatedhost-ondemand.json` feed (the same source the scraper consumes), us-east-1 (`US East (N. Virginia)`).

## Fix

Replace the prefix check with `dedicatedHostInstanceTypeMatches`, which compares the instance family base (the part before the first `.`, e.g. `mac2-m1ultra` from `mac2-m1ultra.metal`) for **exact equality** with the SKU instance type. `HasPrefix` was needed only to strip the `.metal`/size suffix; exact-base matching keeps that while eliminating the cross-SKU collisions. Applied at all three match sites: on-demand US, on-demand China, and reserved.

No prices are invented; the SKU set is whatever AWS returns, and newer Mac types (M3 Ultra, M4/M4 Pro/M4 Max) are already present in the feed and now map correctly.

## Verification

```
cd scraper
go build ./...   # Success
go vet ./...     # No issues found
go test ./...    # ok
gofmt -l         # clean
```

Regression tests added in `scraper/aws/ec2/dedicated_host_pricing_test.go`:

- `TestDedicatedHostInstanceTypeMatches` - asserts the prefix collisions do NOT match.
- `TestDedicatedHostOnDemandAssignment` - replays the real us-east-1 Mac on-demand assignment loop and asserts every instance ends up with its correct AWS price regardless of SKU iteration order.

Both **fail on the pre-fix `HasPrefix` behaviour** (e.g. `mac2-m1ultra.metal: on-demand price = 0.65, want 5`; `mac-m4pro.metal: on-demand price = 1.23, want 1.97`) and **pass after the fix**.

Closes #896
Refs #893
