### PR TITLE
fix(ec2): use extras cpu.speed when AWS pricing omits clockSpeed

### DIFF
--- a/scraper/aws/ec2/ec2_instance.go
+++ b/scraper/aws/ec2/ec2_instance.go
@@ -2,6 +2,7 @@ package ec2
 
 import (
 	"encoding/json"
+	"fmt"
 	"scraper/aws/awsutils"
 	"scraper/aws/ec2/extras"
 	"strconv"
@@ -143,8 +144,16 @@ func avg(ints []int) *float64 {
 	return &avg
 }
 
+func formatClockSpeedFromMhz(speedMhz uint) string {
+	return fmt.Sprintf("%.1f GHz", float64(speedMhz)/1000)
+}
+
 func (instance *EC2Instance) addExtraDetails() {
 	if details, ok := extras.ExtraInstanceDetails[instance.InstanceType]; ok {
+		if details.CPU.Speed > 0 {
+			clockSpeed := formatClockSpeedFromMhz(details.CPU.Speed)
+			instance.ClockSpeedGhz = &clockSpeed
+		}
 		instance.MemorySpeed = details.Memory.SpeedMhz
 		instance.CoremarkIterationsSecond = &details.Coremark.IterationsSecond
 		gpuArchitectures := []string{}

--- a/scraper/aws/ec2/ec2_instance_test.go
+++ b/scraper/aws/ec2/ec2_instance_test.go
@@ -1,0 +1,57 @@
+package ec2
+
+import (
+	"scraper/utils"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+func TestFormatClockSpeedFromMhz(t *testing.T) {
+	tests := []struct {
+		speedMhz uint
+		want     string
+	}{
+		{2500, "2.5 GHz"},
+		{2700, "2.7 GHz"},
+		{3100, "3.1 GHz"},
+	}
+	for _, tc := range tests {
+		if got := formatClockSpeedFromMhz(tc.speedMhz); got != tc.want {
+			t.Errorf("formatClockSpeedFromMhz(%d) = %q, want %q", tc.speedMhz, got, tc.want)
+		}
+	}
+}
+
+func TestAddExtraDetailsSetsClockSpeedFromMeasuredData(t *testing.T) {
+	instance := &EC2Instance{InstanceType: "m6g.medium"}
+	instance.addExtraDetails()
+
+	if instance.ClockSpeedGhz == nil {
+		t.Fatal("ClockSpeedGhz is nil, want 2.5 GHz from measured extras data")
+	}
+	if *instance.ClockSpeedGhz != "2.5 GHz" {
+		t.Errorf("ClockSpeedGhz = %q, want %q", *instance.ClockSpeedGhz, "2.5 GHz")
+	}
+}
+
+func TestEnrichEc2InstancePrefersAwsClockSpeedOverExtras(t *testing.T) {
+	instance := &EC2Instance{InstanceType: "m6g.medium"}
+	instance.addExtraDetails()
+
+	ec2ApiResponses := utils.NewSlowBuildingMap[string, *types.InstanceTypeInfo](func(pushChunk func(map[string]*types.InstanceTypeInfo)) {})
+	enrichEc2Instance(instance, map[string]string{
+		"instanceFamily": "General purpose",
+		"vcpu":           "1",
+		"memory":         "4 GiB",
+		"clockSpeed":     "2.6 GHz",
+		"ecu":            "Variable",
+	}, ec2ApiResponses)
+
+	if instance.ClockSpeedGhz == nil {
+		t.Fatal("ClockSpeedGhz is nil")
+	}
+	if *instance.ClockSpeedGhz != "2.6 GHz" {
+		t.Errorf("ClockSpeedGhz = %q, want AWS pricing value %q", *instance.ClockSpeedGhz, "2.6 GHz")
+	}
+}


### PR DESCRIPTION
Seemingly fixes #542 - though welcoming a review.

AWS’s pricing catalog omits the clockSpeed attribute for the entire m6g family, so those instances were showing no clock speed on the site even though other Graviton2 types (e.g. c6g, r6g) include 2.5 GHz. This change adds a fallback in the scraper: when pricing data has no clock speed, it uses the measured cpu.speed from manually_fetched_data.json (MHz, formatted as "X.X GHz"). AWS pricing still takes precedence when it does provide a value....and this data for m6g is actually already present in manually_fetched_data.json so seemingly a quick fix for a longstanding issue. 