### PR TITLE
Reapply storage IOPS scraper changes

### DIFF
--- a/next/types.ts
+++ b/next/types.ts
@@ -50,6 +50,8 @@ export interface EC2Instance {
         includes_swap_partition: boolean;
         storage_needs_initialization: boolean;
         trim_support: boolean;
+        storage_read_iops?: number;
+        storage_write_iops?: number;
     };
     arch: string[];
     network_performance: string;

--- a/next/utils/colunnData/ec2/columns.tsx
+++ b/next/utils/colunnData/ec2/columns.tsx
@@ -14,6 +14,8 @@ interface Storage {
     ssd: boolean;
     trim_support: boolean;
     storage_needs_initialization: boolean;
+    storage_read_iops?: number;
+    storage_write_iops?: number;
 }
 
 export function calculateCost(
@@ -808,6 +810,66 @@ export const columnsGen = (
                 throw new Error("trim_support is undefined");
             return storage.trim_support ? "Yes" : "No";
         }),
+    },
+    {
+        accessorKey: "storage",
+        header: "Instance Store: Read IOPS",
+        size: 200,
+        id: "storage_read_iops",
+        sortingFn: (rowA, rowB) => {
+            const a = rowA.original.storage?.storage_read_iops;
+            const b = rowB.original.storage?.storage_read_iops;
+            if (!a) return -1;
+            if (!b) return 1;
+            return a - b;
+        },
+        filterFn: (row, _, filterValue) => {
+            const value = row.original.storage?.storage_read_iops;
+            if (!value) return false;
+            try {
+                return exprCompiler(filterValue)(
+                    value,
+                    `${value.toLocaleString()} IOPS`,
+                );
+            } catch {
+                return true;
+            }
+        },
+        cell: (info) => {
+            const storage = info.getValue() as Storage;
+            if (!storage?.storage_read_iops) return undefined;
+            return `${storage.storage_read_iops.toLocaleString()} IOPS`;
+        },
+    },
+    {
+        accessorKey: "storage",
+        header: "Instance Store: Write IOPS",
+        size: 200,
+        id: "storage_write_iops",
+        sortingFn: (rowA, rowB) => {
+            const a = rowA.original.storage?.storage_write_iops;
+            const b = rowB.original.storage?.storage_write_iops;
+            if (!a) return -1;
+            if (!b) return 1;
+            return a - b;
+        },
+        filterFn: (row, _, filterValue) => {
+            const value = row.original.storage?.storage_write_iops;
+            if (!value) return false;
+            try {
+                return exprCompiler(filterValue)(
+                    value,
+                    `${value.toLocaleString()} IOPS`,
+                );
+            } catch {
+                return true;
+            }
+        },
+        cell: (info) => {
+            const storage = info.getValue() as Storage;
+            if (!storage?.storage_write_iops) return undefined;
+            return `${storage.storage_write_iops.toLocaleString()} IOPS`;
+        },
     },
     {
         accessorKey: "arch",

--- a/next/utils/colunnData/ec2/index.ts
+++ b/next/utils/colunnData/ec2/index.ts
@@ -25,6 +25,8 @@ const initialColumnsArr = [
     ["storage", true],
     ["warmed-up", false],
     ["trim-support", false],
+    ["storage_read_iops", false],
+    ["storage_write_iops", false],
     ["arch", false],
     ["network_performance", true],
     ["ebs_baseline_bandwidth", false],
@@ -173,6 +175,8 @@ export function makePrettyNames<V>(
         makeColumnOption("storage", "Instance Storage"),
         makeColumnOption("warmed-up", "Instance Storage: already warmed-up"),
         makeColumnOption("trim-support", "Instance Storage: SSD TRIM Support"),
+        makeColumnOption("storage_read_iops", "Instance Store: Read IOPS"),
+        makeColumnOption("storage_write_iops", "Instance Store: Write IOPS"),
         makeColumnOption("arch", "Arch"),
         makeColumnOption("network_performance", "Network Performance"),
         makeColumnOption(

--- a/next/utils/ec2TablesGenerator.ts
+++ b/next/utils/ec2TablesGenerator.ts
@@ -299,6 +299,18 @@ export function ec2(instance: Omit<EC2Instance, "pricing">): Table[] {
                         instance.storage?.storage_needs_initialization ?? false,
                     bgStyled: true,
                 },
+                {
+                    name: "Instance Store Read IOPS",
+                    children: instance.storage?.storage_read_iops
+                        ? instance.storage.storage_read_iops.toLocaleString()
+                        : "N/A",
+                },
+                {
+                    name: "Instance Store Write IOPS",
+                    children: instance.storage?.storage_write_iops
+                        ? instance.storage.storage_write_iops.toLocaleString()
+                        : "N/A",
+                },
             ],
         },
         {

--- a/next/utils/golden/ec2.json
+++ b/next/utils/golden/ec2.json
@@ -202,6 +202,14 @@
                 "name": "Initialize Storage",
                 "children": false,
                 "bgStyled": true
+            },
+            {
+                "name": "Instance Store Read IOPS",
+                "children": "N/A"
+            },
+            {
+                "name": "Instance Store Write IOPS",
+                "children": "N/A"
             }
         ]
     },

--- a/scraper/aws/ec2/ec2_instance.go
+++ b/scraper/aws/ec2/ec2_instance.go
@@ -61,6 +61,12 @@ type Storage struct {
 	Devices                   int    `json:"devices"`
 	Size                      int    `json:"size"`
 	SizeUnit                  string `json:"size_unit"`
+	// StorageReadIops / StorageWriteIops are the instance-store random read/write
+	// IOPS sourced from the AWS instance-type docs (see iops.go). Pointers so that
+	// instances without a documented value omit the field entirely (frontend treats
+	// absent as "N/A") rather than reporting a fabricated 0.
+	StorageReadIops  *int `json:"storage_read_iops,omitempty"`
+	StorageWriteIops *int `json:"storage_write_iops,omitempty"`
 }
 
 type EC2Instance struct {

--- a/scraper/aws/ec2/iops.go
+++ b/scraper/aws/ec2/iops.go
@@ -1,0 +1,234 @@
+package ec2
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"scraper/utils"
+	"strconv"
+	"strings"
+)
+
+// AWS publishes per-family instance-type docs as markdown. Each doc contains an
+// "Instance store specifications" table with a "Random read IOPS / Random write
+// IOPS" column keyed by instance type. We scrape those tables to expose the
+// instance-store random read/write IOPS on each instance.
+const awsInstanceTypeDocBase = "https://docs.aws.amazon.com/ec2/latest/instancetypes"
+
+// iopsDocSlugs are the instance-type doc families that carry instance-store
+// specs (general purpose, compute, memory, storage, accelerated, HPC).
+var iopsDocSlugs = []string{"gp", "co", "mo", "so", "ac", "hpc"}
+
+var (
+	iopsHeaderRe     = regexp.MustCompile(`(?i)random read IOPS`)
+	instanceHeaderRe = regexp.MustCompile(`(?i)instance type`)
+	// instanceTypeRe matches a "." followed by a word char, the same heuristic
+	// the original Node scraper used to tell instance-type rows (e.g. "m5.large")
+	// apart from family-header rows.
+	instanceTypeRe = regexp.MustCompile(`\.\w`)
+)
+
+type storageIops struct {
+	readIops  int
+	writeIops int
+}
+
+// splitMarkdownRow splits a markdown table row into trimmed cells, dropping the
+// empty leading/trailing edges produced by the surrounding pipes.
+func splitMarkdownRow(line string) []string {
+	line = strings.TrimSpace(line)
+	line = strings.TrimPrefix(line, "|")
+	line = strings.TrimSuffix(line, "|")
+	parts := strings.Split(line, "|")
+	cells := make([]string, len(parts))
+	for i, p := range parts {
+		cells[i] = strings.TrimSpace(p)
+	}
+	return cells
+}
+
+// parseIopsValue mimics JS parseInt after stripping thousands separators: it
+// reads the leading (optionally signed) integer prefix and ignores any trailing
+// text. Returns ok=false when there is no leading integer.
+func parseIopsValue(s string) (int, bool) {
+	s = strings.ReplaceAll(strings.TrimSpace(s), ",", "")
+	end := 0
+	if end < len(s) && (s[end] == '+' || s[end] == '-') {
+		end++
+	}
+	start := end
+	for end < len(s) && s[end] >= '0' && s[end] <= '9' {
+		end++
+	}
+	if end == start {
+		return 0, false
+	}
+	n, err := strconv.Atoi(s[:end])
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// parseIopsTable parses the instance-store IOPS table out of one AWS
+// instance-type markdown doc, returning a lowercase-instance-type -> IOPS map.
+// It locates the table by its "Random read IOPS" header, then reads each data
+// row, skipping the separator row and family-header rows.
+func parseIopsTable(markdown string) map[string]storageIops {
+	lines := strings.Split(markdown, "\n")
+	inTable := false
+	iopsColIdx := -1
+	instanceColIdx := -1
+	results := map[string]storageIops{}
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "|") {
+			// A non-table line ends the table once we are inside one.
+			if inTable {
+				break
+			}
+			continue
+		}
+
+		cells := splitMarkdownRow(trimmed)
+
+		if !inTable {
+			for i, c := range cells {
+				if iopsHeaderRe.MatchString(c) {
+					iopsColIdx = i
+					break
+				}
+			}
+			if iopsColIdx == -1 {
+				continue
+			}
+			inTable = true
+			instanceColIdx = 0
+			for i, c := range cells {
+				if instanceHeaderRe.MatchString(c) {
+					instanceColIdx = i
+					break
+				}
+			}
+			continue
+		}
+
+		// Skip the header/body separator row (cells of only dashes).
+		if isSeparatorRow(cells) {
+			continue
+		}
+
+		// Skip family-header rows: a single non-empty cell that is not itself an
+		// instance type.
+		nonEmpty := make([]string, 0, len(cells))
+		for _, c := range cells {
+			if c != "" {
+				nonEmpty = append(nonEmpty, c)
+			}
+		}
+		if len(nonEmpty) <= 1 {
+			first := ""
+			if len(nonEmpty) == 1 {
+				first = nonEmpty[0]
+			}
+			if !instanceTypeRe.MatchString(first) {
+				continue
+			}
+		}
+
+		if instanceColIdx >= len(cells) || iopsColIdx >= len(cells) {
+			continue
+		}
+		instanceType := cells[instanceColIdx]
+		if instanceType == "" || !instanceTypeRe.MatchString(instanceType) {
+			continue
+		}
+
+		iopsCell := strings.TrimSpace(cells[iopsColIdx])
+		if iopsCell == "" {
+			continue
+		}
+		parts := strings.Split(iopsCell, "/")
+		if len(parts) != 2 {
+			continue
+		}
+		readIops, okRead := parseIopsValue(parts[0])
+		writeIops, okWrite := parseIopsValue(parts[1])
+		if !okRead || !okWrite {
+			continue
+		}
+
+		results[strings.ToLower(instanceType)] = storageIops{
+			readIops:  readIops,
+			writeIops: writeIops,
+		}
+	}
+
+	return results
+}
+
+// isSeparatorRow reports whether every cell consists solely of dashes (the
+// markdown header/body separator), e.g. "--- | ---".
+func isSeparatorRow(cells []string) bool {
+	for _, c := range cells {
+		if c == "" {
+			return false
+		}
+		for _, r := range c {
+			if r != '-' {
+				return false
+			}
+		}
+	}
+	return len(cells) > 0
+}
+
+// addStorageIopsInfo fetches the AWS instance-type docs, parses the
+// instance-store random read/write IOPS tables, and sets the values on each
+// matching instance that has instance storage. Instances without a documented
+// value are left untouched (no fabricated zeros). Fails loud on fetch errors or
+// when nothing parses/matches, so a broken scrape never ships empty data.
+func addStorageIopsInfo(instances map[string]*EC2Instance) {
+	log.Default().Println("Adding instance store IOPS to EC2")
+
+	allIops := map[string]storageIops{}
+	for _, slug := range iopsDocSlugs {
+		url := fmt.Sprintf("%s/%s.md", awsInstanceTypeDocBase, slug)
+		body, err := utils.FetchWithRetry(url, nil)
+		if err != nil {
+			log.Fatalln("Failed to fetch instance store IOPS doc", url, err)
+		}
+		parsed := parseIopsTable(string(body))
+		log.Default().Printf("%s.md: %d instance types with IOPS", slug, len(parsed))
+		for k, v := range parsed {
+			allIops[k] = v
+		}
+	}
+
+	if len(allIops) == 0 {
+		log.Fatalln("Parsed zero instance store IOPS entries across all docs")
+	}
+
+	matched := 0
+	for instanceType, instance := range instances {
+		iops, ok := allIops[strings.ToLower(instanceType)]
+		if !ok {
+			continue
+		}
+		if instance.Storage == nil {
+			continue
+		}
+		readIops := iops.readIops
+		writeIops := iops.writeIops
+		instance.Storage.StorageReadIops = &readIops
+		instance.Storage.StorageWriteIops = &writeIops
+		matched++
+	}
+
+	if matched == 0 {
+		log.Fatalln("Zero instances matched instance store IOPS data; IOPS entries:", len(allIops))
+	}
+
+	log.Default().Printf("Merged instance store IOPS into %d instances (of %d IOPS entries)", matched, len(allIops))
+}

--- a/scraper/aws/ec2/iops.go
+++ b/scraper/aws/ec2/iops.go
@@ -7,12 +7,15 @@ import (
 	"scraper/utils"
 	"strconv"
 	"strings"
+
+	"github.com/anaskhan96/soup"
 )
 
-// AWS publishes per-family instance-type docs as markdown. Each doc contains an
-// "Instance store specifications" table with a "Random read IOPS / Random write
-// IOPS" column keyed by instance type. We scrape those tables to expose the
-// instance-store random read/write IOPS on each instance.
+// AWS publishes per-family instance-type docs as markdown with embedded HTML
+// tables. Each doc contains an "Instance store specifications" table with a
+// "100% random read IOPS / Write IOPS" column keyed by instance type. We scrape
+// those tables to expose the instance-store random read/write IOPS on each
+// instance.
 const awsInstanceTypeDocBase = "https://docs.aws.amazon.com/ec2/latest/instancetypes"
 
 // iopsDocSlugs are the instance-type doc families that carry instance-store
@@ -31,6 +34,84 @@ var (
 type storageIops struct {
 	readIops  int
 	writeIops int
+}
+
+func parseIopsCells(instanceType, iopsCell string) (string, storageIops, bool) {
+	instanceType = strings.TrimSpace(instanceType)
+	if instanceType == "" || !instanceTypeRe.MatchString(instanceType) {
+		return "", storageIops{}, false
+	}
+
+	iopsCell = strings.TrimSpace(iopsCell)
+	if iopsCell == "" {
+		return "", storageIops{}, false
+	}
+	parts := strings.Split(iopsCell, "/")
+	if len(parts) != 2 {
+		return "", storageIops{}, false
+	}
+	readIops, okRead := parseIopsValue(parts[0])
+	writeIops, okWrite := parseIopsValue(parts[1])
+	if !okRead || !okWrite {
+		return "", storageIops{}, false
+	}
+
+	return strings.ToLower(instanceType), storageIops{
+		readIops:  readIops,
+		writeIops: writeIops,
+	}, true
+}
+
+func parseIopsHTMLTables(markdown string) map[string]storageIops {
+	doc := soup.HTMLParse(markdown)
+	results := map[string]storageIops{}
+
+	for _, table := range doc.FindAll("table") {
+		thead := table.Find("thead")
+		if thead.Error != nil {
+			continue
+		}
+		ths := thead.FindAll("th")
+		if len(ths) == 0 {
+			continue
+		}
+
+		iopsColIdx := -1
+		instanceColIdx := 0
+		for i, th := range ths {
+			text := strings.TrimSpace(th.FullText())
+			if iopsHeaderRe.MatchString(text) {
+				iopsColIdx = i
+			}
+			if instanceHeaderRe.MatchString(text) {
+				instanceColIdx = i
+			}
+		}
+		if iopsColIdx == -1 {
+			continue
+		}
+
+		tbody := table.Find("tbody")
+		if tbody.Error != nil {
+			continue
+		}
+		for _, tr := range tbody.FindAll("tr") {
+			tds := tr.FindAll("td")
+			if instanceColIdx >= len(tds) || iopsColIdx >= len(tds) {
+				continue
+			}
+			instanceType, iops, ok := parseIopsCells(
+				tds[instanceColIdx].FullText(),
+				tds[iopsColIdx].FullText(),
+			)
+			if !ok {
+				continue
+			}
+			results[instanceType] = iops
+		}
+	}
+
+	return results
 }
 
 // splitMarkdownRow splits a markdown table row into trimmed cells, dropping the
@@ -72,9 +153,14 @@ func parseIopsValue(s string) (int, bool) {
 
 // parseIopsTable parses the instance-store IOPS table out of one AWS
 // instance-type markdown doc, returning a lowercase-instance-type -> IOPS map.
-// It locates the table by its "Random read IOPS" header, then reads each data
-// row, skipping the separator row and family-header rows.
+// It first handles the current embedded-HTML AWS doc shape, then falls back to
+// the older pipe-table shape used by the original parser.
 func parseIopsTable(markdown string) map[string]storageIops {
+	htmlResults := parseIopsHTMLTables(markdown)
+	if len(htmlResults) > 0 {
+		return htmlResults
+	}
+
 	lines := strings.Split(markdown, "\n")
 	inTable := false
 	iopsColIdx := -1
@@ -140,29 +226,14 @@ func parseIopsTable(markdown string) map[string]storageIops {
 		if instanceColIdx >= len(cells) || iopsColIdx >= len(cells) {
 			continue
 		}
-		instanceType := cells[instanceColIdx]
-		if instanceType == "" || !instanceTypeRe.MatchString(instanceType) {
+		instanceType, iops, ok := parseIopsCells(
+			cells[instanceColIdx],
+			cells[iopsColIdx],
+		)
+		if !ok {
 			continue
 		}
-
-		iopsCell := strings.TrimSpace(cells[iopsColIdx])
-		if iopsCell == "" {
-			continue
-		}
-		parts := strings.Split(iopsCell, "/")
-		if len(parts) != 2 {
-			continue
-		}
-		readIops, okRead := parseIopsValue(parts[0])
-		writeIops, okWrite := parseIopsValue(parts[1])
-		if !okRead || !okWrite {
-			continue
-		}
-
-		results[strings.ToLower(instanceType)] = storageIops{
-			readIops:  readIops,
-			writeIops: writeIops,
-		}
+		results[instanceType] = iops
 	}
 
 	return results

--- a/scraper/aws/ec2/iops_test.go
+++ b/scraper/aws/ec2/iops_test.go
@@ -1,0 +1,61 @@
+package ec2
+
+import "testing"
+
+// sampleIopsDoc mirrors the shape of the AWS instance-type markdown docs: some
+// prose, then an "Instance store specifications" table whose IOPS column is
+// "Random read IOPS / Random write IOPS", interspersed with a family-header row
+// and a row without IOPS data.
+const sampleIopsDoc = `# Storage instances
+
+Some intro text that should be ignored.
+
+| Instance size | Instance store volumes | Random read IOPS / Random write IOPS |
+| --- | --- | --- |
+| Compute optimized | | |
+| c7gd.medium | 1 x 59 GB NVMe SSD | 16,250 / 13,750 |
+| c7gd.large | 1 x 118 GB NVMe SSD | 33,542 / 27,917 |
+| m7gd.large | 1 x 118 GB NVMe SSD | 33,542 IOPS / 27,917 IOPS |
+| no-iops.large | 1 x 100 GB NVMe SSD | |
+
+Trailing prose ends the table.
+`
+
+func TestParseIopsTable(t *testing.T) {
+	got := parseIopsTable(sampleIopsDoc)
+
+	want := map[string]storageIops{
+		"c7gd.medium": {readIops: 16250, writeIops: 13750},
+		"c7gd.large":  {readIops: 33542, writeIops: 27917},
+		"m7gd.large":  {readIops: 33542, writeIops: 27917},
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("parsed %d entries, want %d: %+v", len(got), len(want), got)
+	}
+	for instanceType, wantIops := range want {
+		gotIops, ok := got[instanceType]
+		if !ok {
+			t.Errorf("missing entry for %s", instanceType)
+			continue
+		}
+		if gotIops != wantIops {
+			t.Errorf("IOPS for %s = %+v, want %+v", instanceType, gotIops, wantIops)
+		}
+	}
+
+	// Family-header rows, separator rows, and rows without IOPS data must be
+	// skipped rather than producing fabricated entries.
+	for _, skipped := range []string{"compute optimized", "no-iops.large"} {
+		if _, ok := got[skipped]; ok {
+			t.Errorf("expected %q to be skipped, but it was parsed", skipped)
+		}
+	}
+}
+
+func TestParseIopsTableNoTable(t *testing.T) {
+	// A doc with no IOPS table must yield an empty map, not a panic.
+	if got := parseIopsTable("# No table here\n\nJust prose.\n"); len(got) != 0 {
+		t.Errorf("expected no entries for a doc without an IOPS table, got %+v", got)
+	}
+}

--- a/scraper/aws/ec2/iops_test.go
+++ b/scraper/aws/ec2/iops_test.go
@@ -21,15 +21,22 @@ Some intro text that should be ignored.
 Trailing prose ends the table.
 `
 
-func TestParseIopsTable(t *testing.T) {
-	got := parseIopsTable(sampleIopsDoc)
+const sampleIopsHTMLDoc = `# Storage instances
 
-	want := map[string]storageIops{
-		"c7gd.medium": {readIops: 16250, writeIops: 13750},
-		"c7gd.large":  {readIops: 33542, writeIops: 27917},
-		"m7gd.large":  {readIops: 33542, writeIops: 27917},
-	}
+<table>
+<thead>
+  <tr><th>Instance type</th><th>Instance store volumes</th><th>Instance store type</th><th>100% random read IOPS / Write IOPS</th><th>Needs initialization</th><th>TRIM support</th></tr>
+</thead>
+<tbody>
+  <tr><td>Compute optimized</td><td></td><td></td><td></td><td></td><td></td></tr>
+  <tr><td>i4i.large</td><td>1 x 468 GB</td><td>NVMe SSD</td><td>50,000 / 27,500</td><td></td><td>Yes</td></tr>
+  <tr><td>i4i.xlarge</td><td>1 x 937 GB</td><td>NVMe SSD</td><td>100,000 IOPS / 55,000 IOPS</td><td></td><td>Yes</td></tr>
+  <tr><td>no-iops.large</td><td>1 x 100 GB</td><td>NVMe SSD</td><td></td><td></td><td>Yes</td></tr>
+</tbody>
+</table>`
 
+func assertIopsTable(t *testing.T, got map[string]storageIops, want map[string]storageIops) {
+	t.Helper()
 	if len(got) != len(want) {
 		t.Fatalf("parsed %d entries, want %d: %+v", len(got), len(want), got)
 	}
@@ -43,14 +50,34 @@ func TestParseIopsTable(t *testing.T) {
 			t.Errorf("IOPS for %s = %+v, want %+v", instanceType, gotIops, wantIops)
 		}
 	}
-
-	// Family-header rows, separator rows, and rows without IOPS data must be
-	// skipped rather than producing fabricated entries.
 	for _, skipped := range []string{"compute optimized", "no-iops.large"} {
 		if _, ok := got[skipped]; ok {
 			t.Errorf("expected %q to be skipped, but it was parsed", skipped)
 		}
 	}
+}
+
+func TestParseIopsMarkdownTable(t *testing.T) {
+	got := parseIopsTable(sampleIopsDoc)
+
+	want := map[string]storageIops{
+		"c7gd.medium": {readIops: 16250, writeIops: 13750},
+		"c7gd.large":  {readIops: 33542, writeIops: 27917},
+		"m7gd.large":  {readIops: 33542, writeIops: 27917},
+	}
+
+	assertIopsTable(t, got, want)
+}
+
+func TestParseIopsHTMLTable(t *testing.T) {
+	got := parseIopsTable(sampleIopsHTMLDoc)
+
+	want := map[string]storageIops{
+		"i4i.large":  {readIops: 50000, writeIops: 27500},
+		"i4i.xlarge": {readIops: 100000, writeIops: 55000},
+	}
+
+	assertIopsTable(t, got, want)
 }
 
 func TestParseIopsTableNoTable(t *testing.T) {

--- a/scraper/aws/ec2/process_data.go
+++ b/scraper/aws/ec2/process_data.go
@@ -275,6 +275,9 @@ func processEC2Data(
 	// Add FPGA information for instances AWS does not report via the API
 	addFpgaInfo(instancesHashmap)
 
+	// Add instance store random read/write IOPS from the AWS instance-type docs
+	addStorageIopsInfo(instancesHashmap)
+
 	// Add placement group information
 	addPlacementGroupInfo(instancesHashmap)
 


### PR DESCRIPTION
## Summary
- Reapplies the storage IOPS changes from #946 after the revert in #948.
- Restores the EC2 instance-store read/write IOPS fields, frontend columns, detail rows, and Go scraper integration.

## Test plan
- Not run; this PR intentionally reapplies #946's changes for follow-up review/fixing.