### PR TITLE
fix(scraper): retry transient 404s from the AWS pricing index

### DIFF
--- a/scraper/utils/http_retry.go
+++ b/scraper/utils/http_retry.go
@@ -59,9 +59,16 @@ var sharedHTTPClient = &http.Client{
 }
 
 // retryableStatus reports whether an HTTP status code is worth retrying.
-// 5xx and 429 are transient; other 4xx are caller/permanent errors.
+// 5xx and 429 are transient. 404 is also retried because the AWS pricing index
+// regularly references a per-region file (e.g. a newly added Local Zone's
+// savings-plan index) moments before S3 has finished publishing it: a fetch the
+// index just told us to make then 404s transiently and succeeds seconds later.
+// Without retrying it, a single such publish race aborts the entire scrape.
+// Other 4xx are caller/permanent errors.
 func retryableStatus(code int) bool {
-	return code == http.StatusTooManyRequests || code >= 500
+	return code == http.StatusTooManyRequests ||
+		code == http.StatusNotFound ||
+		code >= 500
 }
 
 // backoffFor returns the exponential-with-cap delay before the given (1-based)

--- a/scraper/utils/http_retry_test.go
+++ b/scraper/utils/http_retry_test.go
@@ -97,23 +97,54 @@ func TestFetchWithRetryGivesUpAfterCap(t *testing.T) {
 }
 
 // TestFetchWithRetryDoesNotRetryPermanentStatus asserts that a non-retryable
-// 4xx fails immediately without burning the retry budget.
+// 4xx (e.g. 403) fails immediately without burning the retry budget.
 func TestFetchWithRetryDoesNotRetryPermanentStatus(t *testing.T) {
 	shrinkBackoff(t)
 
 	var calls int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&calls, 1)
-		w.WriteHeader(http.StatusNotFound)
+		w.WriteHeader(http.StatusForbidden)
 	}))
 	defer srv.Close()
 
 	_, err := FetchWithRetry(srv.URL, nil)
 	if err == nil {
-		t.Fatalf("expected error for 404, got nil")
+		t.Fatalf("expected error for 403, got nil")
 	}
 	if got := atomic.LoadInt32(&calls); got != 1 {
-		t.Fatalf("expected exactly 1 attempt for a permanent 404, got %d", got)
+		t.Fatalf("expected exactly 1 attempt for a permanent 403, got %d", got)
+	}
+}
+
+// TestFetchWithRetryRetriesTransient404 asserts that a 404 is retried rather
+// than treated as permanent: the AWS pricing index can reference a file S3 has
+// not finished publishing, yielding a transient 404 that resolves on retry.
+func TestFetchWithRetryRetriesTransient404(t *testing.T) {
+	shrinkBackoff(t)
+
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n < 3 {
+			// Index references the file before S3 finishes publishing it.
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	body, err := FetchWithRetry(srv.URL, nil)
+	if err != nil {
+		t.Fatalf("expected success after transient 404s, got error: %v", err)
+	}
+	if string(body) != `{"ok":true}` {
+		t.Fatalf("unexpected body: %q", string(body))
+	}
+	if got := atomic.LoadInt32(&calls); got != 3 {
+		t.Fatalf("expected 3 attempts (2 transient 404s then success), got %d", got)
 	}
 }
 


### PR DESCRIPTION
## What

Make a `404` retryable in `scraper/utils/http_retry.go` so the scraper survives a transient 404 from the AWS pricing index.

## Why

The AWS pricing index regularly references a per-region file (e.g. a newly added Local Zone's savings-plan index) moments before S3 has finished publishing it. A fetch the index *just told us to make* then returns a transient 404 and succeeds seconds later.

`retryableStatus` treated every 404 as permanent, so `retryLoop` short-circuited and `processSavingsPlans` hit its `log.Fatal` — aborting the entire scrape. We hit this on `ap-southeast-1-mnl-1` (a new Manila Local Zone); the same file returned 200 minutes later.

Including 404 in the retryable set lets the existing bounded exponential backoff (6 attempts, ~1 min worst case) absorb the publish race. A genuinely missing file still fails loud after the cap.

## Changes

- `retryableStatus` now also retries `404`, with a comment explaining the AWS publish-race rationale.
- Updated `TestFetchWithRetryDoesNotRetryPermanentStatus` to use `403` (still non-retryable) since `404` is no longer permanent.
- Added `TestFetchWithRetryRetriesTransient404`, asserting a transient 404 is retried through to success.

## Testing

```
cd scraper && go test ./utils/
ok  	scraper/utils
```

`gofmt` and `go vet ./utils/` are clean.

Fixes #943
