### PR TITLE
fix: hide missing max ECS task detail row

### DIFF
--- a/next/utils/ec2TablesGenerator.ts
+++ b/next/utils/ec2TablesGenerator.ts
@@ -33,6 +33,13 @@ export function ec2(instance: Omit<EC2Instance, "pricing">): Table[] {
             children: instance.branch_interface,
         });
     }
+    if (typeof instance.max_ecs_tasks === "number") {
+        trunkingRows.push({
+            name: "Max ECS Tasks",
+            help: "https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-instance-eni.html",
+            children: instance.max_ecs_tasks,
+        });
+    }
 
     return [
         {
@@ -185,11 +192,6 @@ export function ec2(instance: Omit<EC2Instance, "pricing">): Table[] {
                     children: instance.placement_group_support,
                 },
                 ...trunkingRows,
-                {
-                    name: "Max ECS Tasks",
-                    help: "https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-instance-eni.html",
-                    children: instance.max_ecs_tasks,
-                },
             ],
         },
         {


### PR DESCRIPTION
## Summary
- Render the EC2 detail-page Max ECS Tasks row only when `max_ecs_tasks` is present.
- Keeps existing/older fixtures and data from producing an undefined detail row.

## Test plan
- `cd next && npm run test -- ec2TablesGenerator.test.ts`