### PR TITLE
fix(azure): default the reserved term so reserved/savings-plan prices show

### DIFF
--- a/next/utils/useGlobalStateValue.ts
+++ b/next/utils/useGlobalStateValue.ts
@@ -104,7 +104,11 @@ const blankStateDump: StateDump = {
     region: "",
     pricingUnit: "instance",
     costDuration: "hourly",
-    reservedTerm: "yrTerm1Standard.noUpfront",
+    // Left empty so the per-page default from useReservedTerm() applies (AWS ->
+    // yrTerm1Standard.noUpfront, Azure -> yrTerm1Standard.allUpfront). Hardcoding
+    // noUpfront here overrode the Azure default, leaving Azure's reserved/savings
+    // columns blank because noUpfront isn't a valid Azure term. Mirrors region/filter.
+    reservedTerm: "",
 };
 
 function deepCopy<T>(v: T): T {


### PR DESCRIPTION
## Default the Azure reserved term so reserved/Savings-Plan prices aren't blank

Fixes #925.

### Root cause
`blankStateDump` in `next/utils/useGlobalStateValue.ts` hardcoded `reservedTerm: "yrTerm1Standard.noUpfront"`. That value is written into every page's fresh state, and since it's non-empty, `resOrDefault` returns it and **never falls back to the per-page default** from `useReservedTerm()`. `useReservedTerm` already special-cases Azure (`yrTerm1Standard.allUpfront`), but that branch was effectively dead code.

`noUpfront` is a valid AWS term, so EC2 worked. Azure's terms are `*.allUpfront` / `*.hybridbenefit` (labelled "No Hybrid Benefit / Hybrid Benefit × 1/3 Year"), so `noUpfront` matched nothing -> the "Hybrid Benefit" selector defaulted to **"Select…"** and the **Linux/Windows Reserved + Savings Plan** columns rendered blank on first load.

### Fix
Leave `reservedTerm` empty in `blankStateDump` (mirroring `region` and `filter`, which already defer to their per-page defaults). Now `resOrDefault` falls back to `useReservedTerm()`'s per-page default: AWS keeps `yrTerm1Standard.noUpfront`, Azure gets `yrTerm1Standard.allUpfront`.

### Verification (local dev build)
- **Azure** `/azure`: term selector now defaults to **"No Hybrid Benefit - 1 Year"**, A2m v2 Linux Reserved = **$0.07/hr** (was "-").
- **EC2** `/`: unchanged — defaults to **"1-year - No Upfront"**, m5.large reserved = $0.06/hr.
- `tsc --noEmit`: no new errors.

One-line change (plus a comment).
