### PR TITLE
fix(scraper): dedupe approxEqual so go test ./aws/ compiles

### DIFF
--- a/scraper/aws/rds_test.go
+++ b/scraper/aws/rds_test.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"math"
 	"testing"
 
 	"scraper/aws/awsutils"
@@ -38,9 +37,7 @@ func assembleOnDemand(
 	return getPricing(attributes["engineCode"]).OnDemand
 }
 
-func approxEqual(a, b float64) bool {
-	return math.Abs(a-b) < 1e-9
-}
+// approxEqual is defined once for package aws in reserved_pricing_test.go.
 
 // TestUnbundledSqlServerLicense replicates the #890 scenario: a db.m7i.2xlarge SQL
 // Server Standard "unbundled" instance must display base + separately-billed


### PR DESCRIPTION
## Fix `go test ./aws/` compile failure (duplicate `approxEqual`)

`func approxEqual` was declared in **both** `scraper/aws/rds_test.go` and `scraper/aws/reserved_pricing_test.go` (both `package aws`), so the `aws` test package failed to build:

```
aws/reserved_pricing_test.go:40:6: approxEqual redeclared in this block
	aws/rds_test.go:41:6: other declaration of approxEqual
```

The two copies were added independently by #912 and #923 and merged separately, so the collision wasn't seen.

### Change
Keep the declaration in `reserved_pricing_test.go`, remove the duplicate from `rds_test.go` (and its now-unused `math` import). One-file, 4-line removal.

### Verification
```
cd scraper && go build ./... && go vet ./... && go test ./aws/
ok  	scraper/aws
```

Closes #932. (The companion CI issue #933 adds a check so this class of failure is caught on PRs.)
