### PR TITLE
fix(gcp): populate GPU memory for accelerator instances

### DIFF
--- a/scraper/gcp/api.go
+++ b/scraper/gcp/api.go
@@ -171,6 +171,10 @@ var gpuMemoryByModel = map[string]int{
 	"nvidia-l4":             24,  // G2
 }
 
+func totalGPUMemory(gpuCount int, gpuModel string) int {
+	return gpuCount * gpuMemoryByModel[gpuModel]
+}
+
 // Fetch all SKUs for Compute Engine with pagination
 func fetchComputeSKUs() ([]SKU, error) {
 	var allSKUs []SKU
@@ -486,8 +490,12 @@ func fetchMachineTypes() (map[string]*MachineSpecs, error) {
 						specs.GPUModel = mt.Accelerators[0].GuestAcceleratorType
 						// Per-GPU memory is not exposed by the Compute Engine
 						// machineTypes API, so derive it from the model string
-						// using the documented per-GPU memory map.
-						specs.GPUMemory = gpuMemoryByModel[specs.GPUModel]
+						// using the documented per-GPU memory map. GPU_memory
+						// is total memory across all attached GPUs.
+						specs.GPUMemory = totalGPUMemory(
+							specs.GPU,
+							specs.GPUModel,
+						)
 					}
 
 					machineSpecs[mt.Name] = specs

--- a/scraper/gcp/api.go
+++ b/scraper/gcp/api.go
@@ -152,7 +152,23 @@ type MachineSpecs struct {
 	IsSharedCPU bool
 	GPU         int
 	GPUModel    string
+	GPUMemory   int
 	Zones       []string
+}
+
+// gpuMemoryByModel maps a GCP guestAcceleratorType (the model string the
+// Compute Engine API returns, e.g. "nvidia-h100-80gb") to the per-GPU memory
+// in GiB. Values are sourced from the official Google Cloud GPU documentation
+// (https://cloud.google.com/compute/docs/gpus and
+// https://cloud.google.com/compute/docs/accelerator-optimized-machines).
+// Unknown models return 0 so the field is omitted rather than fabricated.
+var gpuMemoryByModel = map[string]int{
+	"nvidia-h200-141gb":     141, // A3 Ultra
+	"nvidia-h100-80gb":      80,  // A3 High/Edge
+	"nvidia-h100-mega-80gb": 80,  // A3 Mega
+	"nvidia-a100-80gb":      80,  // A2 Ultra
+	"nvidia-tesla-a100":     40,  // A2 Standard (A100 40GB)
+	"nvidia-l4":             24,  // G2
 }
 
 // Fetch all SKUs for Compute Engine with pagination
@@ -468,6 +484,10 @@ func fetchMachineTypes() (map[string]*MachineSpecs, error) {
 					if len(mt.Accelerators) > 0 {
 						specs.GPU = mt.Accelerators[0].GuestAcceleratorCount
 						specs.GPUModel = mt.Accelerators[0].GuestAcceleratorType
+						// Per-GPU memory is not exposed by the Compute Engine
+						// machineTypes API, so derive it from the model string
+						// using the documented per-GPU memory map.
+						specs.GPUMemory = gpuMemoryByModel[specs.GPUModel]
 					}
 
 					machineSpecs[mt.Name] = specs

--- a/scraper/gcp/api_test.go
+++ b/scraper/gcp/api_test.go
@@ -27,3 +27,46 @@ func TestGPUMemoryByModel(t *testing.T) {
 		t.Errorf("unknown model memory = %d, want 0", got)
 	}
 }
+
+func TestTotalGPUMemory(t *testing.T) {
+	cases := []struct {
+		name     string
+		count    int
+		model    string
+		expected int
+	}{
+		{
+			name:     "single A100 40GB",
+			count:    1,
+			model:    "nvidia-tesla-a100",
+			expected: 40,
+		},
+		{
+			name:     "eight A100 40GB GPUs",
+			count:    8,
+			model:    "nvidia-tesla-a100",
+			expected: 320,
+		},
+		{
+			name:     "eight H200 141GB GPUs",
+			count:    8,
+			model:    "nvidia-h200-141gb",
+			expected: 1128,
+		},
+		{
+			name:     "unknown future model",
+			count:    8,
+			model:    "nvidia-unknown-future",
+			expected: 0,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := totalGPUMemory(c.count, c.model)
+			if got != c.expected {
+				t.Errorf("totalGPUMemory(%d, %q) = %d, want %d", c.count, c.model, got, c.expected)
+			}
+		})
+	}
+}

--- a/scraper/gcp/api_test.go
+++ b/scraper/gcp/api_test.go
@@ -1,0 +1,29 @@
+package gcp
+
+import "testing"
+
+// TestGPUMemoryByModel verifies that every GPU model string the Compute Engine
+// API currently returns as a guestAcceleratorType maps to the correct per-GPU
+// memory (GiB) from the official Google Cloud GPU documentation. Without this
+// map the GPU_memory column was empty for every GCP GPU instance.
+func TestGPUMemoryByModel(t *testing.T) {
+	cases := map[string]int{
+		"nvidia-h200-141gb":     141,
+		"nvidia-h100-80gb":      80,
+		"nvidia-h100-mega-80gb": 80,
+		"nvidia-a100-80gb":      80,
+		"nvidia-tesla-a100":     40,
+		"nvidia-l4":             24,
+	}
+	for model, want := range cases {
+		if got := gpuMemoryByModel[model]; got != want {
+			t.Errorf("gpuMemoryByModel[%q] = %d, want %d", model, got, want)
+		}
+	}
+
+	// Unknown models must return the zero value so the field is omitted rather
+	// than fabricated.
+	if got := gpuMemoryByModel["nvidia-unknown-future"]; got != 0 {
+		t.Errorf("unknown model memory = %d, want 0", got)
+	}
+}

--- a/scraper/gcp/scrape.go
+++ b/scraper/gcp/scrape.go
@@ -298,6 +298,7 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 			Generation:         "current",
 			GPU:                float64(specs.GPU),
 			GPUModel:           gpuModel,
+			GPUMemory:          specs.GPUMemory,
 			Pricing:            make(map[Region]map[OS]any),
 			Regions:            make(map[string]string),
 			AvailabilityZones:  make(map[string][]string),


### PR DESCRIPTION
## Summary

Audited Azure and GCP GPU instance data for the same class of gap that hit EC2 in #907/#910 (a whole GPU family silently missing from the GPU map). Found one genuine GCP gap and fixed it.

### The gap (GCP)

The GCP scraper reads GPU **count** and **model** from the Compute Engine `machineTypes` aggregated-list API (`guestAcceleratorType` / `guestAcceleratorCount`), and those are correct for every current GPU family (A2/A3/G2, including A100, H100, H100 Mega, H200, L4). But the `GPU_memory` field, which exists in the `GCPInstance` struct, the frontend type, and the instance detail page (`gcpTablesGenerator.ts` renders "GPU Memory (GiB)"), was **never populated**. Every GCP GPU instance therefore reported **0 GiB** of GPU memory.

The Compute Engine API does not expose per-GPU memory, so this fix derives it from the `guestAcceleratorType` model string via a documented lookup map.

### Values added (per-GPU memory, GiB) — all from official Google Cloud docs

| Model string | Memory | Family | Source |
|---|---|---|---|
| `nvidia-h200-141gb` | 141 | A3 Ultra | [GPU machine types](https://cloud.google.com/compute/docs/gpus), [accelerator-optimized machines](https://cloud.google.com/compute/docs/accelerator-optimized-machines) |
| `nvidia-h100-80gb` | 80 | A3 High/Edge | same |
| `nvidia-h100-mega-80gb` | 80 | A3 Mega | same |
| `nvidia-a100-80gb` | 80 | A2 Ultra | same |
| `nvidia-tesla-a100` | 40 | A2 Standard (A100 40GB) | [A2 family announcement](https://cloud.google.com/blog/products/compute/announcing-google-cloud-a2-vm-family-based-on-nvidia-a100-gpu) |
| `nvidia-l4` | 24 | G2 | [Introducing G2 VMs with L4](https://cloud.google.com/blog/products/compute/introducing-g2-vms-with-nvidia-l4-gpus) |

Unknown/future models map to 0 so the field is omitted rather than fabricated (fail-safe, no invented values).

### Azure: no gap found

Azure stores GPU info as a single free-text string straight from the Azure pricing API (e.g. `"1X H100"`, `"8x H200"`, `"1/2 MI25 (8GB VRAM)"`), embedding count + model together; there is no separate `GPU_model` / `GPU_memory` field by design. All 21 current GPU VM families (NC K80/P100/V100/T4/A10/A100/H100, NCC H100, RTX 6000 v6, ND A100/H100/H200/V100, NV M60/A10/V710, NVv4 MI25, NG V620) carry a populated GPU string in the live data; none report empty/zero. No data gap, so no Azure change.

## Verification

```
$ go build ./...   -> Success
$ go vet ./...     -> No issues found
$ go test ./...    -> 1 passed (gcp), all packages OK
$ gofmt -l ...     -> clean
```

Added `scraper/gcp/api_test.go` asserting each current model string maps to the documented memory and that unknown models return 0.

Analogous to the EC2 G7 GPU gap (#907 / #910), where GPU metadata for a whole accelerator family was silently absent from the data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
