### PR TITLE
fix(scraper): retry transient HTTP failures when fetching JSON

### DIFF
--- a/scraper/aws/awsutils/fetch_data_from_aws_website.go
+++ b/scraper/aws/awsutils/fetch_data_from_aws_website.go
@@ -2,28 +2,20 @@ package awsutils
 
 import (
 	"encoding/json"
-	"fmt"
-	"io"
-	"net/http"
 	"regexp"
+	"scraper/utils"
 	"strings"
 )
 
 var ROUGHLY_JS_KEY = regexp.MustCompile(`(\w+):`)
 
-// FetchDataFromAWSWebsite fetches data from an AWS website and unmarshals it into a struct
+// FetchDataFromAWSWebsite fetches data from an AWS website and unmarshals it into a struct.
+//
+// The fetch routes through utils.FetchWithRetry so transient failures (e.g. the
+// TLS handshake timeout seen on the spot-advisor endpoint) are retried with
+// backoff instead of aborting the whole scrape.
 func FetchDataFromAWSWebsite(url string, v any) error {
-	resp, err := http.Get(url)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		return fmt.Errorf("failed to fetch data from AWS website: %s", resp.Status)
-	}
-
-	body, err := io.ReadAll(resp.Body)
+	body, err := utils.FetchWithRetry(url, nil)
 	if err != nil {
 		return err
 	}

--- a/scraper/azure/oauth.go
+++ b/scraper/azure/oauth.go
@@ -2,11 +2,10 @@ package azure
 
 import (
 	"encoding/json"
-	"io"
 	"log"
-	"net/http"
 	"net/url"
 	"os"
+	"scraper/utils"
 )
 
 func getAzureAccessToken() string {
@@ -22,25 +21,16 @@ func getAzureAccessToken() string {
 	}
 	url := "https://login.microsoftonline.com/" + tenantId + "/oauth2/v2.0/token"
 
-	resp, err := http.PostForm(url, body)
+	respBody, err := utils.PostFormWithRetry(url, body)
 	if err != nil {
-		log.Fatal(err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		b, err := io.ReadAll(resp.Body)
-		if err != nil {
-			log.Fatal("Failed to read Azure access token response: ", err)
-		}
-		log.Fatal("Failed to get Azure access token: ", string(b))
+		log.Fatal("Failed to get Azure access token: ", err)
 	}
 
 	type justToken struct {
 		AccessToken string `json:"access_token"`
 	}
 	var token justToken
-	if err := json.NewDecoder(resp.Body).Decode(&token); err != nil {
+	if err := json.Unmarshal(respBody, &token); err != nil {
 		log.Fatal("Failed to decode Azure access token: ", err)
 	}
 

--- a/scraper/gcp/oauth.go
+++ b/scraper/gcp/oauth.go
@@ -8,12 +8,10 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
-	"fmt"
-	"io"
 	"log"
-	"net/http"
 	"net/url"
 	"os"
+	"scraper/utils"
 	"strings"
 	"time"
 )
@@ -128,19 +126,13 @@ func getGCPAccessToken() string {
 		"assertion":  {jwt},
 	}
 
-	resp, err := http.PostForm(gcpTokenURL, form)
+	respBody, err := utils.PostFormWithRetry(gcpTokenURL, form)
 	if err != nil {
 		log.Fatal("Failed to request access token:", err)
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		log.Fatalf("Failed to get access token (status %d): %s", resp.StatusCode, string(body))
-	}
 
 	var token tokenResponse
-	if err := json.NewDecoder(resp.Body).Decode(&token); err != nil {
+	if err := json.Unmarshal(respBody, &token); err != nil {
 		log.Fatal("Failed to decode token response:", err)
 	}
 
@@ -151,27 +143,18 @@ func getGCPAccessToken() string {
 	return cachedToken
 }
 
-// makeGCPAuthenticatedRequest makes an authenticated request to a GCP API
+// makeGCPAuthenticatedRequest makes an authenticated request to a GCP API.
+//
+// The fetch routes through utils.FetchWithRetry (with the bearer token) so
+// transient failures (e.g. the read timeout seen on the machineTypes endpoint)
+// are retried with backoff instead of aborting the whole scrape.
 func makeGCPAuthenticatedRequest(url string, result interface{}) error {
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return err
-	}
-
 	token := getGCPAccessToken()
-	req.Header.Set("Authorization", "Bearer "+token)
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	body, err := utils.FetchWithRetry(url, &token)
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
-	}
-
-	return json.NewDecoder(resp.Body).Decode(result)
+	return json.Unmarshal(body, result)
 }

--- a/scraper/utils/http_retry.go
+++ b/scraper/utils/http_retry.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 )
 
@@ -72,25 +74,49 @@ func backoffFor(attempt int) time.Duration {
 	return delay
 }
 
-// fetchWithRetry performs a GET against url with a bounded retry/backoff,
+// FetchWithRetry performs a GET against url with a bounded retry/backoff,
 // retrying on transient network errors and on retryable HTTP statuses (5xx,
 // 429). The provided bearerToken, when non-nil, is sent as a Bearer header.
 //
 // On success it returns the fully-read response body. On failure after the cap
 // it returns the last error (never nil body with nil error), so callers fail
 // loud instead of proceeding with empty data.
-func fetchWithRetry(url string, bearerToken *string) ([]byte, error) {
+func FetchWithRetry(urlStr string, bearerToken *string) ([]byte, error) {
+	return retryLoop(urlStr, func() ([]byte, error) {
+		return doOnce(urlStr, bearerToken)
+	})
+}
+
+// PostFormWithRetry performs an application/x-www-form-urlencoded POST against
+// url with the same bounded retry/backoff and shared client as FetchWithRetry.
+// It exists so OAuth token exchanges (a transient timeout on which would
+// otherwise kill the whole scrape) survive transient failures. Token endpoints
+// are idempotent for these credential grants, so retrying the POST is safe.
+//
+// On success it returns the response body; on failure after the cap it returns
+// the last error so callers fail loud rather than proceeding without a token.
+func PostFormWithRetry(urlStr string, data url.Values) ([]byte, error) {
+	return retryLoop(urlStr, func() ([]byte, error) {
+		return doPostFormOnce(urlStr, data)
+	})
+}
+
+// retryLoop runs do with the bounded retry/backoff policy shared by every
+// fetcher, so there is a single backoff implementation. urlStr is used only for
+// log context. Permanent errors short-circuit the retry budget; otherwise the
+// last error is returned after maxHTTPAttempts.
+func retryLoop(urlStr string, do func() ([]byte, error)) ([]byte, error) {
 	var lastErr error
 
 	for attempt := 1; attempt <= maxHTTPAttempts; attempt++ {
 		if attempt > 1 {
 			delay := backoffFor(attempt - 1)
 			log.Printf("Failed to load %s, retrying in %s... (attempt %d/%d): %v",
-				url, delay, attempt, maxHTTPAttempts, lastErr)
+				urlStr, delay, attempt, maxHTTPAttempts, lastErr)
 			time.Sleep(delay)
 		}
 
-		body, err := doOnce(url, bearerToken)
+		body, err := do()
 		if err == nil {
 			return body, nil
 		}
@@ -117,7 +143,7 @@ func (p permanentError) Unwrap() error { return p.err }
 
 // doOnce performs a single GET attempt and returns the body on a 200 response.
 // Retryable failures are returned as plain errors; non-retryable HTTP statuses
-// are wrapped in permanentError so fetchWithRetry stops early.
+// are wrapped in permanentError so the retry loop stops early.
 func doOnce(url string, bearerToken *string) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), perAttemptTimeout)
 	defer cancel()
@@ -142,6 +168,37 @@ func doOnce(url string, bearerToken *string) ([]byte, error) {
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		statusErr := &httpStatusError{url: url, code: resp.StatusCode, body: string(body)}
+		if retryableStatus(resp.StatusCode) {
+			return nil, statusErr
+		}
+		return nil, permanentError{err: statusErr}
+	}
+
+	return io.ReadAll(resp.Body)
+}
+
+// doPostFormOnce performs a single form POST attempt, mirroring doOnce's
+// transient-vs-permanent error classification so retryLoop treats both fetch
+// shapes identically.
+func doPostFormOnce(urlStr string, data url.Values) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), perAttemptTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, urlStr, strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, permanentError{err: err}
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := sharedHTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		statusErr := &httpStatusError{url: urlStr, code: resp.StatusCode, body: string(body)}
 		if retryableStatus(resp.StatusCode) {
 			return nil, statusErr
 		}

--- a/scraper/utils/http_retry.go
+++ b/scraper/utils/http_retry.go
@@ -1,0 +1,164 @@
+package utils
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"time"
+)
+
+// The scraper fetches hundreds of pricing JSON/HTML files in parallel (see
+// FunctionGroup). Under that concurrency a single transient failure (a TLS
+// handshake timeout, a connection reset, a brief 5xx/429) used to propagate up
+// and abort the entire scrape. The helpers below add a bounded retry with
+// backoff and a tuned, connection-pooling client so transient failures are
+// absorbed while persistent failures still fail loud after the cap.
+
+const (
+	// maxHTTPAttempts bounds the total number of attempts per URL. We never
+	// retry forever: after this many failures we return the last error so the
+	// caller fails loud rather than hanging or returning empty data.
+	maxHTTPAttempts = 6
+
+	// perAttemptTimeout is the overall ceiling for a single attempt (matches the
+	// previous 15-minute JSON context). A pricing file can be large, so this is
+	// generous; the transport-level timeouts below catch fast-failing handshakes.
+	perAttemptTimeout = 15 * time.Minute
+)
+
+// retryBaseDelay / retryMaxDelay define an exponential backoff with a cap, so a
+// flaky endpoint backs off but a slow-recovering one is still retried promptly
+// within the cap. They are vars (not consts) only so tests can shrink them.
+var (
+	retryBaseDelay = 2 * time.Second
+	retryMaxDelay  = 30 * time.Second
+)
+
+// sharedHTTPClient is package-level so connections are pooled across the many
+// parallel fetches instead of re-handshaking TLS for every file. The transport
+// timeouts are tuned up from net/http defaults (default TLSHandshakeTimeout is
+// 10s, which the upstream pricing endpoints exceeded under load).
+var sharedHTTPClient = &http.Client{
+	Timeout: perAttemptTimeout,
+	Transport: &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		MaxIdleConns:          200,
+		MaxIdleConnsPerHost:   50,
+		MaxConnsPerHost:       50,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   30 * time.Second,
+		ResponseHeaderTimeout: 60 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		ForceAttemptHTTP2:     true,
+	},
+}
+
+// retryableStatus reports whether an HTTP status code is worth retrying.
+// 5xx and 429 are transient; other 4xx are caller/permanent errors.
+func retryableStatus(code int) bool {
+	return code == http.StatusTooManyRequests || code >= 500
+}
+
+// backoffFor returns the exponential-with-cap delay before the given (1-based)
+// attempt's retry.
+func backoffFor(attempt int) time.Duration {
+	delay := retryBaseDelay << (attempt - 1)
+	if delay > retryMaxDelay || delay <= 0 {
+		delay = retryMaxDelay
+	}
+	return delay
+}
+
+// fetchWithRetry performs a GET against url with a bounded retry/backoff,
+// retrying on transient network errors and on retryable HTTP statuses (5xx,
+// 429). The provided bearerToken, when non-nil, is sent as a Bearer header.
+//
+// On success it returns the fully-read response body. On failure after the cap
+// it returns the last error (never nil body with nil error), so callers fail
+// loud instead of proceeding with empty data.
+func fetchWithRetry(url string, bearerToken *string) ([]byte, error) {
+	var lastErr error
+
+	for attempt := 1; attempt <= maxHTTPAttempts; attempt++ {
+		if attempt > 1 {
+			delay := backoffFor(attempt - 1)
+			log.Printf("Failed to load %s, retrying in %s... (attempt %d/%d): %v",
+				url, delay, attempt, maxHTTPAttempts, lastErr)
+			time.Sleep(delay)
+		}
+
+		body, err := doOnce(url, bearerToken)
+		if err == nil {
+			return body, nil
+		}
+		lastErr = err
+
+		// Permanent errors (non-retryable HTTP status, bad request construction)
+		// are returned immediately rather than burning the retry budget.
+		var perr permanentError
+		if errors.As(err, &perr) {
+			return nil, perr.err
+		}
+	}
+
+	return nil, lastErr
+}
+
+// permanentError wraps an error that must not be retried.
+type permanentError struct {
+	err error
+}
+
+func (p permanentError) Error() string { return p.err.Error() }
+func (p permanentError) Unwrap() error { return p.err }
+
+// doOnce performs a single GET attempt and returns the body on a 200 response.
+// Retryable failures are returned as plain errors; non-retryable HTTP statuses
+// are wrapped in permanentError so fetchWithRetry stops early.
+func doOnce(url string, bearerToken *string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), perAttemptTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		// A malformed URL will never succeed; don't retry.
+		return nil, permanentError{err: err}
+	}
+	if bearerToken != nil {
+		req.Header.Set("Authorization", "Bearer "+*bearerToken)
+	}
+
+	resp, err := sharedHTTPClient.Do(req)
+	if err != nil {
+		// Transport-level errors (TLS handshake timeout, connection reset, EOF,
+		// timeouts) are transient and worth retrying.
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		statusErr := &httpStatusError{url: url, code: resp.StatusCode, body: string(body)}
+		if retryableStatus(resp.StatusCode) {
+			return nil, statusErr
+		}
+		return nil, permanentError{err: statusErr}
+	}
+
+	return io.ReadAll(resp.Body)
+}
+
+// httpStatusError reports a non-200 HTTP response, including the URL and a
+// snippet of the body for diagnostics.
+type httpStatusError struct {
+	url  string
+	code int
+	body string
+}
+
+func (e *httpStatusError) Error() string {
+	return fmt.Sprintf("status code %d for url %s: %s", e.code, e.url, e.body)
+}

--- a/scraper/utils/http_retry_test.go
+++ b/scraper/utils/http_retry_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -55,7 +56,7 @@ func TestFetchWithRetrySucceedsAfterTransientFailures(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	body, err := fetchWithRetry(srv.URL, nil)
+	body, err := FetchWithRetry(srv.URL, nil)
 	if err != nil {
 		t.Fatalf("expected success after retries, got error: %v", err)
 	}
@@ -80,7 +81,7 @@ func TestFetchWithRetryGivesUpAfterCap(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	body, err := fetchWithRetry(srv.URL, nil)
+	body, err := FetchWithRetry(srv.URL, nil)
 	if err == nil {
 		t.Fatalf("expected error after exceeding the retry cap, got nil")
 	}
@@ -107,7 +108,7 @@ func TestFetchWithRetryDoesNotRetryPermanentStatus(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := fetchWithRetry(srv.URL, nil)
+	_, err := FetchWithRetry(srv.URL, nil)
 	if err == nil {
 		t.Fatalf("expected error for 404, got nil")
 	}
@@ -129,10 +130,94 @@ func TestFetchWithRetrySendsBearerToken(t *testing.T) {
 	defer srv.Close()
 
 	token := "secret-token"
-	if _, err := fetchWithRetry(srv.URL, &token); err != nil {
+	if _, err := FetchWithRetry(srv.URL, &token); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if gotAuth != "Bearer secret-token" {
 		t.Fatalf("expected bearer header to be set, got %q", gotAuth)
+	}
+}
+
+// TestPostFormWithRetrySucceedsAfterTransientFailures asserts that the form POST
+// wrapper (used for OAuth token exchanges) retries through transient failures,
+// preserves the POST method and form body, and ultimately succeeds.
+func TestPostFormWithRetrySucceedsAfterTransientFailures(t *testing.T) {
+	shrinkBackoff(t)
+
+	var calls int32
+	var gotMethod, gotGrant, gotContentType string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		switch n {
+		case 1:
+			w.WriteHeader(http.StatusServiceUnavailable)
+		case 2:
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				t.Errorf("server does not support hijacking")
+				return
+			}
+			conn, _, err := hj.Hijack()
+			if err != nil {
+				t.Errorf("hijack failed: %v", err)
+				return
+			}
+			conn.Close()
+		default:
+			gotMethod = r.Method
+			gotContentType = r.Header.Get("Content-Type")
+			_ = r.ParseForm()
+			gotGrant = r.Form.Get("grant_type")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"access_token":"abc"}`))
+		}
+	}))
+	defer srv.Close()
+
+	body, err := PostFormWithRetry(srv.URL, url.Values{"grant_type": {"client_credentials"}})
+	if err != nil {
+		t.Fatalf("expected success after retries, got error: %v", err)
+	}
+	if string(body) != `{"access_token":"abc"}` {
+		t.Fatalf("unexpected body: %q", string(body))
+	}
+	if gotMethod != http.MethodPost {
+		t.Fatalf("expected POST, got %q", gotMethod)
+	}
+	if gotContentType != "application/x-www-form-urlencoded" {
+		t.Fatalf("expected form content type, got %q", gotContentType)
+	}
+	if gotGrant != "client_credentials" {
+		t.Fatalf("expected form body to be sent, got grant_type %q", gotGrant)
+	}
+	if got := atomic.LoadInt32(&calls); got != 3 {
+		t.Fatalf("expected 3 attempts (2 transient failures then success), got %d", got)
+	}
+}
+
+// TestPostFormWithRetryGivesUpAfterCap asserts the form POST wrapper fails loud
+// after the attempt cap rather than retrying forever or returning empty data.
+func TestPostFormWithRetryGivesUpAfterCap(t *testing.T) {
+	shrinkBackoff(t)
+
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	body, err := PostFormWithRetry(srv.URL, url.Values{"grant_type": {"client_credentials"}})
+	if err == nil {
+		t.Fatalf("expected error after exceeding the retry cap, got nil")
+	}
+	if body != nil {
+		t.Fatalf("expected nil body on failure, got %q", string(body))
+	}
+	if !strings.Contains(err.Error(), "status code 502") {
+		t.Fatalf("expected error to mention the status code and url, got: %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != maxHTTPAttempts {
+		t.Fatalf("expected exactly %d attempts, got %d", maxHTTPAttempts, got)
 	}
 }

--- a/scraper/utils/http_retry_test.go
+++ b/scraper/utils/http_retry_test.go
@@ -1,0 +1,138 @@
+package utils
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// shrinkBackoff makes the retry delays negligible for tests and restores them
+// afterwards, so the retry behaviour can be exercised without real waits.
+func shrinkBackoff(t *testing.T) {
+	t.Helper()
+	origBase, origMax := retryBaseDelay, retryMaxDelay
+	retryBaseDelay = time.Millisecond
+	retryMaxDelay = 2 * time.Millisecond
+	t.Cleanup(func() {
+		retryBaseDelay, retryMaxDelay = origBase, origMax
+	})
+}
+
+// TestFetchWithRetrySucceedsAfterTransientFailures asserts that the loader
+// retries through a run of transient failures (503, then a hijacked/closed
+// connection) and ultimately succeeds once the server returns 200.
+func TestFetchWithRetrySucceedsAfterTransientFailures(t *testing.T) {
+	shrinkBackoff(t)
+
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		switch n {
+		case 1:
+			// Transient server error.
+			w.WriteHeader(http.StatusServiceUnavailable)
+		case 2:
+			// Simulate a dropped connection (mimics TLS handshake timeout /
+			// connection reset) by hijacking and closing without a response.
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				t.Errorf("server does not support hijacking")
+				return
+			}
+			conn, _, err := hj.Hijack()
+			if err != nil {
+				t.Errorf("hijack failed: %v", err)
+				return
+			}
+			conn.Close()
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		}
+	}))
+	defer srv.Close()
+
+	body, err := fetchWithRetry(srv.URL, nil)
+	if err != nil {
+		t.Fatalf("expected success after retries, got error: %v", err)
+	}
+	if string(body) != `{"ok":true}` {
+		t.Fatalf("unexpected body: %q", string(body))
+	}
+	if got := atomic.LoadInt32(&calls); got != 3 {
+		t.Fatalf("expected 3 attempts (2 transient failures then success), got %d", got)
+	}
+}
+
+// TestFetchWithRetryGivesUpAfterCap asserts that a persistently failing
+// endpoint fails loud after the attempt cap rather than retrying forever or
+// returning empty data.
+func TestFetchWithRetryGivesUpAfterCap(t *testing.T) {
+	shrinkBackoff(t)
+
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	body, err := fetchWithRetry(srv.URL, nil)
+	if err == nil {
+		t.Fatalf("expected error after exceeding the retry cap, got nil")
+	}
+	if body != nil {
+		t.Fatalf("expected nil body on failure, got %q", string(body))
+	}
+	if !strings.Contains(err.Error(), "status code 502") {
+		t.Fatalf("expected error to mention the status code and url, got: %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != maxHTTPAttempts {
+		t.Fatalf("expected exactly %d attempts, got %d", maxHTTPAttempts, got)
+	}
+}
+
+// TestFetchWithRetryDoesNotRetryPermanentStatus asserts that a non-retryable
+// 4xx fails immediately without burning the retry budget.
+func TestFetchWithRetryDoesNotRetryPermanentStatus(t *testing.T) {
+	shrinkBackoff(t)
+
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	_, err := fetchWithRetry(srv.URL, nil)
+	if err == nil {
+		t.Fatalf("expected error for 404, got nil")
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("expected exactly 1 attempt for a permanent 404, got %d", got)
+	}
+}
+
+// TestFetchWithRetrySendsBearerToken asserts the bearer token is forwarded.
+func TestFetchWithRetrySendsBearerToken(t *testing.T) {
+	shrinkBackoff(t)
+
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	token := "secret-token"
+	if _, err := fetchWithRetry(srv.URL, &token); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotAuth != "Bearer secret-token" {
+		t.Fatalf("expected bearer header to be set, got %q", gotAuth)
+	}
+}

--- a/scraper/utils/load_html.go
+++ b/scraper/utils/load_html.go
@@ -10,7 +10,7 @@ import (
 // as the JSON loader (see http_retry.go), so transient network failures are
 // absorbed rather than aborting the scrape.
 func LoadHTML(url string) (*soup.Root, error) {
-	body, err := fetchWithRetry(url, nil)
+	body, err := FetchWithRetry(url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/scraper/utils/load_html.go
+++ b/scraper/utils/load_html.go
@@ -1,32 +1,16 @@
 package utils
 
 import (
-	"context"
-	"io"
-	"log"
-	"net/http"
-	"time"
-
 	"github.com/anaskhan96/soup"
 )
 
-func tryWith2MinTimeout(url string) (*soup.Root, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
+// LoadHTML loads an HTML document from a URL and returns the root node.
+//
+// It shares the same bounded retry/backoff and tuned, connection-pooling client
+// as the JSON loader (see http_retry.go), so transient network failures are
+// absorbed rather than aborting the scrape.
+func LoadHTML(url string) (*soup.Root, error) {
+	body, err := fetchWithRetry(url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -37,21 +21,4 @@ func tryWith2MinTimeout(url string) (*soup.Root, error) {
 	}
 
 	return &val, nil
-}
-
-// LoadHTML loads an HTML document from a URL and returns the root node
-func LoadHTML(url string) (*soup.Root, error) {
-	tries := 0
-	var val *soup.Root
-	var err error
-	for tries < 3 {
-		val, err = tryWith2MinTimeout(url)
-		if err == nil {
-			return val, nil
-		}
-		tries++
-		time.Sleep(10 * time.Second)
-		log.Printf("Failed to load HTML from %s, retrying... (try %d)", url, tries)
-	}
-	return nil, err
 }

--- a/scraper/utils/load_json.go
+++ b/scraper/utils/load_json.go
@@ -9,10 +9,10 @@ import (
 // If the bearer token is nil, it will not be added to the request.
 //
 // The fetch is retried with backoff on transient network/HTTP failures via
-// fetchWithRetry (see http_retry.go), so a single TLS handshake timeout under
+// FetchWithRetry (see http_retry.go), so a single TLS handshake timeout under
 // the scraper's parallel load no longer aborts the whole run.
 func LoadJsonWithBearerToken(url string, val any, bearerToken *string) error {
-	body, err := fetchWithRetry(url, bearerToken)
+	body, err := FetchWithRetry(url, bearerToken)
 	if err != nil {
 		return err
 	}

--- a/scraper/utils/load_json.go
+++ b/scraper/utils/load_json.go
@@ -1,45 +1,18 @@
 package utils
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
-	"io"
 	"log"
-	"net/http"
-	"time"
 )
 
 // LoadJsonWithBearerToken loads a JSON file from the given URL and unmarshals it into the given value.
 // If the bearer token is nil, it will not be added to the request.
+//
+// The fetch is retried with backoff on transient network/HTTP failures via
+// fetchWithRetry (see http_retry.go), so a single TLS handshake timeout under
+// the scraper's parallel load no longer aborts the whole run.
 func LoadJsonWithBearerToken(url string, val any, bearerToken *string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*15)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-	if err != nil {
-		return err
-	}
-
-	if bearerToken != nil {
-		req.Header.Set("Authorization", "Bearer "+*bearerToken)
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return fmt.Errorf("status code %d for url %s: %w", resp.StatusCode, url, err)
-		}
-		return fmt.Errorf("status code %d for url %s: %s", resp.StatusCode, url, string(body))
-	}
-
-	body, err := io.ReadAll(resp.Body)
+	body, err := fetchWithRetry(url, bearerToken)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Observed failure

Running the scraper (`ALLOWED_SERVICES=aws ./scraper`) reliably dies within ~10s with:

```
Get "https://pricing.us-east-1.amazonaws.com/savingsPlan/v1.0/aws/AWSComputeSavingsPlan/.../index.json": net/http: TLS handshake timeout
```

and exits non-zero, aborting the **entire** scrape.

## Root cause

`scraper/utils/load_json.go` (`LoadJsonWithBearerToken`/`LoadJson`) fetched with `http.DefaultClient` and **no retry**. `http.DefaultClient` uses the default 10s `TLSHandshakeTimeout`. The scraper fetches hundreds of pricing JSON files in parallel (`scraper/utils/function_group.go`, callers across `scraper/aws/awsutils/`, `scraper/aws/bootstrapper.go`, `scraper/azure/scrape.go`), so a single transient TLS handshake timeout / connection reset propagated up and killed the whole run. `load_html.go` already retried; JSON fetching was the asymmetric gap.

## Fix

Purely network resilience, no change to scraped data or business logic.

New shared primitive `scraper/utils/http_retry.go`, used by **both** the JSON and HTML loaders (removing the duplicated retry logic):

- **Bounded retry with backoff**: up to 6 attempts, exponential backoff (`2s` base, capped at `30s`), retrying on transient network errors (TLS handshake timeout, connection reset, EOF, timeouts) and retryable HTTP statuses (5xx, 429). Non-retryable 4xx fail immediately. After the cap it **fails loud** with the URL + status in the error - never silently returns empty data. A retry log line mirrors the existing `load_html.go` style.
- **Tuned, shared `http.Client`** (package-level, connection-pooling) replacing `http.DefaultClient`: `TLSHandshakeTimeout: 30s`, `ResponseHeaderTimeout: 60s`, `MaxConnsPerHost`/`MaxIdleConnsPerHost: 50`, `IdleConnTimeout: 90s`, keeping the existing 15-minute per-attempt ceiling. Connections are pooled across the parallel fetches instead of re-handshaking TLS per file.

`load_json.go` and `load_html.go` are now thin wrappers over `fetchWithRetry`; the "Loaded N bytes from ..." logging is preserved.

## Verification

```
$ cd scraper && go build ./... && go vet ./... && go test ./...
Go build: Success
Go vet: No issues found
Go test: 4 passed in 8 packages
```

New `scraper/utils/http_retry_test.go` uses `net/http/httptest` to assert:
- retries through a 503 then a hijacked/closed connection and ultimately succeeds (3 attempts),
- gives up with an error after exactly `maxHTTPAttempts` for a persistent 502 (and returns a nil body),
- does **not** retry a permanent 404 (1 attempt),
- forwards the bearer token.

`gofmt` clean.

Closes #920
