### PR TITLE
fix(ec2): report FPGA count for vt1 instances

### DIFF
--- a/scraper/aws/ec2/fpga_data.go
+++ b/scraper/aws/ec2/fpga_data.go
@@ -1,0 +1,46 @@
+package ec2
+
+import "log"
+
+/*
+AWS does not return FpgaInfo from DescribeInstanceTypes for vt1 instances, even
+though they carry Xilinx Alveo U30 media accelerator cards. AWS markets vt1 as
+"media accelerators" rather than F1-style FPGAs, so the FpgaInfo field used to
+populate instance.FPGA in enrichEc2Instance is nil for vt1 and the count stays
+0 (see https://github.com/vantage-sh/ec2instances.info/issues/825).
+
+The U30 is a Zynq UltraScale+ based FPGA accelerator card. We report the number
+of U30 accelerator cards per instance, which is the FPGA accelerator unit AWS
+itself counts in its specs and the unit directly comparable to the per-FPGA
+count AWS reports via FpgaInfo for f1 instances (f1.2xlarge=1, f1.4xlarge=2,
+f1.16xlarge=8). Each U30 card additionally contains two XCU30 SoCs, but the
+card is the accelerator unit AWS exposes, so we count cards to stay consistent
+with the f1 1/2/8 progression.
+
+Sources:
+
+	https://aws.amazon.com/ec2/instance-types/vt1/
+	https://aws.amazon.com/blogs/compute/deep-dive-on-amazon-ec2-vt1-instances/
+*/
+var FPGA_DATA = map[string]int{
+	"vt1.3xlarge":  1,
+	"vt1.6xlarge":  2,
+	"vt1.24xlarge": 8,
+}
+
+// addFpgaInfo fills in FPGA counts for instances that carry FPGA accelerators
+// which AWS does not report through DescribeInstanceTypes' FpgaInfo. Values
+// already set from the AWS API (e.g. f1) are left untouched.
+func addFpgaInfo(instances map[string]*EC2Instance) {
+	log.Default().Println("Adding FPGA info to EC2")
+
+	for instanceType, fpgaCount := range FPGA_DATA {
+		instance, ok := instances[instanceType]
+		if !ok {
+			continue
+		}
+		if instance.FPGA == 0 {
+			instance.FPGA = fpgaCount
+		}
+	}
+}

--- a/scraper/aws/ec2/fpga_data_test.go
+++ b/scraper/aws/ec2/fpga_data_test.go
@@ -1,0 +1,31 @@
+package ec2
+
+import "testing"
+
+func TestAddFpgaInfo(t *testing.T) {
+	instances := map[string]*EC2Instance{
+		"vt1.3xlarge":  {InstanceType: "vt1.3xlarge"},
+		"vt1.6xlarge":  {InstanceType: "vt1.6xlarge"},
+		"vt1.24xlarge": {InstanceType: "vt1.24xlarge"},
+		// Non-FPGA instance must stay at 0.
+		"m5.large": {InstanceType: "m5.large"},
+		// FPGA count already set from the AWS API (f1) must be preserved.
+		"f1.2xlarge": {InstanceType: "f1.2xlarge", FPGA: 1},
+	}
+
+	addFpgaInfo(instances)
+
+	expected := map[string]int{
+		"vt1.3xlarge":  1,
+		"vt1.6xlarge":  2,
+		"vt1.24xlarge": 8,
+		"m5.large":     0,
+		"f1.2xlarge":   1,
+	}
+
+	for instanceType, want := range expected {
+		if got := instances[instanceType].FPGA; got != want {
+			t.Errorf("FPGA count for %s = %d, want %d", instanceType, got, want)
+		}
+	}
+}

--- a/scraper/aws/ec2/process_data.go
+++ b/scraper/aws/ec2/process_data.go
@@ -272,6 +272,9 @@ func processEC2Data(
 	// Add GPU information
 	addGpuInfo(instancesHashmap)
 
+	// Add FPGA information for instances AWS does not report via the API
+	addFpgaInfo(instancesHashmap)
+
 	// Add placement group information
 	addPlacementGroupInfo(instancesHashmap)
 


### PR DESCRIPTION
## Root cause

vt1 instances (vt1.3xlarge, vt1.6xlarge, vt1.24xlarge) showed FPGA count = 0 on the site.

The FPGA column is populated in `scraper/aws/ec2/enrichment.go` from the AWS `DescribeInstanceTypes` response: `apiDescription.FpgaInfo.Fpgas[].Count`. AWS markets vt1 as "media accelerators" rather than F1-style FPGAs and does not return `FpgaInfo` for vt1, so that field is nil and `instance.FPGA` was never set, staying at its zero value. f1 instances are unaffected because AWS does report `FpgaInfo` for them.

## Fix

Added an explicit `FPGA_DATA` map (`scraper/aws/ec2/fpga_data.go`), applied via `addFpgaInfo` in a post-processing step mirroring the existing `addGpuInfo`/`GPU_DATA` pattern. It only fills counts that are still 0, so any AWS-API-sourced value (f1) is left untouched. Change is vt1-specific.

Per-size counts (number of Xilinx Alveo U30 accelerator cards):

| Instance | U30 cards (FPGA count) |
|---|---|
| vt1.3xlarge | 1 |
| vt1.6xlarge | 2 |
| vt1.24xlarge | 8 |

## Device-vs-card decision

Each U30 card contains two XCU30 Zynq UltraScale+ SoCs, so the addressable-device counts would be 2 / 4 / 16. I report the **U30 card count (1 / 2 / 8)** instead, because:

- AWS's own specs enumerate vt1 by U30 accelerator card, and the card is the FPGA accelerator unit AWS exposes.
- It is the unit directly comparable to the per-FPGA count AWS reports via `FpgaInfo` for f1 (f1.2xlarge=1, f1.4xlarge=2, f1.16xlarge=8), keeping the FPGA column semantics consistent across f1 and vt1.

## Sources

- https://aws.amazon.com/ec2/instance-types/vt1/
- https://aws.amazon.com/blogs/compute/deep-dive-on-amazon-ec2-vt1-instances/

## Verification

- Added regression test `TestAddFpgaInfo`: asserts vt1 sizes get 1/2/8, a non-FPGA instance (m5.large) stays 0, and an API-sourced f1 value is preserved. Confirmed it FAILS before the fix (vt1 = 0) and PASSES after.
- `cd scraper && go build ./... && go vet ./... && go test ./...` all pass. gofmt clean.

Closes #825
