### PR TITLE
feat(azure): add core count column

### DIFF
--- a/next/utils/colunnData/azure.tsx
+++ b/next/utils/colunnData/azure.tsx
@@ -63,6 +63,7 @@ const initialColumnsArr = [
     ["instance_type", true],
     ["memory", true],
     ["vcpu", true],
+    ["cores", false],
     ["memory_per_vcpu", false],
     ["GPU", false],
     ["size", true],
@@ -98,6 +99,7 @@ export function makePrettyNames<V>(
         makeColumnOption("instance_type", "API Name"),
         makeColumnOption("memory", "Instance Memory"),
         makeColumnOption("vcpu", "vCPUs"),
+        makeColumnOption("cores", "Cores"),
         makeColumnOption("memory_per_vcpu", "Memory per vCPU"),
         makeColumnOption("GPU", "GPUs"),
         makeColumnOption("size", "Storage"),
@@ -312,6 +314,42 @@ export const columnsGen = (
             id: "vcpu",
             sortingFn: "alphanumeric",
             filterFn: expr,
+        },
+        {
+            // Azure does not expose a physical core count directly, so derive
+            // it from vcpu / vcpus_percore. vcpus_percore is only populated for
+            // a subset of SKUs (and is 0/absent for the rest); when it is
+            // missing or zero we render empty rather than a misleading value.
+            id: "cores",
+            header: "Cores",
+            size: 110,
+            accessorFn: (row) => {
+                const vcpu = row.vcpu;
+                const perCore = row.vcpus_percore;
+                if (!perCore || perCore <= 0 || !vcpu) return undefined;
+                return vcpu / perCore;
+            },
+            sortingFn: (rowA, rowB) => {
+                const valueA = rowA.getValue("cores") as number | undefined;
+                const valueB = rowB.getValue("cores") as number | undefined;
+                if (valueA === null || valueA === undefined) return -1;
+                if (valueB === null || valueB === undefined) return 1;
+                return valueA - valueB;
+            },
+            filterFn: (row, _, filterValue) => {
+                const cores = row.getValue("cores") as number | undefined;
+                if (cores === null || cores === undefined) return false;
+                try {
+                    return exprCompiler(filterValue)(cores, `${cores} cores`);
+                } catch {
+                    return true;
+                }
+            },
+            cell: (info) => {
+                const value = info.getValue() as number | undefined;
+                if (value === null || value === undefined) return undefined;
+                return `${value} cores`;
+            },
         },
         {
             accessorKey: "memory",


### PR DESCRIPTION
## What

Adds a default-off **Cores** column to the **Azure** VM instance table, extending the EC2 core-count work (#906, implemented in #913) to Azure for parity.

## Per-provider detail

### Azure (implemented)
- New **Cores** column in `next/utils/colunnData/azure.tsx`: nullable, sortable, filterable, **default-off** visibility, registered in the visibility config (`initialColumnsArr`) and the column-picker (`makePrettyNames`), mirroring the EC2 pattern from #913.
- **Data source / derivation**: Azure's scraper does not emit an explicit physical core count, but it does scrape `vcpu` and `vcpus_percore` (from the Azure `vCPUsPerCore` SKU capability, see `scraper/azure/specs_file.go`), both already present on the `AzureInstance` type. Cores are derived as `vcpu / vcpus_percore`.
- **Honest provenance / fail-loud**: `vcpus_percore` is only populated for a subset of SKUs (~525 of ~994 in the sample data). When it is missing or `0`, the column renders **empty** rather than a misleading `0` or a fabricated value. Implemented via an `accessorFn` that returns `undefined` when `vcpus_percore <= 0` or `vcpu` is falsy, with the filter excluding empty rows. No type change was needed because `vcpus_percore` already exists on the type.
- Example: a VM with 8 vCPU and `vcpus_percore = 2` shows **4 cores**; an older A-series VM with `vcpus_percore = 1` shows its full vCPU count as cores.

### GCP (intentionally skipped)
The GCP Compute Engine `machineTypes` API (`scraper/gcp/api.go`) only exposes `guestCpus` (vCPUs) and `isSharedCpu`. There is **no physical core count and no threads-per-core** field, and the per-instance SMT factor varies by family (Tau T2D/T2A and some Arm families are 1 thread/core, shared-core e2-micro/small/medium differ, most others are SMT-2). Deriving cores would require **fabricating SMT assumptions**, so per the "real data or sound derivation, never guesses" principle, GCP is omitted. (The "core" references in the GCP scraper are per-core SKU *pricing*, not physical core counts.)

## Verification
- `npm run check-types`: **zero new type errors**. The repo has 8 pre-existing errors from missing build-generated JSON artifacts (`@/public/*.json`, `../../www/*.json`); confirmed the error set is byte-identical with this change stashed. None reference the changed file.
- `npm run test` (Vitest): **241 passed, 0 failed**.
- Logic verified end-to-end against the Azure mock dataset: 8 vCPU / 2 per-core -> 4 cores; `vcpus_percore = 0` or absent -> empty.
- `prettier --check` clean on the changed file.

Extends #906 / #913 to Azure for parity.
