### PR TITLE
ci: run scraper Go build/vet/tests and gate on pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 name: Tests
-on: push
+on: [push, pull_request]
 
 jobs:
     gofmt:
@@ -12,6 +12,17 @@ jobs:
                   go-version: 1.26.0
             - name: Check gofmt
               run: cd scraper && gofmt -l . && test -z "$(gofmt -l .)"
+
+    go-tests:
+        name: Go build, vet and tests (scraper)
+        runs-on: ubuntu-22.04
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-go@v5
+              with:
+                  go-version: 1.26.0
+            - name: Build, vet and test the scraper
+              run: cd scraper && go build ./... && go vet ./... && go test ./...
 
     prettier:
         name: Prettier


### PR DESCRIPTION
## CI: run the scraper's Go build/vet/tests, and gate on PRs

The `Tests` workflow checked `gofmt`, prettier, and the frontend (check-types + vitest), but **never compiled or ran the scraper's Go tests** — `gofmt` passes on code that doesn't compile, which is how a non-compiling test package reached `develop` unnoticed (`approxEqual redeclared`, see #932).

### Change
- Add a **`go-tests`** job to `.github/workflows/tests.yml` that runs `go build ./... && go vet ./... && go test ./...` in `scraper/` (Go 1.26.0, matching the existing `gofmt` job). These are pure unit tests — no cloud creds or scraped data needed.
- Change the trigger from `on: push` to `on: [push, pull_request]` so pull requests (including from forks) are gated by the checks, not just branch pushes.

### Why
This would have caught #932 on the PR. It's the smallest addition that closes the gap; the frontend test job already exists and is unchanged.

Closes #933. Related: #932 / #934 (the duplicate-helper fix this check would have caught).
