### PR TITLE
 feat(ec2): max pods per instance type

### DIFF
--- a/next/components/IndividualColumnFilter.tsx
+++ b/next/components/IndividualColumnFilter.tsx
@@ -237,6 +237,7 @@ const exprColumns = [
     "ebs-max-bandwidth",
     "ebs-max-throughput",
     "ebs-iops",
+    "max_pods",
 ];
 
 export default function IndividualColumnFilter<Instance>({

--- a/next/types.ts
+++ b/next/types.ts
@@ -75,6 +75,7 @@ export interface EC2Instance {
     is_trunking_compatible?: boolean;
     branch_interface?: number;
     max_ecs_tasks?: number;
+    max_pods?: number;
     enhanced_networking: boolean;
     vpc_only: boolean;
     ipv6_support: boolean;

--- a/next/utils/colunnData/ec2/columns.tsx
+++ b/next/utils/colunnData/ec2/columns.tsx
@@ -1189,6 +1189,24 @@ export const columnsGen = (
         },
     },
     {
+        accessorKey: "max_pods",
+        header: "Max Pods",
+        id: "max_pods",
+        sortingFn: (rowA, rowB) => {
+            const valueA = rowA.original.max_pods;
+            const valueB = rowB.original.max_pods;
+            if (valueA === undefined) return 1;
+            if (valueB === undefined) return -1;
+            return valueA - valueB;
+        },
+        filterFn: expr,
+        cell: (info) => {
+            const value = info.getValue() as number | undefined;
+            if (value === undefined) return undefined;
+            return value;
+        },
+    },
+    {
         accessorKey: "vpc_only",
         header: "VPC Only",
         size: 110,

--- a/next/utils/colunnData/ec2/index.ts
+++ b/next/utils/colunnData/ec2/index.ts
@@ -109,6 +109,7 @@ const initialColumnsArr = [
     ["is_trunking_compatible", false],
     ["branch_interface", false],
     ["max_ecs_tasks", false],
+    ["max_pods", false],
 ] as const;
 
 export const initialColumnsValue: {
@@ -206,6 +207,7 @@ export function makePrettyNames<V>(
         makeColumnOption("is_trunking_compatible", "Trunking compatible"),
         makeColumnOption("branch_interface", "Branch interface"),
         makeColumnOption("max_ecs_tasks", "Max ECS Tasks"),
+        makeColumnOption("max_pods", "Max Pods"),
         makeColumnOption("vpc_only", "VPC Only"),
         makeColumnOption("ipv6_support", "IPv6 Support"),
         makeColumnOption("placement_group_support", "Placement Group Support"),

--- a/scraper/aws/ec2/ec2_instance.go
+++ b/scraper/aws/ec2/ec2_instance.go
@@ -137,6 +137,7 @@ type EC2Instance struct {
 	BranchInterface          *int                       `json:"branch_interface,omitempty"`
 	MaxECSTasks              *int                       `json:"max_ecs_tasks,omitempty"`
 	DateIntroduced           *string                    `json:"date_introduced,omitempty"`
+	MaxPods                  *int                       `json:"max_pods,omitempty"`
 }
 
 func avg(ints []int) *float64 {

--- a/scraper/aws/ec2/max_pods.go
+++ b/scraper/aws/ec2/max_pods.go
@@ -10,7 +10,7 @@ import (
 )
 
 const minExpectedEniMaxPodsEntries = 1000 // sanity floor
-const AWS_ENI_MAX_PODS = "https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/master/misc/eni-max-pods.txt"
+const eniMaxPodsURL = "https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/master/misc/eni-max-pods.txt"
 
 func parseMaxPodsTable(doc []byte) map[string]int {
 	instancesToPods := make(map[string]int)
@@ -42,7 +42,7 @@ func validateMaxPodsCount(n int) error {
 }
 
 func fetchMaxPods() (map[string]int, error) {
-	resp, err := utils.FetchWithRetry(AWS_ENI_MAX_PODS, nil)
+	resp, err := utils.FetchWithRetry(eniMaxPodsURL, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/scraper/aws/ec2/max_pods_test.go
+++ b/scraper/aws/ec2/max_pods_test.go
@@ -1,0 +1,130 @@
+package ec2
+
+import (
+	"strings"
+	"testing"
+)
+
+// sampleMaxPodsDoc mirrors the real eni-max-pods.txt shape: a license/header
+// comment block, ordinary "instance.type pods" data lines, and a trailing
+// newline (which produces an empty final line after splitting on "\n").
+const sampleMaxPodsDoc = `# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Mapping is calculated from AWS EC2 API using the following formula:
+#   # of ENI * (# of IPv4 per ENI - 1) + 2
+#
+a1.2xlarge 58
+a1.4xlarge 234
+a1.large 29
+c5.xlarge 58
+t3.small 11
+`
+
+func assertMaxPodsTable(t *testing.T, got map[string]int, want map[string]int) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("parsed %d entries, want %d: %+v", len(got), len(want), got)
+	}
+
+	for instanceType, wantPods := range want {
+		gotPods, ok := got[instanceType]
+		if !ok {
+			t.Errorf("missing entry for %s", instanceType)
+			continue
+		}
+		if gotPods != wantPods {
+			t.Errorf("pods for %s = %d, want %d", instanceType, gotPods, wantPods)
+		}
+	}
+}
+
+func TestParseMaxPodsTable(t *testing.T) {
+	got := parseMaxPodsTable([]byte(sampleMaxPodsDoc))
+	want := map[string]int{
+		"a1.2xlarge": 58,
+		"a1.4xlarge": 234,
+		"a1.large":   29,
+		"c5.xlarge":  58,
+		"t3.small":   11,
+	}
+	assertMaxPodsTable(t, got, want)
+}
+
+func TestParseMaxPodsTableSkipsCommentLines(t *testing.T) {
+	got := parseMaxPodsTable([]byte(sampleMaxPodsDoc))
+	for instanceType := range got {
+		if strings.Contains(instanceType, "#") {
+			t.Errorf("comment line leaked into results as key %q", instanceType)
+		}
+	}
+}
+
+func TestParseMaxPodsTableHandlesTrailingNewline(t *testing.T) {
+	doc := []byte("c5.xlarge 58\n")
+	got := parseMaxPodsTable(doc)
+	want := map[string]int{"c5.xlarge": 58}
+	assertMaxPodsTable(t, got, want)
+}
+
+func TestParseMaxPodsTableSkipsBlankLines(t *testing.T) {
+	doc := []byte("c5.xlarge 58\n\n\nt3.small 11\n")
+	got := parseMaxPodsTable(doc)
+	want := map[string]int{"c5.xlarge": 58, "t3.small": 11}
+	assertMaxPodsTable(t, got, want)
+}
+
+func TestParseMaxPodsTableSkipsMalformedLines(t *testing.T) {
+	doc := []byte("c5.xlarge 58\nmalformed line here\nlonelytoken\nt3.small 11\n")
+	got := parseMaxPodsTable(doc)
+	want := map[string]int{"c5.xlarge": 58, "t3.small": 11}
+	assertMaxPodsTable(t, got, want)
+}
+
+func TestParseMaxPodsTableSkipsNonNumericPods(t *testing.T) {
+	doc := []byte("c5.xlarge fifty-eight\nt3.small 11\n")
+	got := parseMaxPodsTable(doc)
+	want := map[string]int{"t3.small": 11}
+	assertMaxPodsTable(t, got, want)
+}
+
+func TestParseMaxPodsTableNoTable(t *testing.T) {
+	// A doc with only comments and blank lines must yield an empty map, not
+	// a panic.
+	if got := parseMaxPodsTable([]byte("# just a comment\n\n")); len(got) != 0 {
+		t.Errorf("expected no entries for a doc without data lines, got %+v", got)
+	}
+}
+
+func TestParseMaxPodsTableDuplicateInstanceType(t *testing.T) {
+	// If the same instance type appears twice, the later line wins (map
+	// semantics)
+	doc := []byte("c5.xlarge 58\nc5.xlarge 99\n")
+	got := parseMaxPodsTable(doc)
+	want := map[string]int{"c5.xlarge": 99}
+	assertMaxPodsTable(t, got, want)
+}
+
+func TestValidateMaxPodsCountZero(t *testing.T) {
+	if err := validateMaxPodsCount(0); err == nil {
+		t.Error("expected an error for zero entries, got nil")
+	}
+}
+
+func TestValidateMaxPodsCountBelowFloor(t *testing.T) {
+	if err := validateMaxPodsCount(minExpectedEniMaxPodsEntries - 1); err == nil {
+		t.Error("expected an error for a count just below the floor, got nil")
+	}
+}
+
+func TestValidateMaxPodsCountAtFloor(t *testing.T) {
+	if err := validateMaxPodsCount(minExpectedEniMaxPodsEntries); err != nil {
+		t.Errorf("expected no error exactly at the floor, got %v", err)
+	}
+}
+
+func TestValidateMaxPodsCountAboveFloor(t *testing.T) {
+	if err := validateMaxPodsCount(minExpectedEniMaxPodsEntries + 500); err != nil {
+		t.Errorf("expected no error comfortably above the floor, got %v", err)
+	}
+}

--- a/scraper/aws/ec2/pods.go
+++ b/scraper/aws/ec2/pods.go
@@ -1,0 +1,80 @@
+package ec2
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"scraper/utils"
+	"strconv"
+	"strings"
+)
+
+const minExpectedEniMaxPodsEntries = 1000 // sanity floor
+const AWS_ENI_MAX_PODS = "https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/master/misc/eni-max-pods.txt"
+
+func parseMaxPodsTable(doc []byte) map[string]int {
+	instancesToPods := make(map[string]int)
+	for line := range bytes.SplitSeq(doc, []byte("\n")) {
+		if bytes.Contains(line, []byte("#")) {
+			continue
+		}
+		instanceAndPods := bytes.Split(line, []byte(" "))
+		if len(instanceAndPods) != 2 {
+			continue
+		}
+		pods, err := strconv.Atoi(string(instanceAndPods[1]))
+		if err != nil {
+			continue
+		}
+		instancesToPods[string(instanceAndPods[0])] = pods
+	}
+	return instancesToPods
+}
+
+func validateMaxPodsCount(n int) error {
+	if n == 0 {
+		return fmt.Errorf("parsed zero eni-max-pods entries")
+	}
+	if n < minExpectedEniMaxPodsEntries {
+		return fmt.Errorf("parsed only %d eni-max-pods entries, expected at least %d", n, minExpectedEniMaxPodsEntries)
+	}
+	return nil
+}
+
+func fetchMaxPods() (map[string]int, error) {
+	resp, err := utils.FetchWithRetry(AWS_ENI_MAX_PODS, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	instancesToPods := parseMaxPodsTable(resp)
+
+	if err := validateMaxPodsCount(len(instancesToPods)); err != nil {
+		return nil, err
+	}
+
+	return instancesToPods, nil
+}
+
+func addMaxPodsInfo(instances map[string]*EC2Instance) {
+	log.Default().Println("Adding EKS max pods to EC2")
+
+	maxPods, err := fetchMaxPods()
+	if err != nil {
+		log.Fatalln("Failed to fetch EKS max pods data:", err)
+	}
+
+	matched := 0
+	for instanceName, instance := range instances {
+		if pods, ok := maxPods[strings.ToLower(instanceName)]; ok {
+			instance.MaxPods = &pods
+			matched++
+		}
+	}
+
+	if matched == 0 {
+		log.Fatalln("Zero instances matched EKS max pods data; entries:", len(maxPods))
+	}
+
+	log.Default().Printf("Merged EKS max pods into %d instances (of %d entries)", matched, len(maxPods))
+}

--- a/scraper/aws/ec2/process_data.go
+++ b/scraper/aws/ec2/process_data.go
@@ -297,8 +297,10 @@ func processEC2Data(
 	// Add VPC only instances
 	addVpcOnlyInstances(instancesHashmap)
 
+	// Add date introduced from instancetyp.es timeline
 	addDateIntroduced(instancesHashmap)
 
+	// Add max pods info
 	addMaxPodsInfo(instancesHashmap)
 
 	// Add savings plans pricing

--- a/scraper/aws/ec2/process_data.go
+++ b/scraper/aws/ec2/process_data.go
@@ -297,8 +297,9 @@ func processEC2Data(
 	// Add VPC only instances
 	addVpcOnlyInstances(instancesHashmap)
 
-	// Add date introduced from instancetyp.es timeline
 	addDateIntroduced(instancesHashmap)
+
+	addMaxPodsInfo(instancesHashmap)
 
 	// Add savings plans pricing
 	for region, skuMap := range savingsPlanData() {


### PR DESCRIPTION
## Summary

Adds a "Max Pods" column showing the maximum number of Kubernetes pods that can be scheduled on each EC2 instance type when used as an EKS node, closing #691.

## Changes

**Scraper (`scraper/aws/ec2/max_pods.go`)**
- Fetches AWS's `eni-max-pods.txt` (maintained in [aws/amazon-vpc-cni-k8s](https://github.com/aws/amazon-vpc-cni-k8s/blob/master/misc/eni-max-pods.txt)) and parses it into an `instance-type -> max-pods` map.
- Adds `MaxPods *int` to `EC2Instance` (`json:"max_pods,omitempty"`).
- Throws an error (`log.Fatalln`) if the fetch errors, if parsing yields zero entries, if the parsed count falls below a sanity floor (1000 — the real file currently has ~1,369 entries), or if zero instances end up matched.

**Why a lookup table instead of computing the formula ourselves**

AWS's own default formula is `(max_enis × (ips_per_eni − 1)) + 2`, and the site already stores `max_enis`/`ips_per_eni` per instance (see `VPC` struct). I was considered computing this client-side instead of scraping a second file, but per [#691's discussion thread](https://github.com/vantage-sh/ec2instances.info/issues/691#issuecomment-2117206743), the formula breaks down for "exotic" multi-network-card instance types (e.g. `p5.48xlarge`, `g7.48xlarge`, the `hpc7a` family). AWS's own file header confirms this explicitly: *"For multi-card instance types... the max limit is calculated only against the default network card at index (0)."* I verified this against the actual file: several large instance sizes report the *same or lower* max-pods value as a smaller sibling in the same family (e.g. `g7.24xlarge` → 1514 vs. `g7.48xlarge` → 758), which the formula would get wrong. Using AWS's maintained table avoids reproducing the edge-case logic..

**Frontend (`next/`)**
- New "Max Pods" column: numeric, sortable, filterable via the existing `expr` filter (registered in `exprColumns`).
- Registered in `initialColumnsArr` and `makePrettyNames`.

## Testing

- Unit tests (`max_pods_test.go`) cover: normal parsing, comment/header-line skipping, trailing-newline handling (the real file ends in `\n`, producing an empty final split), blank lines, malformed lines, non-numeric values, duplicate keys, and the sanity-floor boundary conditions.
- Manually verified a handful of parsed values against the live file (e.g. `t3.small` → 11) and against the AWS EKS docs' worked example.
- Manually tested the frontend column: sorting (both directions), filtering, and correct blank-cell handling for instance types absent from AWS's file.

## Known limitations

- Not every instance type appears in AWS's source file (very new or edge-case types); those simply show no value rather than a computed guess.

## Note
- Sorry for creating another PR and closing it! I accidentally targeted main and couldn't figure out how to set it to develop instead.

