### PR TITLE
feat(gcp): add committed use discount pricing

### DIFF
--- a/next/utils/colunnData/gcp.tsx
+++ b/next/utils/colunnData/gcp.tsx
@@ -15,6 +15,11 @@ export interface GCPPricing {
         [platform: string]: {
             ondemand: number;
             spot?: number;
+            // Resource-based committed use discount (CUD) hourly prices, sourced
+            // from the catalog's committed-use SKUs. Present only on the linux
+            // platform and only when the machine family/region has a CUD SKU.
+            cud_1yr?: number;
+            cud_3yr?: number;
         };
     };
 }
@@ -51,6 +56,8 @@ const initialColumnsArr = [
     ["local_ssd", false],
     ["shared_cpu", false],
     ["linux-ondemand", true],
+    ["linux-1yr-cud", true],
+    ["linux-3yr-cud", true],
     ["linux-spot", true],
     ["windows-ondemand", true],
     ["windows-spot", true],
@@ -85,6 +92,8 @@ export function makePrettyNames<V>(
         makeColumnOption("local_ssd", "Local SSD"),
         makeColumnOption("shared_cpu", "Shared CPU"),
         makeColumnOption("linux-ondemand", "Linux On-Demand"),
+        makeColumnOption("linux-1yr-cud", "Linux 1-Year CUD"),
+        makeColumnOption("linux-3yr-cud", "Linux 3-Year CUD"),
         makeColumnOption("linux-spot", "Linux Spot"),
         makeColumnOption("windows-ondemand", "Windows On-Demand"),
         makeColumnOption("windows-spot", "Windows Spot"),
@@ -379,6 +388,30 @@ export const columnsGen = (
                 pricingUnit,
                 costDuration,
                 (pricing) => pricing?.linux?.ondemand,
+                currency,
+            ),
+        },
+        {
+            accessorKey: "pricing",
+            header: "Linux 1-Year CUD cost",
+            id: "linux-1yr-cud",
+            ...getPricingSorter(
+                selectedRegion,
+                pricingUnit,
+                costDuration,
+                (pricing) => pricing?.linux?.cud_1yr,
+                currency,
+            ),
+        },
+        {
+            accessorKey: "pricing",
+            header: "Linux 3-Year CUD cost",
+            id: "linux-3yr-cud",
+            ...getPricingSorter(
+                selectedRegion,
+                pricingUnit,
+                costDuration,
+                (pricing) => pricing?.linux?.cud_3yr,
                 currency,
             ),
         },

--- a/scraper/gcp/api.go
+++ b/scraper/gcp/api.go
@@ -545,6 +545,57 @@ func determineMachineFamily(name string) string {
 // "Licensing Fee for Windows Server 2012 BYOL (RAM cost)"
 var machineTypeRegex = regexp.MustCompile(`(?i)(n1|n2d|n2|n4d|n4|e2|e2a|c2|c2d|m1|m2|m3|m4|t2d|t2a|a2|a3|g2|h3|c3|c3d|z3|c4)\b.*(?:instance\s+(core|ram)|\((?:cpu|ram)\s+cost\))`)
 
+// Resource-based committed use discount (CUD) SKUs use a distinct display-name
+// format from on-demand instance SKUs, e.g.:
+//
+//	"Commitment v1: N2 Cpu in Americas for 1 Year"
+//	"Commitment v1: C2D AMD Ram in EMEA for 3 Year"
+//
+// The family token may carry a vendor qualifier ("AMD") before the resource
+// keyword; the term is "1 Year" or "3 Year". An optional skip group consumes
+// such qualifiers so the resource keyword (Cpu/Ram) is captured directly.
+var cudSKURegex = regexp.MustCompile(`(?i)^commitment\s+v\d+:\s+(n1|n2d|n2|n4d|n4|e2|e2a|c2|c2d|m1|m2|m3|m4|t2d|t2a|a2|a3|g2|h3|c3|c3d|z3|c4)\s+(?:[a-z0-9]+\s+)*?(cpu|ram)\s+in\s+.+\s+for\s+(1|3)\s+year`)
+
+// CUD commitment terms used as keys in the CUD pricing buckets.
+const (
+	cudTerm1Yr = "1yr"
+	cudTerm3Yr = "3yr"
+)
+
+// parseCUDSKU parses a resource-based committed use discount SKU. It returns the
+// machine family (uppercased, e.g. "N2"), resource type ("core" or "ram"), the
+// commitment term ("1yr" or "3yr"), and whether the SKU is a CUD SKU at all.
+// Region resolution is left to the shared geo-taxonomy machinery (the same path
+// on-demand SKUs use), so the region groupings in the display name are ignored.
+func parseCUDSKU(sku SKU) (machineFamily string, resourceType string, term string, ok bool) {
+	matches := cudSKURegex.FindStringSubmatch(sku.DisplayName)
+	if len(matches) < 4 {
+		return "", "", "", false
+	}
+
+	machineFamily = strings.ToUpper(matches[1])
+
+	switch strings.ToLower(matches[2]) {
+	case "cpu":
+		resourceType = "core"
+	case "ram":
+		resourceType = "ram"
+	default:
+		return "", "", "", false
+	}
+
+	switch matches[3] {
+	case "1":
+		term = cudTerm1Yr
+	case "3":
+		term = cudTerm3Yr
+	default:
+		return "", "", "", false
+	}
+
+	return machineFamily, resourceType, term, true
+}
+
 func parseMachineTypeFromSKU(sku SKU) (machineFamily string, resourceType string, region string, isSpot bool, isWindows bool) {
 	displayName := sku.DisplayName
 

--- a/scraper/gcp/cud_test.go
+++ b/scraper/gcp/cud_test.go
@@ -1,0 +1,172 @@
+package gcp
+
+import (
+	"strconv"
+	"testing"
+)
+
+// usdRate builds a USD per-hour rate PriceInfo for a single tier-0 list price.
+func usdRate(unit string, dollars float64) PriceInfo {
+	units := int64(dollars)
+	nanos := int64((dollars - float64(units)) * 1e9)
+	return PriceInfo{
+		CurrencyCode: "USD",
+		ValueType:    "rate",
+		Rate: Rate{
+			Tiers: []Tier{
+				{
+					StartAmount: Money{},
+					ListPrice:   Money{Units: strconv.FormatInt(units, 10), Nanos: nanos},
+				},
+			},
+			Unit: UnitInfo{Unit: unit},
+		},
+	}
+}
+
+func cudSKU(id, displayName string, regions []string) SKU {
+	return SKU{
+		SkuId:       id,
+		DisplayName: displayName,
+		GeoTaxonomy: GeoTaxonomy{Regions: regions},
+	}
+}
+
+func onDemandSKU(id, displayName string, regions []string) SKU {
+	return SKU{
+		SkuId:       id,
+		DisplayName: displayName,
+		GeoTaxonomy: GeoTaxonomy{Regions: regions},
+	}
+}
+
+func TestParseCUDSKU(t *testing.T) {
+	cases := []struct {
+		display      string
+		wantFamily   string
+		wantResource string
+		wantTerm     string
+		wantOK       bool
+	}{
+		{"Commitment v1: N2 Cpu in Americas for 1 Year", "N2", "core", cudTerm1Yr, true},
+		{"Commitment v1: N2 Ram in Americas for 3 Year", "N2", "ram", cudTerm3Yr, true},
+		{"Commitment v1: C2D AMD Cpu in EMEA for 1 Year", "C2D", "core", cudTerm1Yr, true},
+		{"Commitment v1: C2D AMD Ram in EMEA for 3 Year", "C2D", "ram", cudTerm3Yr, true},
+		// On-demand and spot SKUs must NOT be treated as CUD.
+		{"N2 Instance Core running in Americas", "", "", "", false},
+		{"Spot Preemptible N2 Instance Ram running in Paris", "", "", "", false},
+		// Spend-based / flexible CUDs are not resource-based and must be ignored.
+		{"Commitment - dollar based v1: GCE for 1 year", "", "", "", false},
+	}
+
+	for _, tc := range cases {
+		family, resource, term, ok := parseCUDSKU(SKU{DisplayName: tc.display})
+		if ok != tc.wantOK {
+			t.Errorf("%q: ok=%v want %v", tc.display, ok, tc.wantOK)
+			continue
+		}
+		if !tc.wantOK {
+			continue
+		}
+		if family != tc.wantFamily || resource != tc.wantResource || term != tc.wantTerm {
+			t.Errorf("%q: got (%s,%s,%s) want (%s,%s,%s)",
+				tc.display, family, resource, term,
+				tc.wantFamily, tc.wantResource, tc.wantTerm)
+		}
+	}
+}
+
+// TestProcessGCPDataCUDPricing verifies the end-to-end CUD assembly:
+// per-instance 1yr/3yr CUD = core_rate*vCPU + ram_rate*RAM, sourced from the
+// committed-use SKUs the scraper previously discarded. It also asserts CUD
+// rates never leak into on-demand pricing.
+func TestProcessGCPDataCUDPricing(t *testing.T) {
+	const region = "us-central1"
+
+	// On-demand rates (so the instance has a baseline price in the region).
+	odCore := 0.031611
+	odRam := 0.004237
+
+	// Committed-use 1yr and 3yr per-core / per-RAM-GB rates.
+	cud1Core := 0.019915
+	cud1Ram := 0.002669
+	cud3Core := 0.014225
+	cud3Ram := 0.001907
+
+	skus := []SKU{
+		onDemandSKU("od-core", "N2 Instance Core running in Iowa", []string{region}),
+		onDemandSKU("od-ram", "N2 Instance Ram running in Iowa", []string{region}),
+		cudSKU("cud1-core", "Commitment v1: N2 Cpu in Americas for 1 Year", []string{region}),
+		cudSKU("cud1-ram", "Commitment v1: N2 Ram in Americas for 1 Year", []string{region}),
+		cudSKU("cud3-core", "Commitment v1: N2 Cpu in Americas for 3 Year", []string{region}),
+		cudSKU("cud3-ram", "Commitment v1: N2 Ram in Americas for 3 Year", []string{region}),
+	}
+
+	pricing := map[string]PriceInfo{
+		"od-core":   usdRate("h", odCore),
+		"od-ram":    usdRate("giby.h", odRam),
+		"cud1-core": usdRate("h", cud1Core),
+		"cud1-ram":  usdRate("giby.h", cud1Ram),
+		"cud3-core": usdRate("h", cud3Core),
+		"cud3-ram":  usdRate("giby.h", cud3Ram),
+	}
+
+	const vcpu = 8
+	const memGB = 32.0
+	machineSpecs := map[string]*MachineSpecs{
+		"n2-standard-8": {
+			VCPU:     vcpu,
+			MemoryGB: memGB,
+			Family:   "General purpose",
+		},
+	}
+
+	regions := map[string]string{region: "Iowa"}
+
+	instances := processGCPData(skus, pricing, machineSpecs, regions)
+
+	inst, ok := instances["n2-standard-8"]
+	if !ok {
+		t.Fatalf("expected n2-standard-8 instance to be built")
+	}
+
+	regionPricing, ok := inst.Pricing[region]
+	if !ok {
+		t.Fatalf("expected pricing for region %s", region)
+	}
+	linux, ok := regionPricing["linux"].(*GCPPricingData)
+	if !ok {
+		t.Fatalf("expected linux pricing data")
+	}
+
+	wantOnDemand := float64(vcpu)*odCore + memGB*odRam
+	want1Yr := float64(vcpu)*cud1Core + memGB*cud1Ram
+	want3Yr := float64(vcpu)*cud3Core + memGB*cud3Ram
+
+	assertPrice(t, "ondemand", linux.OnDemand, wantOnDemand)
+	assertPrice(t, "cud_1yr", linux.CUD1Yr, want1Yr)
+	assertPrice(t, "cud_3yr", linux.CUD3Yr, want3Yr)
+
+	// CUD rates must be a real discount below on-demand and must not have
+	// leaked into the on-demand field.
+	if want1Yr >= wantOnDemand || want3Yr >= want1Yr {
+		t.Errorf("expected 3yr < 1yr < ondemand, got ondemand=%f 1yr=%f 3yr=%f",
+			wantOnDemand, want1Yr, want3Yr)
+	}
+}
+
+func assertPrice(t *testing.T, label, got string, want float64) {
+	t.Helper()
+	if got == "" {
+		t.Errorf("%s: empty, want %s", label, formatPrice(want))
+		return
+	}
+	gotF, err := strconv.ParseFloat(got, 64)
+	if err != nil {
+		t.Errorf("%s: parse %q: %v", label, got, err)
+		return
+	}
+	if diff := gotF - want; diff > 1e-6 || diff < -1e-6 {
+		t.Errorf("%s: got %f want %f", label, gotF, want)
+	}
+}

--- a/scraper/gcp/gcp_instance.go
+++ b/scraper/gcp/gcp_instance.go
@@ -32,6 +32,11 @@ func (p *Price) UnmarshalJSON(data []byte) error {
 type GCPPricingData struct {
 	OnDemand string `json:"ondemand,omitempty"`
 	Spot     string `json:"spot,omitempty"`
+	// Resource-based committed use discount (CUD) hourly prices, assembled from
+	// the catalog's committed-use Cpu/Ram SKUs (core_rate*vCPU + ram_rate*RAM).
+	// Empty when the instance's machine family/region has no committed-use SKU.
+	CUD1Yr string `json:"cud_1yr,omitempty"`
+	CUD3Yr string `json:"cud_3yr,omitempty"`
 }
 
 // GCPInstance represents a GCP Compute Engine instance type in AWS instance format

--- a/scraper/gcp/scrape.go
+++ b/scraper/gcp/scrape.go
@@ -82,6 +82,33 @@ func targetRegionsForSKU(sku SKU, fallbackRegion string) []string {
 	return []string{fallbackRegion}
 }
 
+// cudTargetRegions resolves the region codes a committed use discount SKU
+// applies to. Resource-based CUD SKUs carry explicit region codes in their geo
+// taxonomy in most cases; for multi-regional commitment SKUs the geo taxonomy
+// has no region list, so the broad grouping is taken from the display name
+// ("Americas" / "EMEA" / "APAC"), mapped to the same multi-region identifiers
+// on-demand pricing uses. EMEA/APAC differ from the on-demand wording
+// (europe/asia), so this is resolved here rather than via parseMachineTypeFromSKU.
+func cudTargetRegions(sku SKU) []string {
+	if len(sku.GeoTaxonomy.Regions) > 0 {
+		return sku.GeoTaxonomy.Regions
+	}
+	if sku.GeoTaxonomy.RegionalMetadata != nil && sku.GeoTaxonomy.RegionalMetadata.Region.Region != "" {
+		return []string{sku.GeoTaxonomy.RegionalMetadata.Region.Region}
+	}
+
+	displayLower := strings.ToLower(sku.DisplayName)
+	switch {
+	case strings.Contains(displayLower, "americas"):
+		return []string{"multi-americas"}
+	case strings.Contains(displayLower, "emea"), strings.Contains(displayLower, "europe"):
+		return []string{"multi-europe"}
+	case strings.Contains(displayLower, "apac"), strings.Contains(displayLower, "asia"):
+		return []string{"multi-asia"}
+	}
+	return nil
+}
+
 func expandedRegionsForMultiRegion(region string) []string {
 	switch region {
 	case "multi-americas":
@@ -141,6 +168,17 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 
 	skuData := make(map[skuKey][]PriceInfo)
 
+	// Resource-based committed use discount (CUD) pricing, kept entirely separate
+	// from on-demand/spot so commitment rates never bleed into baseline pricing.
+	type cudKey struct {
+		machineType  string
+		region       string
+		term         string // cudTerm1Yr or cudTerm3Yr
+		resourceType string // "core" or "ram"
+	}
+	cudData := make(map[cudKey][]PriceInfo)
+	cudSKUCount := 0
+
 	// Store Windows license fees separately (they're global, not region-specific)
 	type windowsLicenseType struct {
 		resourceType string // "core" or "ram"
@@ -187,6 +225,46 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 				}
 			}
 			continue // Don't process as instance SKU
+		}
+
+		// Capture resource-based committed use discount (CUD) SKUs into a
+		// dedicated bucket. These use the "Commitment v1: <family> Cpu/Ram in
+		// <region> for <1|3> Year" naming and are intentionally never mixed into
+		// on-demand/spot pricing. Done before the on-demand "instance" gate
+		// (their display name has no "instance" token) and before the
+		// commitment/discount taxonomy filter that drops them.
+		if strings.Contains(displayLower, "commitment v") {
+			cudFamily, cudResource, cudCommitTerm, isCUD := parseCUDSKU(sku)
+			if !isCUD {
+				continue
+			}
+
+			price, hasPricing := pricing[sku.SkuId]
+			if !hasPricing {
+				continue
+			}
+			cudSKUCount++
+
+			for _, targetRegion := range cudTargetRegions(sku) {
+				key := cudKey{
+					machineType:  cudFamily,
+					region:       targetRegion,
+					term:         cudCommitTerm,
+					resourceType: cudResource,
+				}
+				cudData[key] = append(cudData[key], price)
+
+				for _, expandedRegion := range expandedRegionsForMultiRegion(targetRegion) {
+					expandedKey := cudKey{
+						machineType:  cudFamily,
+						region:       expandedRegion,
+						term:         cudCommitTerm,
+						resourceType: cudResource,
+					}
+					cudData[expandedKey] = append(cudData[expandedKey], price)
+				}
+			}
+			continue
 		}
 
 		// Process both instance SKUs and Windows licensing SKUs
@@ -272,11 +350,12 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 	}
 
 	log.Printf(
-		"GCP SKU filtering: parsed=%d priced=%d skippedByTaxonomy=%d duplicateCandidateKeys=%d",
+		"GCP SKU filtering: parsed=%d priced=%d skippedByTaxonomy=%d duplicateCandidateKeys=%d cudSKUs=%d",
 		parsedSKUCount,
 		pricedSKUCount,
 		skippedByTaxonomyCount,
 		duplicatePriceKeys,
+		cudSKUCount,
 	)
 
 	// Build instances from machine specs
@@ -398,6 +477,78 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 			} else {
 				// Fallback to friendly name lookup for regions not in compute API
 				instance.Regions[rk.region] = getRegionFriendlyName(rk.region)
+			}
+		}
+
+		// Assemble resource-based committed use discount (CUD) pricing the same
+		// way on-demand is built: per-region, per-term, total =
+		// core_rate*vCPU + ram_rate*RAM. CUDs apply to the Linux compute price
+		// (no OS license), so they attach to the Linux pricing data.
+		type cudRegionKey struct {
+			region string
+			term   string
+		}
+		cudRegionPricing := make(map[cudRegionKey]struct {
+			corePrice float64
+			ramPrice  float64
+			hasCores  bool
+			hasRAM    bool
+		})
+
+		for key, candidates := range cudData {
+			if key.machineType != machineFamily {
+				continue
+			}
+
+			// CUD list prices are baseline rates; use the standard list-price
+			// selection (same as on-demand, not the spot-style minimum).
+			hourlyPrice, hasPrice := selectHourlyPrice(candidates, false)
+			if !hasPrice {
+				continue
+			}
+
+			crk := cudRegionKey{region: key.region, term: key.term}
+			p := cudRegionPricing[crk]
+			switch key.resourceType {
+			case "core":
+				p.corePrice = hourlyPrice
+				p.hasCores = true
+			case "ram":
+				p.ramPrice = hourlyPrice
+				p.hasRAM = true
+			}
+			cudRegionPricing[crk] = p
+		}
+
+		for crk, p := range cudRegionPricing {
+			// Both core and RAM rates are required to assemble a price.
+			if !p.hasCores || !p.hasRAM {
+				continue
+			}
+
+			totalCUD := (float64(specs.VCPU) * p.corePrice) + (specs.MemoryGB * p.ramPrice)
+			if totalCUD == 0 {
+				continue
+			}
+
+			// Only attach CUD to regions that already have Linux on-demand
+			// pricing; an instance with no baseline price in a region should not
+			// surface a lone commitment rate.
+			regionPricingMap, hasRegion := instance.Pricing[crk.region]
+			if !hasRegion {
+				continue
+			}
+			linuxPricing, ok := regionPricingMap["linux"].(*GCPPricingData)
+			if !ok {
+				continue
+			}
+
+			cudStr := formatPrice(totalCUD)
+			switch crk.term {
+			case cudTerm1Yr:
+				linuxPricing.CUD1Yr = cudStr
+			case cudTerm3Yr:
+				linuxPricing.CUD3Yr = cudStr
 			}
 		}
 


### PR DESCRIPTION
## Add GCP Committed Use Discount (CUD) pricing

GCP's analog to AWS/Azure reserved pricing is **resource-based Committed Use Discounts (CUDs)**: a per-machine-family commitment to vCPU + memory in a region for **1 or 3 years**. The site previously showed GCP on-demand + spot only.

### Data source

The scraper already reads committed-use SKUs from the **GCP Cloud Billing Catalog** (`cloudbilling.googleapis.com` SKU + prices endpoints) but discarded them via the `commit`/`cud`/`discount`/`reserved` display-name and taxonomy filters.

Resource-based CUD SKUs use a distinct display-name format from on-demand:

```
Commitment v1: N2 Cpu in Americas for 1 Year
Commitment v1: C2D AMD Ram in EMEA for 3 Year
```

These carry the same per-core (`Cpu`) and per-RAM-GB (`Ram`) hourly rates the scraper already parses for on-demand, just under the committed-use SKU naming.

### How the 1yr/3yr rate is assembled

Identical to how on-demand is built today: the committed-use `Cpu` and `Ram` SKUs are bucketed by `(machine family, region, term)` and combined per instance as

```
cud_price = core_rate * vCPU + ram_rate * RAM
```

CUD SKUs go into a **dedicated bucket** and are never mixed into on-demand/spot. No hardcoded discount ratio is used: the rate comes entirely from the catalog SKU prices. An instance with no CUD SKU for its family/region renders **empty** (`cud_1yr`/`cud_3yr` omitted), not a misleading 0. CUDs attach to the Linux compute price only (they carry no OS license) and only in regions that already have a Linux on-demand price.

Scope is resource-based CUDs on general-purpose / compute / memory / accelerator families (n1, n2, n2d, c2, c2d, c3, m1, m2, m3, a2, etc.). Spend-based / flexible CUDs (`Commitment - dollar based v1: ...`) and Sustained Use Discounts are intentionally **not** matched (not per-instance).

### UI

Adds `cud_1yr`/`cud_3yr` to `GCPPricingData` (Go) and the `GCPPricing` TS type, plus **Linux 1-Year CUD** and **Linux 3-Year CUD** columns in the GCP comparison table, mirroring how Azure's reserved column works.

### Example discount check

For an `n2-standard-8` in a US region the assembled rates match GCP's published resource-based CUD discounts for general-purpose families:

- 1-year CUD ≈ **37% below** on-demand
- 3-year CUD ≈ **55% below** on-demand

(derived purely from the catalog SKU rates, not applied as a ratio).

### Verification

- Scraper: `go build ./...`, `go vet ./gcp/`, `go test ./...` all pass.
- Added regression test (`scraper/gcp/cud_test.go`) asserting `parseCUDSKU` parsing and end-to-end that an N2's 1yr/3yr CUD = `core_rate*vCPU + ram_rate*RAM`, that CUD rates do not leak into on-demand, and that 3yr < 1yr < on-demand. Confirmed the end-to-end test **fails** before the implementation (CUD fields empty) and **passes** after.
- Frontend: `npm run check-types` introduces no new errors (the 8 pre-existing errors are missing generated data files, unrelated to this change); full `vitest` suite passes (241 tests).
- `gofmt` and `prettier` clean.

Closes #916
