### PR TITLE
feat: Add volume pricing to the API and site

### DIFF
--- a/next/components/Filters.tsx
+++ b/next/components/Filters.tsx
@@ -14,6 +14,7 @@ import {
     useColumnVisibility,
     useSelected,
     useCurrency,
+    useRequestedStorageGb,
 } from "@/state";
 import { pricingUnitOptions, durationOptions } from "@/utils/dataMappings";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -56,6 +57,8 @@ export default function Filters<DataKey extends keyof typeof columnData>({
     const [compareOn, setCompareOn] = useCompareOn(pathname);
     const [selected] = useSelected(pathname);
     const [currency, setCurrency] = useCurrency(pathname, currencies);
+    const [requestedStorageGb, setRequestedStorageGb] =
+        useRequestedStorageGb(pathname);
 
     const [frequentlyUsedRegions, setFrequentlyUsedRegions] = useState<{
         [key: string]: number;
@@ -242,6 +245,30 @@ export default function Filters<DataKey extends keyof typeof columnData>({
                         hideSearch={false}
                         small={true}
                     />
+                    <div className="d-flex flex-column gap-1">
+                        <label
+                            htmlFor="requested-storage-gb"
+                            className="text-xs text-gray-500"
+                        >
+                            Storage (GB)
+                        </label>
+                        <input
+                            id="requested-storage-gb"
+                            type="number"
+                            min={0}
+                            step={1}
+                            inputMode="numeric"
+                            value={requestedStorageGb || ""}
+                            onChange={(e) => {
+                                const v = Number(e.target.value);
+                                setRequestedStorageGb(
+                                    Number.isFinite(v) && v >= 0 ? v : 0,
+                                );
+                            }}
+                            placeholder="0"
+                            className="form-control p-1 border-gray-3 border rounded-md bg-background text-foreground w-24"
+                        />
+                    </div>
                     <ColumnFilter<DataKey>
                         // @ts-expect-error: TS doesn't like this for some reason.
                         columns={columnOptions}

--- a/next/components/InstanceTable.tsx
+++ b/next/components/InstanceTable.tsx
@@ -25,6 +25,7 @@ import {
     useSelected,
     useCurrency,
     currencyRateAtom,
+    useRequestedStorageGb,
 } from "@/state";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useCallback, useMemo, useRef } from "react";
@@ -96,6 +97,7 @@ export default function InstanceTable<
     const [selected, setSelected] = useSelected(pathname);
     const [sorting, setSorting] = useSorting(pathname);
     const [currency] = useCurrency(pathname);
+    const [requestedStorageGb] = useRequestedStorageGb(pathname);
     const conversionRate = currencyRateAtom.use();
 
     const columns = columnData[columnAtomKey].columnsGen(
@@ -108,6 +110,7 @@ export default function InstanceTable<
             usdRate: conversionRate.usd,
             cnyRate: conversionRate.cny,
         },
+        requestedStorageGb,
     );
     for (const col of columns) {
         col.sortUndefined = "last";

--- a/next/state.ts
+++ b/next/state.ts
@@ -99,6 +99,13 @@ export function useDuration(pathname: string) {
     ];
 }
 
+export function useRequestedStorageGb(pathname: string) {
+    return useGlobalStateValue("requestedStorageGb", pathname, 0) as readonly [
+        number,
+        (value: number) => void,
+    ];
+}
+
 export function useReservedTerm(pathname: string) {
     const defaultReservedTerm = pathname.includes("azure")
         ? "yrTerm1Standard.allUpfront"

--- a/next/types.ts
+++ b/next/types.ts
@@ -16,6 +16,13 @@ export interface Pricing {
     };
 }
 
+export type CostPerGb = {
+    baseline: number | { [platform: string]: number };
+    regions: {
+        [regionSlug: string]: number | { [platform: string]: number };
+    };
+};
+
 export interface EC2Instance {
     instance_type: string;
     family: string;
@@ -110,6 +117,7 @@ export interface EC2Instance {
     memory_per_numa_node_mb?: number | null;
     l3_per_numa_node_mb?: number | null;
     l3_shared?: boolean | null;
+    costPerGb?: CostPerGb;
 }
 
 export interface Region {

--- a/next/utils/colunnData/azure.tsx
+++ b/next/utils/colunnData/azure.tsx
@@ -6,7 +6,7 @@ import {
     expr,
     transformAllDataTables,
 } from "./shared";
-import { CostDuration } from "@/types";
+import { CostDuration, CostPerGb } from "@/types";
 import RegionLinkPreloader from "@/components/RegionLinkPreloader";
 import exprCompiler from "@/utils/expr";
 
@@ -56,6 +56,7 @@ export type AzureInstance = {
     rdma: boolean;
     storage?: Storage;
     ACU?: number;
+    costPerGb?: CostPerGb;
 };
 
 const initialColumnsArr = [

--- a/next/utils/colunnData/azure.tsx
+++ b/next/utils/colunnData/azure.tsx
@@ -5,6 +5,7 @@ import {
     makeCellWithRegexSorter,
     expr,
     transformAllDataTables,
+    getStorageHourlyAddon,
 } from "./shared";
 import { CostDuration, CostPerGb } from "@/types";
 import RegionLinkPreloader from "@/components/RegionLinkPreloader";
@@ -125,6 +126,7 @@ function calculateCost(
     pricingUnit: PricingUnit,
     costDuration: CostDuration,
     usdRate: number,
+    storageHourlyAddon: number = 0,
 ): number {
     if (!price) return -1;
 
@@ -151,9 +153,8 @@ function calculateCost(
         ] as number;
     }
 
-    return (
-        ((Number(price) * durationMultiplier) / pricingUnitModifier) * usdRate
-    );
+    const hourlyTotal = Number(price) + storageHourlyAddon;
+    return ((hourlyTotal * durationMultiplier) / pricingUnitModifier) * usdRate;
 }
 
 export function calculateAndFormatCost(
@@ -165,6 +166,7 @@ export function calculateAndFormatCost(
         code: string;
         usdRate: number;
     },
+    storageHourlyAddon: number = 0,
 ): string | undefined {
     const perTime = calculateCost(
         price,
@@ -172,6 +174,7 @@ export function calculateAndFormatCost(
         pricingUnit,
         costDuration,
         currency.usdRate,
+        storageHourlyAddon,
     );
     if (perTime === -1) return undefined;
 
@@ -213,7 +216,14 @@ function getPricingSorter(
         code: string;
         usdRate: number;
     },
+    requestedStorageGb: number,
 ) {
+    const storageAddonFor = (instance: { costPerGb?: CostPerGb }) =>
+        getStorageHourlyAddon(
+            instance.costPerGb,
+            requestedStorageGb,
+            selectedRegion,
+        );
     return {
         sortingFn: (rowA, rowB) => {
             const valueA = calculateCost(
@@ -222,6 +232,7 @@ function getPricingSorter(
                 pricingUnit,
                 costDuration,
                 currency.usdRate,
+                storageAddonFor(rowA.original),
             );
             const valueB = calculateCost(
                 getter(rowB.original.pricing?.[selectedRegion]),
@@ -229,6 +240,7 @@ function getPricingSorter(
                 pricingUnit,
                 costDuration,
                 currency.usdRate,
+                storageAddonFor(rowB.original),
             );
             return valueA - valueB;
         },
@@ -242,6 +254,7 @@ function getPricingSorter(
                 pricingUnit,
                 costDuration,
                 currency.usdRate,
+                storageAddonFor(row),
             );
             return value === -1 ? undefined : value;
         },
@@ -249,15 +262,62 @@ function getPricingSorter(
             const pricing = info.row.original.pricing;
             const price = getter(pricing?.[selectedRegion]);
             if (isNaN(Number(price))) return undefined;
-            return calculateAndFormatCost(
+            const addon = storageAddonFor(info.row.original);
+            const formatted = calculateAndFormatCost(
                 price,
                 info.row.original,
                 pricingUnit,
                 costDuration,
                 currency,
+                addon,
+            );
+            if (!formatted || addon <= 0) return formatted;
+            return renderWithStorageIndicator(
+                formatted,
+                Number(price),
+                addon,
+                requestedStorageGb,
+                info.row.original.costPerGb,
+                selectedRegion,
             );
         }),
     } satisfies Partial<ColumnDef<AzureInstance>>;
+}
+
+function renderWithStorageIndicator(
+    formatted: string,
+    computePriceUsdHr: number,
+    storageHourlyAddon: number,
+    requestedStorageGb: number,
+    costPerGb: CostPerGb | undefined,
+    selectedRegion: string,
+) {
+    const fmt = Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency: "USD",
+        maximumFractionDigits: 6,
+    });
+    const baseline = (() => {
+        if (!costPerGb) return 0;
+        const b = costPerGb.baseline;
+        if (typeof b === "number") return b;
+        let min = Infinity;
+        for (const k in b) if (b[k] < min) min = b[k];
+        return min === Infinity ? 0 : min;
+    })();
+    const extraGb = Math.max(0, requestedStorageGb - baseline);
+    const tooltip =
+        `Compute: ${fmt.format(computePriceUsdHr)}/hr\n` +
+        `Storage: ${fmt.format(storageHourlyAddon)}/hr` +
+        ` (${extraGb} GB × storage rate, ${selectedRegion})`;
+    return (
+        <span
+            title={tooltip}
+            className="border-b border-dotted border-current cursor-help"
+        >
+            {formatted}
+        </span>
+    );
 }
 
 export const columnsGen = (
@@ -270,6 +330,7 @@ export const columnsGen = (
         usdRate: number;
         cnyRate: number;
     },
+    requestedStorageGb: number,
 ): ColumnDef<AzureInstance>[] => {
     const savingsKey = reservedTerm.replace("Standard", "Savings");
 
@@ -401,6 +462,7 @@ export const columnsGen = (
                 costDuration,
                 (pricing) => pricing?.linux?.ondemand,
                 currency,
+                requestedStorageGb,
             ),
         },
         {
@@ -413,6 +475,7 @@ export const columnsGen = (
                 costDuration,
                 (pricing) => pricing?.linux?.reserved?.[savingsKey],
                 currency,
+                requestedStorageGb,
             ),
         },
         {
@@ -425,6 +488,7 @@ export const columnsGen = (
                 costDuration,
                 (pricing) => pricing?.linux?.reserved?.[reservedTerm],
                 currency,
+                requestedStorageGb,
             ),
         },
         {
@@ -437,6 +501,7 @@ export const columnsGen = (
                 costDuration,
                 (pricing) => pricing?.linux?.spot_min,
                 currency,
+                requestedStorageGb,
             ),
         },
         {
@@ -449,6 +514,7 @@ export const columnsGen = (
                 costDuration,
                 (pricing) => pricing?.windows?.ondemand,
                 currency,
+                requestedStorageGb,
             ),
         },
         {
@@ -461,6 +527,7 @@ export const columnsGen = (
                 costDuration,
                 (pricing) => pricing?.windows?.reserved?.[savingsKey],
                 currency,
+                requestedStorageGb,
             ),
         },
         {
@@ -473,6 +540,7 @@ export const columnsGen = (
                 costDuration,
                 (pricing) => pricing?.windows?.reserved?.[reservedTerm],
                 currency,
+                requestedStorageGb,
             ),
         },
         {
@@ -485,6 +553,7 @@ export const columnsGen = (
                 costDuration,
                 (pricing) => pricing?.windows?.spot_min,
                 currency,
+                requestedStorageGb,
             ),
         },
     ];

--- a/next/utils/colunnData/cache.tsx
+++ b/next/utils/colunnData/cache.tsx
@@ -70,6 +70,7 @@ export const columnsGen = (
         usdRate: number;
         cnyRate: number;
     },
+    requestedStorageGb: number,
 ): ColumnDef<EC2Instance>[] => [
     {
         accessorKey: "pretty_name",
@@ -148,6 +149,7 @@ export const columnsGen = (
             (pricing) => pricing?.Redis?.ondemand,
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -161,6 +163,7 @@ export const columnsGen = (
             (pricing) => pricing?.Redis?.reserved?.[reservedTerm],
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -174,6 +177,7 @@ export const columnsGen = (
             (pricing) => pricing?.Memcached?.ondemand,
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -187,6 +191,7 @@ export const columnsGen = (
             (pricing) => pricing?.Memcached?.reserved?.[reservedTerm],
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -200,6 +205,7 @@ export const columnsGen = (
             (pricing) => pricing?.Valkey?.ondemand,
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -213,6 +219,7 @@ export const columnsGen = (
             (pricing) => pricing?.Valkey?.reserved?.[reservedTerm],
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {

--- a/next/utils/colunnData/ec2/columns.tsx
+++ b/next/utils/colunnData/ec2/columns.tsx
@@ -1,4 +1,10 @@
-import { CostDuration, CostPerGb, EC2Instance, Pricing, PricingUnit } from "@/types";
+import {
+    CostDuration,
+    CostPerGb,
+    EC2Instance,
+    Pricing,
+    PricingUnit,
+} from "@/types";
 import { ColumnDef } from "@tanstack/react-table";
 import RegionLinkPreloader from "@/components/RegionLinkPreloader";
 import { ClockFadingIcon } from "lucide-react";

--- a/next/utils/colunnData/ec2/columns.tsx
+++ b/next/utils/colunnData/ec2/columns.tsx
@@ -1,9 +1,14 @@
-import { CostDuration, EC2Instance, Pricing, PricingUnit } from "@/types";
+import { CostDuration, CostPerGb, EC2Instance, Pricing, PricingUnit } from "@/types";
 import { ColumnDef } from "@tanstack/react-table";
 import RegionLinkPreloader from "@/components/RegionLinkPreloader";
 import { ClockFadingIcon } from "lucide-react";
 import sortByInstanceType from "@/utils/sortByInstanceType";
-import { regex, makeCellWithRegexSorter, expr } from "../shared";
+import {
+    regex,
+    makeCellWithRegexSorter,
+    expr,
+    getStorageHourlyAddon,
+} from "../shared";
 import exprCompiler from "@/utils/expr";
 
 interface Storage {
@@ -29,6 +34,7 @@ export function calculateCost(
         usdRate: number;
         cnyRate: number;
     },
+    storageHourlyAddon: number = 0,
 ): number {
     if (!price) return -1;
 
@@ -65,8 +71,9 @@ export function calculateCost(
         ? currency.cnyRate
         : currency.usdRate;
 
+    const hourlyTotal = Number(price) + storageHourlyAddon;
     return (
-        ((Number(price) * durationMultiplier) / pricingUnitModifier) *
+        ((hourlyTotal * durationMultiplier) / pricingUnitModifier) *
         currencyMultiplier
     );
 }
@@ -84,6 +91,7 @@ export function calculateAndFormatCost(
         usdRate: number;
         cnyRate: number;
     },
+    storageHourlyAddon: number = 0,
 ): string | undefined {
     const perTime = calculateCost(
         price,
@@ -92,6 +100,7 @@ export function calculateAndFormatCost(
         costDuration,
         selectedRegion,
         currency,
+        storageHourlyAddon,
     );
     if (perTime === -1) return undefined;
 
@@ -135,7 +144,15 @@ export function getPricingSorter(
         usdRate: number;
         cnyRate: number;
     },
+    requestedStorageGb: number = 0,
 ) {
+    const storageAddonFor = (instance: { costPerGb?: CostPerGb }) =>
+        getStorageHourlyAddon(
+            instance.costPerGb,
+            requestedStorageGb,
+            selectedRegion,
+        );
+
     return {
         sortingFn: (rowA, rowB) => {
             if (!convertToPrice) {
@@ -154,6 +171,7 @@ export function getPricingSorter(
                 costDuration,
                 selectedRegion,
                 currency,
+                storageAddonFor(rowA.original),
             );
             const valueB = calculateCost(
                 getter(rowB.original.pricing?.[selectedRegion]),
@@ -162,6 +180,7 @@ export function getPricingSorter(
                 costDuration,
                 selectedRegion,
                 currency,
+                storageAddonFor(rowB.original),
             );
             return valueA - valueB;
         },
@@ -176,6 +195,7 @@ export function getPricingSorter(
                 costDuration,
                 selectedRegion,
                 currency,
+                storageAddonFor(row),
             );
             return value === -1 ? undefined : value;
         },
@@ -184,16 +204,63 @@ export function getPricingSorter(
             if (!convertToPrice) return getter(pricing?.[selectedRegion]);
             const price = getter(pricing?.[selectedRegion]);
             if (isNaN(Number(price)) || price === "0") return undefined;
-            return calculateAndFormatCost(
+            const addon = storageAddonFor(info.row.original);
+            const formatted = calculateAndFormatCost(
                 price,
                 info.row.original,
                 pricingUnit,
                 costDuration,
                 selectedRegion,
                 currency,
+                addon,
+            );
+            if (!formatted || addon <= 0) return formatted;
+            return renderWithStorageIndicator(
+                formatted,
+                price!,
+                addon,
+                requestedStorageGb,
+                info.row.original.costPerGb,
+                selectedRegion,
             );
         }),
     } satisfies Partial<ColumnDef<EC2Instance>>;
+}
+
+function renderWithStorageIndicator(
+    formatted: string,
+    computePriceUsdHr: string,
+    storageHourlyAddon: number,
+    requestedStorageGb: number,
+    costPerGb: CostPerGb | undefined,
+    selectedRegion: string,
+) {
+    const computeFmt = Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency: "USD",
+        maximumFractionDigits: 6,
+    });
+    const baseline = (() => {
+        if (!costPerGb) return 0;
+        const b = costPerGb.baseline;
+        if (typeof b === "number") return b;
+        let min = Infinity;
+        for (const k in b) if (b[k] < min) min = b[k];
+        return min === Infinity ? 0 : min;
+    })();
+    const extraGb = Math.max(0, requestedStorageGb - baseline);
+    const tooltip =
+        `Compute: ${computeFmt.format(Number(computePriceUsdHr))}/hr\n` +
+        `Storage: ${computeFmt.format(storageHourlyAddon)}/hr` +
+        ` (${extraGb} GB × storage rate, ${selectedRegion})`;
+    return (
+        <span
+            title={tooltip}
+            className="border-b border-dotted border-current cursor-help"
+        >
+            {formatted}
+        </span>
+    );
 }
 
 function formatStorage(
@@ -222,6 +289,7 @@ export const columnsGen = (
         usdRate: number;
         cnyRate: number;
     },
+    requestedStorageGb: number,
 ): ColumnDef<EC2Instance>[] => [
     {
         accessorKey: "pretty_name",
@@ -1271,6 +1339,7 @@ export const columnsGen = (
             },
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -1287,6 +1356,7 @@ export const columnsGen = (
             },
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -1301,6 +1371,7 @@ export const columnsGen = (
             (pricing) => pricing?.linux?.spot_min,
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -1315,6 +1386,7 @@ export const columnsGen = (
             (pricing) => pricing?.linux?.spot_avg,
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -1329,6 +1401,7 @@ export const columnsGen = (
             (pricing) => pricing?.rhel?.ondemand,
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -1342,6 +1415,7 @@ export const columnsGen = (
             (pricing) => pricing?.rhel?.reserved?.[reservedTerm],
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -1355,6 +1429,7 @@ export const columnsGen = (
             (pricing) => pricing?.rhel?.spot_min,
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -1368,6 +1443,7 @@ export const columnsGen = (
             (pricing) => pricing?.rhel?.spot_max,
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -1381,6 +1457,7 @@ export const columnsGen = (
             (pricing) => pricing?.rhelHA?.ondemand,
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -1394,6 +1471,7 @@ export const columnsGen = (
             (pricing) => pricing?.rhelHA?.reserved?.[reservedTerm],
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -1407,6 +1485,7 @@ export const columnsGen = (
             (pricing) => pricing?.rhelHA?.spot_min,
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -1420,6 +1499,7 @@ export const columnsGen = (
             (pricing) => pricing?.rhelHA?.spot_max,
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -1433,6 +1513,7 @@ export const columnsGen = (
             (pricing) => pricing?.sles?.ondemand,
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -1446,6 +1527,7 @@ export const columnsGen = (
             (pricing) => pricing?.sles?.reserved?.[reservedTerm],
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -1459,6 +1541,7 @@ export const columnsGen = (
             (pricing) => pricing?.sles?.spot_min,
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -1472,6 +1555,7 @@ export const columnsGen = (
             (pricing) => pricing?.sles?.spot_max,
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -1485,6 +1569,7 @@ export const columnsGen = (
             (pricing) => pricing?.mswin?.ondemand,
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -1498,6 +1583,7 @@ export const columnsGen = (
             (pricing) => pricing?.mswin?.reserved?.[reservedTerm],
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -1511,6 +1597,7 @@ export const columnsGen = (
             (pricing) => pricing?.mswin?.spot_min,
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -1524,6 +1611,7 @@ export const columnsGen = (
             (pricing) => pricing?.mswin?.spot_avg,
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -1537,6 +1625,7 @@ export const columnsGen = (
             (pricing) => pricing?.dedicated?.ondemand,
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -1550,6 +1639,7 @@ export const columnsGen = (
             (pricing) => pricing?.dedicated?.reserved?.[reservedTerm],
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -1563,6 +1653,7 @@ export const columnsGen = (
             (pricing) => pricing?.mswinSQLWeb?.ondemand,
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -1576,6 +1667,7 @@ export const columnsGen = (
             (pricing) => pricing?.mswinSQLWeb?.reserved?.[reservedTerm],
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -1589,6 +1681,7 @@ export const columnsGen = (
             (pricing) => pricing?.mswinSQL?.ondemand,
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -1602,6 +1695,7 @@ export const columnsGen = (
             (pricing) => pricing?.mswinSQL?.reserved?.[reservedTerm],
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -1615,6 +1709,7 @@ export const columnsGen = (
             (pricing) => pricing?.mswinSQLEnterprise?.ondemand,
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -1628,6 +1723,7 @@ export const columnsGen = (
             (pricing) => pricing?.mswinSQLEnterprise?.reserved?.[reservedTerm],
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -1641,6 +1737,7 @@ export const columnsGen = (
             (pricing) => pricing?.linuxSQLWeb?.ondemand,
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -1654,6 +1751,7 @@ export const columnsGen = (
             (pricing) => pricing?.linuxSQLWeb?.reserved?.[reservedTerm],
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -1667,6 +1765,7 @@ export const columnsGen = (
             (pricing) => pricing?.linuxSQL?.ondemand,
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -1680,6 +1779,7 @@ export const columnsGen = (
             (pricing) => pricing?.linuxSQL?.reserved?.[reservedTerm],
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -1693,6 +1793,7 @@ export const columnsGen = (
             (pricing) => pricing?.linuxSQLEnterprise?.ondemand,
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -1706,6 +1807,7 @@ export const columnsGen = (
             (pricing) => pricing?.linuxSQLEnterprise?.reserved?.[reservedTerm],
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -1733,6 +1835,7 @@ export const columnsGen = (
             (pricing) => pricing?.emr?.emr,
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {

--- a/next/utils/colunnData/gcp.tsx
+++ b/next/utils/colunnData/gcp.tsx
@@ -6,7 +6,7 @@ import {
     expr,
     transformAllDataTables,
 } from "./shared";
-import { CostDuration } from "@/types";
+import { CostDuration, CostPerGb } from "@/types";
 import RegionLinkPreloader from "@/components/RegionLinkPreloader";
 import exprCompiler from "@/utils/expr";
 
@@ -42,6 +42,7 @@ export type GCPInstance = {
     compute_optimized?: boolean;
     memory_optimized?: boolean;
     accelerator_type?: string;
+    costPerGb?: CostPerGb;
 };
 
 const initialColumnsArr = [

--- a/next/utils/colunnData/gcp.tsx
+++ b/next/utils/colunnData/gcp.tsx
@@ -5,6 +5,7 @@ import {
     makeCellWithRegexSorter,
     expr,
     transformAllDataTables,
+    getStorageHourlyAddon,
 } from "./shared";
 import { CostDuration, CostPerGb } from "@/types";
 import RegionLinkPreloader from "@/components/RegionLinkPreloader";
@@ -111,6 +112,7 @@ function calculateCost(
     pricingUnit: PricingUnit,
     costDuration: CostDuration,
     usdRate: number,
+    storageHourlyAddon: number = 0,
 ): number {
     if (!price) return -1;
 
@@ -133,9 +135,8 @@ function calculateCost(
         ] as number;
     }
 
-    return (
-        ((Number(price) * durationMultiplier) / pricingUnitModifier) * usdRate
-    );
+    const hourlyTotal = Number(price) + storageHourlyAddon;
+    return ((hourlyTotal * durationMultiplier) / pricingUnitModifier) * usdRate;
 }
 
 export function calculateAndFormatCost(
@@ -147,6 +148,7 @@ export function calculateAndFormatCost(
         code: string;
         usdRate: number;
     },
+    storageHourlyAddon: number = 0,
 ): string | undefined {
     const perTime = calculateCost(
         price,
@@ -154,6 +156,7 @@ export function calculateAndFormatCost(
         pricingUnit,
         costDuration,
         currency.usdRate,
+        storageHourlyAddon,
     );
     if (perTime === -1) return undefined;
 
@@ -195,7 +198,14 @@ function getPricingSorter(
         code: string;
         usdRate: number;
     },
+    requestedStorageGb: number,
 ) {
+    const storageAddonFor = (instance: { costPerGb?: CostPerGb }) =>
+        getStorageHourlyAddon(
+            instance.costPerGb,
+            requestedStorageGb,
+            selectedRegion,
+        );
     return {
         sortingFn: (rowA, rowB) => {
             const valueA = calculateCost(
@@ -204,6 +214,7 @@ function getPricingSorter(
                 pricingUnit,
                 costDuration,
                 currency.usdRate,
+                storageAddonFor(rowA.original),
             );
             const valueB = calculateCost(
                 getter(rowB.original.pricing?.[selectedRegion]),
@@ -211,6 +222,7 @@ function getPricingSorter(
                 pricingUnit,
                 costDuration,
                 currency.usdRate,
+                storageAddonFor(rowB.original),
             );
             return valueA - valueB;
         },
@@ -224,6 +236,7 @@ function getPricingSorter(
                 pricingUnit,
                 costDuration,
                 currency.usdRate,
+                storageAddonFor(row),
             );
             return value === -1 ? undefined : value;
         },
@@ -231,15 +244,62 @@ function getPricingSorter(
             const pricing = info.row.original.pricing;
             const price = getter(pricing?.[selectedRegion]);
             if (isNaN(Number(price))) return undefined;
-            return calculateAndFormatCost(
+            const addon = storageAddonFor(info.row.original);
+            const formatted = calculateAndFormatCost(
                 price,
                 info.row.original,
                 pricingUnit,
                 costDuration,
                 currency,
+                addon,
+            );
+            if (!formatted || addon <= 0) return formatted;
+            return renderWithStorageIndicator(
+                formatted,
+                Number(price),
+                addon,
+                requestedStorageGb,
+                info.row.original.costPerGb,
+                selectedRegion,
             );
         }),
     } satisfies Partial<ColumnDef<GCPInstance>>;
+}
+
+function renderWithStorageIndicator(
+    formatted: string,
+    computePriceUsdHr: number,
+    storageHourlyAddon: number,
+    requestedStorageGb: number,
+    costPerGb: CostPerGb | undefined,
+    selectedRegion: string,
+) {
+    const fmt = Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency: "USD",
+        maximumFractionDigits: 6,
+    });
+    const baseline = (() => {
+        if (!costPerGb) return 0;
+        const b = costPerGb.baseline;
+        if (typeof b === "number") return b;
+        let min = Infinity;
+        for (const k in b) if (b[k] < min) min = b[k];
+        return min === Infinity ? 0 : min;
+    })();
+    const extraGb = Math.max(0, requestedStorageGb - baseline);
+    const tooltip =
+        `Compute: ${fmt.format(computePriceUsdHr)}/hr\n` +
+        `Storage: ${fmt.format(storageHourlyAddon)}/hr` +
+        ` (${extraGb} GB × storage rate, ${selectedRegion})`;
+    return (
+        <span
+            title={tooltip}
+            className="border-b border-dotted border-current cursor-help"
+        >
+            {formatted}
+        </span>
+    );
 }
 
 export const columnsGen = (
@@ -252,6 +312,7 @@ export const columnsGen = (
         usdRate: number;
         cnyRate: number;
     },
+    requestedStorageGb: number,
 ): ColumnDef<GCPInstance>[] => {
     return [
         {
@@ -390,6 +451,7 @@ export const columnsGen = (
                 costDuration,
                 (pricing) => pricing?.linux?.ondemand,
                 currency,
+                requestedStorageGb,
             ),
         },
         {
@@ -402,6 +464,7 @@ export const columnsGen = (
                 costDuration,
                 (pricing) => pricing?.linux?.cud_1yr,
                 currency,
+                requestedStorageGb,
             ),
         },
         {
@@ -414,6 +477,7 @@ export const columnsGen = (
                 costDuration,
                 (pricing) => pricing?.linux?.cud_3yr,
                 currency,
+                requestedStorageGb,
             ),
         },
         {
@@ -426,6 +490,7 @@ export const columnsGen = (
                 costDuration,
                 (pricing) => pricing?.linux?.spot,
                 currency,
+                requestedStorageGb,
             ),
         },
         {
@@ -438,6 +503,7 @@ export const columnsGen = (
                 costDuration,
                 (pricing) => pricing?.windows?.ondemand,
                 currency,
+                requestedStorageGb,
             ),
         },
         {
@@ -450,6 +516,7 @@ export const columnsGen = (
                 costDuration,
                 (pricing) => pricing?.windows?.spot,
                 currency,
+                requestedStorageGb,
             ),
         },
     ];

--- a/next/utils/colunnData/opensearch.tsx
+++ b/next/utils/colunnData/opensearch.tsx
@@ -1,4 +1,4 @@
-import { CostDuration, PricingUnit } from "@/types";
+import { CostDuration, CostPerGb, PricingUnit } from "@/types";
 import {
     calculateCost,
     calculateCostNumeric,
@@ -31,6 +31,7 @@ export type Instance = {
     currentGeneration: string;
     family: string;
     memory: string;
+    costPerGb?: CostPerGb;
 };
 
 const initialColumnsArr = [

--- a/next/utils/colunnData/opensearch.tsx
+++ b/next/utils/colunnData/opensearch.tsx
@@ -6,6 +6,7 @@ import {
     makeCellWithRegexSorter,
     expr,
     transformAllDataTables,
+    getStorageHourlyAddon,
 } from "./shared";
 import { ColumnDef } from "@tanstack/react-table";
 import RegionLinkPreloader from "@/components/RegionLinkPreloader";
@@ -90,7 +91,14 @@ function getPricingSorter(
         usdRate: number;
         cnyRate: number;
     },
+    requestedStorageGb: number,
 ) {
+    const storageAddonFor = (instance: { costPerGb?: CostPerGb }) =>
+        getStorageHourlyAddon(
+            instance.costPerGb,
+            requestedStorageGb,
+            selectedRegion,
+        );
     return {
         sortingFn: "basic" as const,
         sortUndefined: "last",
@@ -104,22 +112,70 @@ function getPricingSorter(
                 costDuration,
                 selectedRegion,
                 currency,
+                storageAddonFor(row),
             );
         },
         ...makeCellWithRegexSorter("pricing", (info) => {
             const pricing = info.row.original.pricing;
             const price = getter(pricing?.[selectedRegion]);
             if (isNaN(Number(price)) || !price) return undefined;
-            return calculateCost(
+            const addon = storageAddonFor(info.row.original);
+            const formatted = calculateCost(
                 price,
                 info.row.original,
                 pricingUnit,
                 costDuration,
                 selectedRegion,
                 currency,
+                addon,
+            );
+            if (addon <= 0) return formatted;
+            return renderWithStorageIndicator(
+                formatted,
+                price,
+                addon,
+                requestedStorageGb,
+                info.row.original.costPerGb,
+                selectedRegion,
             );
         }),
     } satisfies Partial<ColumnDef<Instance>>;
+}
+
+function renderWithStorageIndicator(
+    formatted: string,
+    computePriceUsdHr: string,
+    storageHourlyAddon: number,
+    requestedStorageGb: number,
+    costPerGb: CostPerGb | undefined,
+    selectedRegion: string,
+) {
+    const fmt = Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency: "USD",
+        maximumFractionDigits: 6,
+    });
+    const baseline = (() => {
+        if (!costPerGb) return 0;
+        const b = costPerGb.baseline;
+        if (typeof b === "number") return b;
+        let min = Infinity;
+        for (const k in b) if (b[k] < min) min = b[k];
+        return min === Infinity ? 0 : min;
+    })();
+    const extraGb = Math.max(0, requestedStorageGb - baseline);
+    const tooltip =
+        `Compute: ${fmt.format(Number(computePriceUsdHr))}/hr\n` +
+        `Storage: ${fmt.format(storageHourlyAddon)}/hr` +
+        ` (${extraGb} GB × storage rate, ${selectedRegion})`;
+    return (
+        <span
+            title={tooltip}
+            className="border-b border-dotted border-current cursor-help"
+        >
+            {formatted}
+        </span>
+    );
 }
 
 export const columnsGen = (
@@ -132,6 +188,7 @@ export const columnsGen = (
         usdRate: number;
         cnyRate: number;
     },
+    requestedStorageGb: number,
 ): ColumnDef<Instance>[] => [
     {
         accessorKey: "pretty_name",
@@ -212,6 +269,7 @@ export const columnsGen = (
             costDuration,
             (pricing) => pricing?.ondemand,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -224,6 +282,7 @@ export const columnsGen = (
             costDuration,
             (pricing) => pricing?.reserved?.[reservedTerm],
             currency,
+            requestedStorageGb,
         ),
     },
     {

--- a/next/utils/colunnData/rds.tsx
+++ b/next/utils/colunnData/rds.tsx
@@ -159,6 +159,7 @@ export const columnsGen = (
         usdRate: number;
         cnyRate: number;
     },
+    requestedStorageGb: number,
 ): ColumnDef<EC2Instance>[] => [
     {
         header: "Name",
@@ -277,6 +278,7 @@ export const columnsGen = (
             (pricing) => pricing?.["14"]?.ondemand,
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -290,6 +292,7 @@ export const columnsGen = (
             (pricing) => pricing?.["14"]?.reserved?.[reservedTerm],
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -303,6 +306,7 @@ export const columnsGen = (
             (pricing) => pricing?.["2"]?.ondemand,
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -316,6 +320,7 @@ export const columnsGen = (
             (pricing) => pricing?.["2"]?.reserved?.[reservedTerm],
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -329,6 +334,7 @@ export const columnsGen = (
             (pricing) => pricing?.["10"]?.ondemand,
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -342,6 +348,7 @@ export const columnsGen = (
             (pricing) => pricing?.["10"]?.reserved?.[reservedTerm],
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -355,6 +362,7 @@ export const columnsGen = (
             (pricing) => pricing?.["11"]?.ondemand,
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -368,6 +376,7 @@ export const columnsGen = (
             (pricing) => pricing?.["11"]?.reserved?.[reservedTerm],
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -381,6 +390,7 @@ export const columnsGen = (
             (pricing) => pricing?.["12"]?.ondemand,
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -394,6 +404,7 @@ export const columnsGen = (
             (pricing) => pricing?.["12"]?.reserved?.[reservedTerm],
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -407,6 +418,7 @@ export const columnsGen = (
             (pricing) => pricing?.["15"]?.ondemand,
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -420,6 +432,7 @@ export const columnsGen = (
             (pricing) => pricing?.["15"]?.reserved?.[reservedTerm],
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -433,6 +446,7 @@ export const columnsGen = (
             (pricing) => pricing?.["21"]?.ondemand,
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -446,6 +460,7 @@ export const columnsGen = (
             (pricing) => pricing?.["21"]?.reserved?.[reservedTerm],
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -459,6 +474,7 @@ export const columnsGen = (
             (pricing) => pricing?.["211"]?.ondemand,
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -472,6 +488,7 @@ export const columnsGen = (
             (pricing) => pricing?.["18"]?.ondemand,
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -485,6 +502,7 @@ export const columnsGen = (
             (pricing) => pricing?.["18"]?.reserved?.[reservedTerm],
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -498,6 +516,7 @@ export const columnsGen = (
             (pricing) => pricing?.["5"]?.ondemand,
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -511,6 +530,7 @@ export const columnsGen = (
             (pricing) => pricing?.["5"]?.reserved?.[reservedTerm],
             true,
             currency,
+            requestedStorageGb,
         ),
     },
     {

--- a/next/utils/colunnData/redshift.tsx
+++ b/next/utils/colunnData/redshift.tsx
@@ -1,5 +1,5 @@
 import { PricingUnit } from "@/types";
-import { CostDuration } from "@/types";
+import { CostDuration, CostPerGb } from "@/types";
 import {
     calculateCost,
     calculateCostNumeric,
@@ -37,6 +37,7 @@ export type Instance = {
     storage_per_node: string;
     storage_capacity: string;
     pricing: RedshiftPricing;
+    costPerGb?: CostPerGb;
 };
 
 const initialColumnsArr = [

--- a/next/utils/colunnData/redshift.tsx
+++ b/next/utils/colunnData/redshift.tsx
@@ -7,6 +7,7 @@ import {
     makeCellWithRegexSorter,
     expr,
     transformAllDataTables,
+    getStorageHourlyAddon,
 } from "./shared";
 import { ColumnDef } from "@tanstack/react-table";
 import RegionLinkPreloader from "@/components/RegionLinkPreloader";
@@ -98,7 +99,14 @@ function getPricingSorter(
         usdRate: number;
         cnyRate: number;
     },
+    requestedStorageGb: number,
 ) {
+    const storageAddonFor = (instance: { costPerGb?: CostPerGb }) =>
+        getStorageHourlyAddon(
+            instance.costPerGb,
+            requestedStorageGb,
+            selectedRegion,
+        );
     return {
         sortingFn: "basic" as const,
         sortUndefined: "last",
@@ -112,22 +120,70 @@ function getPricingSorter(
                 costDuration,
                 selectedRegion,
                 currency,
+                storageAddonFor(row),
             );
         },
         ...makeCellWithRegexSorter("pricing", (info) => {
             const pricing = info.row.original.pricing;
             const price = getter(pricing?.[selectedRegion]);
             if (isNaN(Number(price)) || !price) return undefined;
-            return calculateCost(
+            const addon = storageAddonFor(info.row.original);
+            const formatted = calculateCost(
                 price,
                 info.row.original,
                 pricingUnit,
                 costDuration,
                 selectedRegion,
                 currency,
+                addon,
+            );
+            if (addon <= 0) return formatted;
+            return renderWithStorageIndicator(
+                formatted,
+                price,
+                addon,
+                requestedStorageGb,
+                info.row.original.costPerGb,
+                selectedRegion,
             );
         }),
     } satisfies Partial<ColumnDef<Instance>>;
+}
+
+function renderWithStorageIndicator(
+    formatted: string,
+    computePriceUsdHr: string,
+    storageHourlyAddon: number,
+    requestedStorageGb: number,
+    costPerGb: CostPerGb | undefined,
+    selectedRegion: string,
+) {
+    const fmt = Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency: "USD",
+        maximumFractionDigits: 6,
+    });
+    const baseline = (() => {
+        if (!costPerGb) return 0;
+        const b = costPerGb.baseline;
+        if (typeof b === "number") return b;
+        let min = Infinity;
+        for (const k in b) if (b[k] < min) min = b[k];
+        return min === Infinity ? 0 : min;
+    })();
+    const extraGb = Math.max(0, requestedStorageGb - baseline);
+    const tooltip =
+        `Compute: ${fmt.format(Number(computePriceUsdHr))}/hr\n` +
+        `Storage: ${fmt.format(storageHourlyAddon)}/hr` +
+        ` (${extraGb} GB × storage rate, ${selectedRegion})`;
+    return (
+        <span
+            title={tooltip}
+            className="border-b border-dotted border-current cursor-help"
+        >
+            {formatted}
+        </span>
+    );
 }
 
 export const columnsGen = (
@@ -140,6 +196,7 @@ export const columnsGen = (
         usdRate: number;
         cnyRate: number;
     },
+    requestedStorageGb: number,
 ): ColumnDef<Instance>[] => [
     {
         accessorKey: "pretty_name",
@@ -241,6 +298,7 @@ export const columnsGen = (
                 return pricing?.ondemand;
             },
             currency,
+            requestedStorageGb,
         ),
     },
     {
@@ -253,6 +311,7 @@ export const columnsGen = (
             costDuration,
             (pricing) => pricing?.reserved?.[reservedTerm],
             currency,
+            requestedStorageGb,
         ),
     },
 ];

--- a/next/utils/colunnData/shared.ts
+++ b/next/utils/colunnData/shared.ts
@@ -1,4 +1,4 @@
-import { CostDuration, PricingUnit } from "@/types";
+import { CostDuration, CostPerGb, PricingUnit } from "@/types";
 import { Row } from "@tanstack/react-table";
 import exprCompiler from "@/utils/expr";
 
@@ -75,6 +75,7 @@ export function calculateCostNumeric(
         usdRate: number;
         cnyRate: number;
     },
+    storageHourlyAddon: number = 0,
 ): number | undefined {
     if (!price) return undefined;
 
@@ -90,10 +91,49 @@ export function calculateCostNumeric(
         ? currency.cnyRate
         : currency.usdRate;
 
+    const hourlyTotal = Number(price) + storageHourlyAddon;
     return (
-        ((Number(price) * durationMultiplier) / pricingUnitModifier) *
+        ((hourlyTotal * durationMultiplier) / pricingUnitModifier) *
         currencyMultiplier
     );
+}
+
+// Resolves a number-or-platform-map value to a single number. For
+// platform maps with multiple values we take the minimum (cheapest case)
+// since the storage cost is folded into a service-wide pricing column
+// and not tied to a specific engine/platform selector. Returns 0 for
+// absent values.
+function resolveCostPerGbValue(
+    value: number | { [platform: string]: number } | undefined,
+): number {
+    if (value === undefined) return 0;
+    if (typeof value === "number") return value;
+    let min = Infinity;
+    for (const k in value) {
+        if (value[k] < min) min = value[k];
+    }
+    return min === Infinity ? 0 : min;
+}
+
+// getStorageHourlyAddon returns the per-instance storage cost in USD
+// per hour to add on top of the compute price. Returns 0 when storage
+// is at or below baseline (no extra cost) or when no overage rate exists.
+//
+// AWS publishes storage rates as USD per GB-month; we convert to per-hour
+// so the value can be added to the existing per-hour compute price and
+// flow through the existing duration / currency math.
+export function getStorageHourlyAddon(
+    costPerGb: CostPerGb | undefined,
+    requestedGb: number,
+    selectedRegion: string,
+): number {
+    if (!costPerGb || requestedGb <= 0) return 0;
+    const baseline = resolveCostPerGbValue(costPerGb.baseline);
+    const rate = resolveCostPerGbValue(costPerGb.regions?.[selectedRegion]);
+    const extraGb = Math.max(0, requestedGb - baseline);
+    if (extraGb === 0 || rate === 0) return 0;
+    const monthHours = (365 * 24) / 12;
+    return (extraGb * rate) / monthHours;
 }
 
 export function calculateCost(
@@ -107,6 +147,7 @@ export function calculateCost(
         usdRate: number;
         cnyRate: number;
     },
+    storageHourlyAddon: number = 0,
 ) {
     if (!price) return "N/A";
 
@@ -117,6 +158,7 @@ export function calculateCost(
         costDuration,
         selectedRegion,
         currency,
+        storageHourlyAddon,
     );
     if (perTime === undefined) return "N/A";
 

--- a/next/utils/instancesKvClient.ts
+++ b/next/utils/instancesKvClient.ts
@@ -19,6 +19,7 @@ type DumpV1 = {
     costDuration: string;
     region: string;
     reservedTerm: string;
+    requestedStorageGb?: number;
     compareOn: boolean;
     selected: string[];
     visibleColumns: Record<string, boolean>;

--- a/next/utils/useGlobalStateValue.ts
+++ b/next/utils/useGlobalStateValue.ts
@@ -109,6 +109,7 @@ const blankStateDump: StateDump = {
     // noUpfront here overrode the Azure default, leaving Azure's reserved/savings
     // columns blank because noUpfront isn't a valid Azure term. Mirrors region/filter.
     reservedTerm: "",
+    requestedStorageGb: 0,
 };
 
 function deepCopy<T>(v: T): T {

--- a/scraper/aws/bootstrapper.go
+++ b/scraper/aws/bootstrapper.go
@@ -103,6 +103,27 @@ func loadAllRegionsForServices(services []service, globalRootIndex, chinaRootInd
 		perServiceParallelism = int(x)
 	}
 
+	// Optional region filter. When set to a comma-separated list of region
+	// slugs (e.g. "us-east-1,us-west-2") only those regions are fetched.
+	// Empty string disables the filter (all regions).
+	allowedRegionsRaw := os.Getenv("ALLOWED_REGIONS")
+	allowedRegions := map[string]struct{}{}
+	if allowedRegionsRaw != "" {
+		for _, r := range strings.Split(allowedRegionsRaw, ",") {
+			r = strings.TrimSpace(r)
+			if r != "" {
+				allowedRegions[r] = struct{}{}
+			}
+		}
+	}
+	regionAllowed := func(name string) bool {
+		if len(allowedRegions) == 0 {
+			return true
+		}
+		_, ok := allowedRegions[name]
+		return ok
+	}
+
 	// Global
 	chinaToUrlToSavingsPlan := make(map[bool]map[string]savingsPlanHandler)
 	for _, service := range services {
@@ -123,6 +144,9 @@ func loadAllRegionsForServices(services []service, globalRootIndex, chinaRootInd
 				if regionName == "cn-north-1-pkx-1" {
 					// Absolutely zero clue why this is being exposed by non-China, but
 					// it breaks things later on. Continue past it.
+					continue
+				}
+				if !regionAllowed(regionName) {
 					continue
 				}
 				dataFlattened = append(dataFlattened, flatData{
@@ -173,6 +197,9 @@ func loadAllRegionsForServices(services []service, globalRootIndex, chinaRootInd
 			for regionName, regionMeta := range regionIndex.Regions {
 				if regionName == "aws-cn-other" {
 					// Weird thing AWS sends in China
+					continue
+				}
+				if !regionAllowed(regionName) {
 					continue
 				}
 				dataFlattened = append(dataFlattened, flatData{

--- a/scraper/aws/bootstrapper.go
+++ b/scraper/aws/bootstrapper.go
@@ -3,10 +3,13 @@ package aws
 import (
 	"context"
 	"log"
+	"os"
 	"runtime"
 	"scraper/aws/awsutils"
 	ec2Internal "scraper/aws/ec2"
 	"scraper/utils"
+	"slices"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -53,30 +56,61 @@ type flatData struct {
 	currentVersionUrl string
 }
 
+type savingsPlanHandler = func() map[string]map[string]map[string]float64
+
+func getSavingsPlansHandler(
+	url string,
+	isChina bool,
+	cache map[bool]map[string]savingsPlanHandler,
+) savingsPlanHandler {
+	disableStr := os.Getenv("DISABLE_SAVINGS_PLANS")
+	disableSavingsPlans := slices.Contains([]string{"true", "1", "yes", "y"}, disableStr)
+	if disableSavingsPlans || url == "" {
+		// If savings plans are off, there needs to be a method here for later,
+		// but we shouldn't do anything further here
+		return func() map[string]map[string]map[string]float64 {
+			return nil
+		}
+	}
+
+	planUrl := AWS_NON_CHINA_ROOT_URL
+	if isChina {
+		planUrl = AWS_CHINA_ROOT_URL
+	}
+
+	urls, ok := cache[isChina]
+	if !ok {
+		urls = make(map[string]savingsPlanHandler)
+		cache[isChina] = urls
+	}
+	if h, ok := urls[url]; ok {
+		return h
+	}
+
+	h := awsutils.GetSavingsPlans(planUrl, url, isChina)
+	urls[url] = h
+	return h
+}
+
 func loadAllRegionsForServices(services []service, globalRootIndex, chinaRootIndex AwsRootIndexResponse) {
+	// Number of goroutines to run for each service for data collection (defaults to 5)
+	perServiceParallelism := 5
+	if e := os.Getenv("PER_SERVICE_PARALLELISM"); e != "" {
+		x, err := strconv.ParseUint(e, 10, 32)
+		if err != nil {
+			log.Fatal("PER_SERVICE_PARALLELISM is not a valid integer", err)
+		}
+		perServiceParallelism = int(x)
+	}
+
 	// Global
-	chinaToUrlToSavingsPlan := make(map[bool]map[string]func() map[string]map[string]map[string]float64)
+	chinaToUrlToSavingsPlan := make(map[bool]map[string]savingsPlanHandler)
 	for _, service := range services {
 		region, ok := globalRootIndex.Offers[service.serviceName]
 		if !ok {
 			log.Fatalf("Service %s not found in global root index", service.serviceName)
 		}
-
-		handler := func() map[string]map[string]map[string]float64 {
-			return nil
-		}
-		urls, ok := chinaToUrlToSavingsPlan[false]
-		if !ok {
-			urls = make(map[string]func() map[string]map[string]map[string]float64)
-			chinaToUrlToSavingsPlan[false] = urls
-		}
-		url := region.CurrentSavingsPlanIndexUrl
-		if h, ok := urls[url]; ok {
-			handler = h
-		} else if url != "" {
-			handler = awsutils.GetSavingsPlans(AWS_NON_CHINA_ROOT_URL, url, false)
-			urls[url] = handler
-		}
+		handler := getSavingsPlansHandler(region.CurrentSavingsPlanIndexUrl, false, chinaToUrlToSavingsPlan)
 
 		go func() {
 			var regionIndex AwsRegionIndexResponse
@@ -96,7 +130,7 @@ func loadAllRegionsForServices(services []service, globalRootIndex, chinaRootInd
 					currentVersionUrl: regionMeta.CurrentVersionUrl,
 				})
 			}
-			chunks := utils.Chunk(dataFlattened, 5)
+			chunks := utils.Chunk(dataFlattened, perServiceParallelism)
 
 			for _, chunk := range chunks {
 				fg := utils.FunctionGroup{}
@@ -127,22 +161,7 @@ func loadAllRegionsForServices(services []service, globalRootIndex, chinaRootInd
 		if !ok {
 			log.Fatalf("Service %s not found in china root index", service.serviceName)
 		}
-
-		handler := func() map[string]map[string]map[string]float64 {
-			return nil
-		}
-		urls, ok := chinaToUrlToSavingsPlan[true]
-		if !ok {
-			urls = make(map[string]func() map[string]map[string]map[string]float64)
-			chinaToUrlToSavingsPlan[true] = urls
-		}
-		url := region.CurrentSavingsPlanIndexUrl
-		if h, ok := urls[url]; ok {
-			handler = h
-		} else if url != "" {
-			handler = awsutils.GetSavingsPlans(AWS_CHINA_ROOT_URL, url, true)
-			urls[url] = handler
-		}
+		handler := getSavingsPlansHandler(region.CurrentSavingsPlanIndexUrl, true, chinaToUrlToSavingsPlan)
 
 		go func() {
 			var regionIndex AwsRegionIndexResponse
@@ -161,7 +180,7 @@ func loadAllRegionsForServices(services []service, globalRootIndex, chinaRootInd
 					currentVersionUrl: regionMeta.CurrentVersionUrl,
 				})
 			}
-			chunks := utils.Chunk(dataFlattened, 5)
+			chunks := utils.Chunk(dataFlattened, perServiceParallelism)
 
 			for _, chunk := range chunks {
 				fg := utils.FunctionGroup{}

--- a/scraper/aws/ec2/cost_per_gb.go
+++ b/scraper/aws/ec2/cost_per_gb.go
@@ -1,0 +1,17 @@
+package ec2
+
+// CostPerGb expresses storage cost separately from compute.
+//
+// Baseline is the bundled storage capacity (in GB) included with the instance.
+// Regions maps region codes to per-GB overage rates when applicable.
+//
+// For EC2 instance store, there is no per-GB overage rate, so Regions is
+// always an empty map (serialized as "{}", never null).
+//
+// TODO: This local definition can be unified with the AWS-package-level
+// type in scraper/aws/storage_pricing.go once that file exists; the JSON
+// shape is identical.
+type CostPerGb struct {
+	Baseline any            `json:"baseline"`
+	Regions  map[string]any `json:"regions"`
+}

--- a/scraper/aws/ec2/ec2_instance.go
+++ b/scraper/aws/ec2/ec2_instance.go
@@ -137,6 +137,7 @@ type EC2Instance struct {
 	BranchInterface          *int                       `json:"branch_interface,omitempty"`
 	MaxECSTasks              *int                       `json:"max_ecs_tasks,omitempty"`
 	DateIntroduced           *string                    `json:"date_introduced,omitempty"`
+	CostPerGb                *CostPerGb                 `json:"costPerGb,omitempty"`
 }
 
 func avg(ints []int) *float64 {

--- a/scraper/aws/ec2/process_data.go
+++ b/scraper/aws/ec2/process_data.go
@@ -334,6 +334,18 @@ func processEC2Data(
 	// Clean up empty regions and set the regions map for non-empty regions
 	for _, instance := range instancesHashmap {
 		instance.Regions = cleanEmptyRegions(instance.Pricing, regionDescriptions)
+
+		// Populate costPerGb so storage is expressed separately from compute.
+		// Baseline is the total instance-store capacity in GB; instance store
+		// has no per-GB overage rate, so Regions is always an empty map.
+		var totalGb float64 = 0
+		if instance.Storage != nil {
+			totalGb = float64(instance.Storage.Size * instance.Storage.Devices)
+		}
+		instance.CostPerGb = &CostPerGb{
+			Baseline: totalGb,
+			Regions:  map[string]any{},
+		}
 	}
 
 	// Save the instances

--- a/scraper/aws/ec2/process_data.go
+++ b/scraper/aws/ec2/process_data.go
@@ -52,6 +52,13 @@ func processEC2Data(
 	instancesHashmap := make(map[string]*EC2Instance)
 	sku2SkuData := make(map[string]ec2SkuData)
 
+	// EBS gp3 storage SKUs and the resulting per-region rate.
+	// Used to populate costPerGb.regions so a user-selected storage
+	// amount above the bundled instance-store baseline is priced as
+	// attached gp3 EBS.
+	ebsGp3Skus := make(map[string]bool)
+	gp3RatePerRegion := make(map[string]float64)
+
 	// The descriptions found for each region
 	regionDescriptions := make(map[string]string)
 
@@ -68,6 +75,15 @@ func processEC2Data(
 		// Process the products in the region
 		regionDescription := ""
 		for _, product := range rawRegion.RegionData.Products {
+			// Capture EBS gp3 storage SKUs before the family filter so
+			// they survive into the OnDemand pass below. Only the gp3
+			// volume type is used; other volume types are ignored.
+			if product.ProductFamily == "Storage" &&
+				product.Attributes["volumeApiName"] == "gp3" {
+				ebsGp3Skus[product.SKU] = true
+				continue
+			}
+
 			if _, ok := EC2_OK_PRODUCT_FAMILIES[product.ProductFamily]; !ok {
 				continue
 			}
@@ -152,6 +168,31 @@ func processEC2Data(
 		// Process the on demand pricing
 		for _, offerMapping := range rawRegion.RegionData.Terms.OnDemand {
 			for _, offer := range offerMapping {
+				// EBS gp3 storage SKU: extract the per-GB-month rate
+				// for this region. Take the lowest tier (BeginRange == "0").
+				if ebsGp3Skus[offer.SKU] {
+					for _, dim := range offer.PriceDimensions {
+						if !strings.EqualFold(dim.Unit, "GB-Mo") {
+							continue
+						}
+						if dim.BeginRange != "" && dim.BeginRange != "0" {
+							continue
+						}
+						priceStr := dim.PricePerUnit[currency]
+						if priceStr == "" {
+							continue
+						}
+						rate, err := strconv.ParseFloat(priceStr, 64)
+						if err != nil || rate <= 0 {
+							continue
+						}
+						if existing, ok := gp3RatePerRegion[rawRegion.RegionName]; !ok || rate < existing {
+							gp3RatePerRegion[rawRegion.RegionName] = rate
+						}
+					}
+					continue
+				}
+
 				// Get the instance in question
 				skuData, ok := sku2SkuData[offer.SKU]
 				if !ok {
@@ -331,20 +372,35 @@ func processEC2Data(
 		}
 	}
 
+	// Build the costPerGb.regions map once; the gp3 rate applies to
+	// every EC2 instance equally (it's the rate of an attached EBS
+	// volume, not something that varies per instance type).
+	costPerGbRegions := make(map[string]any, len(gp3RatePerRegion))
+	for region, rate := range gp3RatePerRegion {
+		costPerGbRegions[region] = rate
+	}
+
 	// Clean up empty regions and set the regions map for non-empty regions
 	for _, instance := range instancesHashmap {
 		instance.Regions = cleanEmptyRegions(instance.Pricing, regionDescriptions)
 
-		// Populate costPerGb so storage is expressed separately from compute.
-		// Baseline is the total instance-store capacity in GB; instance store
-		// has no per-GB overage rate, so Regions is always an empty map.
+		// Populate costPerGb so storage is expressed separately from
+		// compute. Baseline is the total instance-store capacity in GB
+		// (free with the instance); regions[r] is the per-GB-month gp3
+		// EBS rate for additional storage beyond the baseline.
 		var totalGb float64 = 0
 		if instance.Storage != nil {
 			totalGb = float64(instance.Storage.Size * instance.Storage.Devices)
 		}
+		// Copy so each instance has an independent map (the value in the
+		// json is per-instance-shaped even though the rates are shared).
+		regionsCopy := make(map[string]any, len(costPerGbRegions))
+		for k, v := range costPerGbRegions {
+			regionsCopy[k] = v
+		}
 		instance.CostPerGb = &CostPerGb{
 			Baseline: totalGb,
-			Regions:  map[string]any{},
+			Regions:  regionsCopy,
 		}
 	}
 

--- a/scraper/aws/elasticache.go
+++ b/scraper/aws/elasticache.go
@@ -81,6 +81,44 @@ func enrichElastiCacheInstance(instance map[string]any, attributes map[string]st
 	}
 }
 
+// processCacheStorageDimensions accumulates per-GB-month storage rates for
+// an ElastiCache storage SKU. Storage costs apply per-engine (e.g. data
+// tiering for Redis/Valkey on r6gd) and are emitted globally to all
+// instances.
+func processCacheStorageDimensions(
+	attributes map[string]string,
+	offer awsutils.RegionTerm,
+	regionName string,
+	currency string,
+	ratesPerRegion map[string]map[string]float64,
+) {
+	engine := attributes["cacheEngine"]
+	if engine == "" {
+		engine = attributes["databaseEngine"]
+	}
+	if engine == "" {
+		// Use a sentinel so we still emit data when no engine attribute
+		// is provided; consumers will see a single platform key.
+		engine = "default"
+	}
+
+	for _, dim := range offer.PriceDimensions {
+		dimCopy := dim
+		rate, ok := extractStorageRate(&dimCopy, currency)
+		if !ok || rate <= 0 {
+			continue
+		}
+		regionRates, exists := ratesPerRegion[regionName]
+		if !exists {
+			regionRates = make(map[string]float64)
+			ratesPerRegion[regionName] = regionRates
+		}
+		if existing, ok := regionRates[engine]; !ok || rate > existing {
+			regionRates[engine] = rate
+		}
+	}
+}
+
 func processElastiCacheOnDemandDimension(attributes map[string]string, priceDimension awsutils.RegionPriceDimension, getPricingData func(platform string) *genericAwsPricingData, currency string) {
 	descLower := strings.ToLower(priceDimension.Description)
 	for _, chunk := range BAD_DESCRIPTION_CHUNKS {
@@ -174,6 +212,11 @@ func processElastiCacheData(
 	instancesHashmap := make(map[string]map[string]any)
 	sku2SkuData := make(map[string]genericAwsSkuData)
 
+	// Storage SKU bookkeeping (data tiering on r6gd Redis/Valkey).
+	// Storage rates are per-engine and global to the run.
+	cacheStorageSkus := make(map[string]map[string]string)
+	cacheStorageRates := make(map[string]map[string]float64) // region -> engine -> rate
+
 	// The descriptions found for each region
 	regionDescriptions := make(map[string]string)
 
@@ -190,6 +233,19 @@ func processElastiCacheData(
 		// Process the products in the region
 		regionDescription := ""
 		for _, product := range rawRegion.RegionData.Products {
+			// Capture storage SKUs (data tiering, e.g. r6gd Redis/Valkey).
+			// TODO: ElastiCache may use ProductFamily values like
+			// "Cache Storage" or "ElastiCache Storage"; the exact name
+			// has not been verified against live data. Accept any
+			// family containing "Storage" so we still emit the field
+			// when present.
+			if product.ProductFamily != "Cache Instance" &&
+				strings.Contains(strings.ToLower(product.ProductFamily), "storage") &&
+				product.Attributes["locationType"] == "AWS Region" {
+				cacheStorageSkus[product.SKU] = product.Attributes
+				continue
+			}
+
 			if product.ProductFamily != "Cache Instance" {
 				continue
 			}
@@ -231,6 +287,15 @@ func processElastiCacheData(
 		// Process the on demand pricing
 		for _, offerMapping := range rawRegion.RegionData.Terms.OnDemand {
 			for _, offer := range offerMapping {
+				// Storage SKUs flow through their own per-GB-month path.
+				if storageAttrs, ok := cacheStorageSkus[offer.SKU]; ok {
+					processCacheStorageDimensions(
+						storageAttrs, offer, rawRegion.RegionName,
+						currency, cacheStorageRates,
+					)
+					continue
+				}
+
 				// Get the instance in question
 				skuData, ok := sku2SkuData[offer.SKU]
 				if !ok {
@@ -303,6 +368,12 @@ func processElastiCacheData(
 	// Clean up empty regions and set the regions map for non-empty regions
 	for _, instance := range instancesHashmap {
 		instance["regions"] = cleanEmptyRegions(instance["pricing"].(map[string]map[string]any), regionDescriptions)
+	}
+
+	// Build the per-instance costPerGb. Storage rates are global per-engine.
+	cacheCostPerGb := buildCostPerGb(cacheStorageRates, true)
+	for _, instance := range instancesHashmap {
+		instance["costPerGb"] = cacheCostPerGb
 	}
 
 	// Set the cache parameters

--- a/scraper/aws/opensearch.go
+++ b/scraper/aws/opensearch.go
@@ -38,6 +38,50 @@ var IGNORE_OPENSEARCH_ATTRIBUTES = map[string]bool{
 	"usagetype":    true,
 }
 
+// processOpenSearchStorageDimensions accumulates EBS per-GB-month storage
+// rates for OpenSearch volume SKUs. We prefer gp3 when multiple
+// volumeTypes are encountered for the same region. No platform layer.
+func processOpenSearchStorageDimensions(
+	attributes map[string]string,
+	offer awsutils.RegionTerm,
+	regionName string,
+	currency string,
+	ratesPerRegion map[string]map[string]float64,
+) {
+	volumeType := strings.ToLower(attributes["volumeType"])
+	// Only capture gp3 (preferred). If we already saw a non-gp3 entry
+	// for this region, gp3 will replace it. If we already have gp3,
+	// we skip non-gp3.
+	preferGp3 := strings.Contains(volumeType, "gp3")
+	if !preferGp3 {
+		// Allow non-gp3 only if no entry yet for this region.
+		if existing, ok := ratesPerRegion[regionName]; ok {
+			if _, has := existing[""]; has {
+				return
+			}
+		}
+	}
+
+	for _, dim := range offer.PriceDimensions {
+		dimCopy := dim
+		rate, ok := extractStorageRate(&dimCopy, currency)
+		if !ok || rate <= 0 {
+			continue
+		}
+		regionRates, exists := ratesPerRegion[regionName]
+		if !exists {
+			regionRates = make(map[string]float64)
+			ratesPerRegion[regionName] = regionRates
+		}
+		// gp3 always wins; otherwise keep the lowest seen rate.
+		if preferGp3 {
+			regionRates[""] = rate
+		} else if existing, ok := regionRates[""]; !ok || rate < existing {
+			regionRates[""] = rate
+		}
+	}
+}
+
 func enrichOpenSearchInstance(instance map[string]any, attributes map[string]string) {
 	// Clean up the memory attribute
 	if attributes["memoryGib"] != "" {
@@ -201,6 +245,11 @@ func processOpenSearchData(
 	instancesHashmap := make(map[string]map[string]any)
 	sku2Instance := make(map[string]map[string]any)
 
+	// Storage SKU bookkeeping (EBS volumes, gp3 preferred). No platform
+	// layer; sentinel "" key.
+	osStorageSkus := make(map[string]map[string]string)
+	osStorageRates := make(map[string]map[string]float64) // region -> "" -> rate
+
 	// The descriptions found for each region
 	regionDescriptions := make(map[string]string)
 
@@ -217,6 +266,13 @@ func processOpenSearchData(
 		// Process the products in the region
 		regionDescription := ""
 		for _, product := range rawRegion.RegionData.Products {
+			// Capture EBS storage volume SKUs. We prefer gp3 when
+			// multiple volumeTypes exist for the same region.
+			if product.ProductFamily == "Amazon OpenSearch Service Volume" {
+				osStorageSkus[product.SKU] = product.Attributes
+				continue
+			}
+
 			if product.ProductFamily != "Amazon OpenSearch Service Instance" ||
 				product.Attributes["operation"] == "DirectQueryAmazonS3GDCOCU" {
 				continue
@@ -250,6 +306,15 @@ func processOpenSearchData(
 		// Process the on demand pricing
 		for _, offerMapping := range rawRegion.RegionData.Terms.OnDemand {
 			for _, offer := range offerMapping {
+				// Storage SKUs flow through their own per-GB-month path.
+				if storageAttrs, ok := osStorageSkus[offer.SKU]; ok {
+					processOpenSearchStorageDimensions(
+						storageAttrs, offer, rawRegion.RegionName,
+						currency, osStorageRates,
+					)
+					continue
+				}
+
 				// Get the instance in question
 				instance, ok := sku2Instance[offer.SKU]
 				if !ok {
@@ -337,6 +402,13 @@ func processOpenSearchData(
 	// Clean up empty regions and set the regions map for non-empty regions
 	for _, instance := range instancesHashmap {
 		instance["regions"] = clearHalfEmptyRegions(instance["pricing"].(map[string]*genericAwsPricingData), regionDescriptions)
+	}
+
+	// Build per-instance costPerGb. OpenSearch storage rates have no
+	// platform layer; the same value is attached to every instance.
+	osCostPerGb := buildCostPerGb(osStorageRates, false)
+	for _, instance := range instancesHashmap {
+		instance["costPerGb"] = osCostPerGb
 	}
 
 	// Process the volume quotas

--- a/scraper/aws/rds.go
+++ b/scraper/aws/rds.go
@@ -218,6 +218,46 @@ func unbundledSqlServerLicenseSurcharge(
 
 type engineCode = string
 
+// processRdsStorageDimensions accumulates per-GB-month storage rates for an
+// RDS Database Storage SKU into the global per-region/per-engine rate maps.
+// Storage rates are per-engine (not per-instance), so the same map is later
+// applied to every instance.
+func processRdsStorageDimensions(
+	attributes map[string]string,
+	offer awsutils.RegionTerm,
+	regionName string,
+	currency string,
+	ratesPerRegion map[string]map[string]float64,
+) {
+	engineCode := attributes["engineCode"]
+	if engineCode == "" {
+		// Fall back to databaseEngine when engineCode is absent so we
+		// still emit something useful.
+		engineCode = attributes["databaseEngine"]
+	}
+	if engineCode == "" {
+		return
+	}
+
+	for _, dim := range offer.PriceDimensions {
+		dimCopy := dim
+		rate, ok := extractStorageRate(&dimCopy, currency)
+		if !ok || rate <= 0 {
+			continue
+		}
+		regionRates, exists := ratesPerRegion[regionName]
+		if !exists {
+			regionRates = make(map[string]float64)
+			ratesPerRegion[regionName] = regionRates
+		}
+		// Keep the maximum rate when multiple dimensions match (rare;
+		// RDS storage SKUs typically have a single relevant tier).
+		if existing, ok := regionRates[engineCode]; !ok || rate > existing {
+			regionRates[engineCode] = rate
+		}
+	}
+}
+
 func processRdsOnDemandDimension(
 	attributes map[string]string,
 	instanceType string,
@@ -371,6 +411,13 @@ func processRDSData(
 	instancesHashmap := make(map[string]map[string]any)
 	sku2SkuData := make(map[string]genericAwsSkuData)
 
+	// Storage SKU bookkeeping: SKU -> attributes (region, databaseEngine, engineCode).
+	// Storage pricing is keyed by engine (not by instance type), so we accumulate it
+	// once and attach the same costPerGb to every instance after processing.
+	rdsStorageSkus := make(map[string]map[string]string)
+	// region -> engineCode -> per-GB-month rate
+	rdsStorageRates := make(map[string]map[string]float64)
+
 	// The descriptions found for each region
 	regionDescriptions := make(map[string]string)
 
@@ -386,6 +433,18 @@ func processRDSData(
 		// Process the products in the region
 		regionDescription := ""
 		for _, product := range rawRegion.RegionData.Products {
+			// Capture storage SKUs (Single-AZ only, to match the
+			// instance-pricing convention below). Storage rates are
+			// keyed by engine and applied to every instance later.
+			if product.ProductFamily == "Database Storage" {
+				if product.Attributes["deploymentOption"] != "" &&
+					product.Attributes["deploymentOption"] != "Single-AZ" {
+					continue
+				}
+				rdsStorageSkus[product.SKU] = product.Attributes
+				continue
+			}
+
 			if product.ProductFamily != "Database Instance" {
 				continue
 			}
@@ -441,6 +500,16 @@ func processRDSData(
 		// Process the on demand pricing
 		for _, offerMapping := range rawRegion.RegionData.Terms.OnDemand {
 			for _, offer := range offerMapping {
+				// Storage SKUs flow through their own per-GB-month
+				// path; they don't have a single hourly rate.
+				if storageAttrs, ok := rdsStorageSkus[offer.SKU]; ok {
+					processRdsStorageDimensions(
+						storageAttrs, offer, rawRegion.RegionName,
+						currency, rdsStorageRates,
+					)
+					continue
+				}
+
 				// Get the instance in question
 				skuData, ok := sku2SkuData[offer.SKU]
 				if !ok {
@@ -537,6 +606,15 @@ func processRDSData(
 				instance["engine_support"] = support
 			}
 		}
+	}
+
+	// Build the per-instance costPerGb. RDS storage rates are per-engine
+	// and global to the run, so the same value is attached to every
+	// instance. Downstream consumers can pick the engine relevant to
+	// their workload from the map.
+	rdsCostPerGb := buildCostPerGb(rdsStorageRates, true)
+	for _, instance := range instancesHashmap {
+		instance["costPerGb"] = rdsCostPerGb
 	}
 
 	// Save the data

--- a/scraper/aws/redshift.go
+++ b/scraper/aws/redshift.go
@@ -44,6 +44,31 @@ func enrichRedshiftInstance(instance map[string]any, attributes map[string]strin
 	}
 }
 
+// processRedshiftStorageDimensions accumulates RA3 managed-storage rates.
+// Redshift storage has no platform layer, so we use a sentinel "" key.
+func processRedshiftStorageDimensions(
+	offer awsutils.RegionTerm,
+	regionName string,
+	currency string,
+	ratesPerRegion map[string]map[string]float64,
+) {
+	for _, dim := range offer.PriceDimensions {
+		dimCopy := dim
+		rate, ok := extractStorageRate(&dimCopy, currency)
+		if !ok || rate <= 0 {
+			continue
+		}
+		regionRates, exists := ratesPerRegion[regionName]
+		if !exists {
+			regionRates = make(map[string]float64)
+			ratesPerRegion[regionName] = regionRates
+		}
+		if existing, ok := regionRates[""]; !ok || rate > existing {
+			regionRates[""] = rate
+		}
+	}
+}
+
 func processRedshiftOnDemandDimension(priceDimension awsutils.RegionPriceDimension, getPricingData func() *genericAwsPricingData, currency string) {
 	descLower := strings.ToLower(priceDimension.Description)
 	for _, chunk := range BAD_DESCRIPTION_CHUNKS {
@@ -145,6 +170,10 @@ func processRedshiftData(
 	instancesHashmap := make(map[string]map[string]any)
 	sku2Instance := make(map[string]map[string]any)
 
+	// Storage SKU bookkeeping (RA3 managed storage). No platform layer.
+	redshiftStorageSkus := make(map[string]map[string]string)
+	redshiftStorageRates := make(map[string]map[string]float64) // region -> "" -> rate
+
 	// The descriptions found for each region
 	regionDescriptions := make(map[string]string)
 
@@ -160,6 +189,16 @@ func processRedshiftData(
 		// Process the products in the region
 		regionDescription := ""
 		for _, product := range rawRegion.RegionData.Products {
+			// Capture storage SKUs (RA3 managed storage). The exact
+			// ProductFamily for Redshift managed storage is "Storage";
+			// accept either "Storage" or anything containing
+			// "Managed Storage" as a defensive fallback.
+			if product.ProductFamily == "Storage" ||
+				strings.Contains(strings.ToLower(product.ProductFamily), "managed storage") {
+				redshiftStorageSkus[product.SKU] = product.Attributes
+				continue
+			}
+
 			if product.ProductFamily != "Compute Instance" {
 				continue
 			}
@@ -204,6 +243,15 @@ func processRedshiftData(
 		// Process the on demand pricing
 		for _, offerMapping := range rawRegion.RegionData.Terms.OnDemand {
 			for _, offer := range offerMapping {
+				// Storage SKUs flow through their own per-GB-month path.
+				if _, ok := redshiftStorageSkus[offer.SKU]; ok {
+					processRedshiftStorageDimensions(
+						offer, rawRegion.RegionName, currency,
+						redshiftStorageRates,
+					)
+					continue
+				}
+
 				// Get the instance in question
 				instance, ok := sku2Instance[offer.SKU]
 				if !ok {
@@ -275,6 +323,15 @@ func processRedshiftData(
 	// Clean up empty regions and set the regions map for non-empty regions
 	for _, instance := range instancesHashmap {
 		instance["regions"] = clearHalfEmptyRegions(instance["pricing"].(map[string]*genericAwsPricingData), regionDescriptions)
+	}
+
+	// Build per-instance costPerGb. Redshift managed storage rates have
+	// no platform layer; the same value is attached to every instance
+	// (RA3 nodes use it; non-RA3 nodes will see an empty regions map
+	// since they don't have managed-storage SKUs).
+	redshiftCostPerGb := buildCostPerGb(redshiftStorageRates, false)
+	for _, instance := range instancesHashmap {
+		instance["costPerGb"] = redshiftCostPerGb
 	}
 
 	// Set the node parameters

--- a/scraper/aws/storage_pricing.go
+++ b/scraper/aws/storage_pricing.go
@@ -1,0 +1,118 @@
+package aws
+
+import (
+	"math"
+	"scraper/aws/awsutils"
+	"strings"
+)
+
+// CostPerGb represents the per-GB-month storage cost for an instance.
+// Baseline is the GB included with the instance at no per-GB cost. For
+// AWS RDS / ElastiCache / Redshift / OpenSearch the pricing API does not
+// expose any free-storage allowance (the AWS Free Tier is an account-level
+// promotional benefit, not encoded in the pricing JSON), so Baseline is
+// always 0 here. Other providers (EC2 instance store, Azure temp disk,
+// GCP local SSD bundle) populate Baseline from instance metadata in their
+// own scrapers without using this helper.
+//
+// Regions maps region slug -> per-GB-month rate. Values for Regions
+// entries are emitted as scalars when uniform across platforms, or as a
+// map[string]float64 (platform -> value) otherwise.
+type CostPerGb struct {
+	Baseline any            `json:"baseline"`
+	Regions  map[string]any `json:"regions"`
+}
+
+// extractStorageRate inspects a PriceDimension and returns the per-GB-month
+// rate if and only if the dimension's unit is "GB-Mo" (case-insensitive)
+// and the dimension covers the lowest tier (BeginRange == "0" or empty).
+//
+// Tiered pricing is reduced to the lowest tier per the project decision.
+// AWS storage SKUs in practice always have a single flat tier; the tier
+// guard exists for safety.
+func extractStorageRate(priceDim *awsutils.RegionPriceDimension, currency string) (rate float64, ok bool) {
+	if priceDim == nil {
+		return 0, false
+	}
+	if !strings.EqualFold(priceDim.Unit, "GB-Mo") {
+		return 0, false
+	}
+	if priceDim.BeginRange != "" && priceDim.BeginRange != "0" {
+		return 0, false
+	}
+
+	priceStr := priceDim.PricePerUnit[currency]
+	if priceStr == "" {
+		return 0, false
+	}
+	return awsutils.Floaty(priceStr), true
+}
+
+// collapseUniform returns either a scalar float64 (when all values in the
+// map are equal within float64 tolerance) or the original map. An empty
+// map collapses to float64(0), and a single-entry map collapses to its
+// scalar value.
+func collapseUniform(perPlatform map[string]float64) any {
+	if len(perPlatform) == 0 {
+		return float64(0)
+	}
+	var first float64
+	firstSet := false
+	uniform := true
+	for _, v := range perPlatform {
+		if !firstSet {
+			first = v
+			firstSet = true
+			continue
+		}
+		if math.Abs(v-first) > 1e-12 {
+			uniform = false
+			break
+		}
+	}
+	if uniform {
+		return first
+	}
+	return perPlatform
+}
+
+// buildCostPerGb assembles a CostPerGb value from accumulated per-region,
+// per-platform raw rate data. Baseline is always 0 because AWS pricing
+// does not expose any free-storage allowance (see CostPerGb docs).
+//
+// When hasPlatform is false (Redshift/OpenSearch), the input map is
+// expected to use a single sentinel platform key (typically ""); the
+// helper emits scalars directly.
+//
+// Regions whose inner platform map is empty are dropped from the output.
+func buildCostPerGb(
+	ratesPerRegion map[string]map[string]float64,
+	hasPlatform bool,
+) CostPerGb {
+	out := CostPerGb{
+		Baseline: float64(0),
+		Regions:  make(map[string]any),
+	}
+
+	if !hasPlatform {
+		for region, perPlatform := range ratesPerRegion {
+			if len(perPlatform) == 0 {
+				continue
+			}
+			var v float64
+			for _, vv := range perPlatform {
+				v = vv
+			}
+			out.Regions[region] = v
+		}
+		return out
+	}
+
+	for region, perPlatform := range ratesPerRegion {
+		if len(perPlatform) == 0 {
+			continue
+		}
+		out.Regions[region] = collapseUniform(perPlatform)
+	}
+	return out
+}

--- a/scraper/azure/cost_per_gb.go
+++ b/scraper/azure/cost_per_gb.go
@@ -1,0 +1,6 @@
+package azure
+
+type CostPerGb struct {
+	Baseline any            `json:"baseline"`
+	Regions  map[string]any `json:"regions"`
+}

--- a/scraper/azure/scrape.go
+++ b/scraper/azure/scrape.go
@@ -40,6 +40,8 @@ type AzureInstance struct {
 	PrettyNameAzure   string         `json:"pretty_name_azure,omitempty"`
 	AzureSpecsData    `json:",inline"`
 
+	CostPerGb *CostPerGb `json:"costPerGb,omitempty"`
+
 	disownedFromFamily bool
 }
 
@@ -420,6 +422,15 @@ func DoAzureScraping() {
 	for _, instance := range instances {
 		if instance.PrettyNameAzure == "" {
 			instance.PrettyNameAzure = instance.PrettyName
+		}
+
+		var baselineGb float64 = 0
+		if instance.Storage.Size > 0 {
+			baselineGb = float64(instance.Storage.Size) / 1024.0
+		}
+		instance.CostPerGb = &CostPerGb{
+			Baseline: baselineGb,
+			Regions:  map[string]any{},
 		}
 	}
 

--- a/scraper/gcp/cost_per_gb.go
+++ b/scraper/gcp/cost_per_gb.go
@@ -1,0 +1,48 @@
+package gcp
+
+// CostPerGb describes the cost of attaching local SSD storage to an instance.
+//
+// Baseline is the number of GB of local SSD bundled with the instance at no
+// extra storage charge (typically 0 for GCP, since local SSD is opt-in and
+// charged per attached 375 GB disk; non-zero only for legacy machine types
+// like *-lssd that include mandatory bundled disks).
+//
+// Regions maps region code -> rate. The rate is either a scalar float64
+// (USD per GB-month, when on-demand and spot have the same rate) or a
+// map[string]float64 keyed by platform ("ondemand", "spot") when the rates
+// differ.
+type CostPerGb struct {
+	Baseline any            `json:"baseline"`
+	Regions  map[string]any `json:"regions"`
+}
+
+// collapseUniform reduces a {platform: rate} map to either a scalar (when all
+// platform rates are equal) or the original map encoded as map[string]any.
+// An empty map collapses to 0.
+func collapseUniform(m map[string]float64) any {
+	if len(m) == 0 {
+		return float64(0)
+	}
+	var first float64
+	var firstSet bool
+	uniform := true
+	for _, v := range m {
+		if !firstSet {
+			first = v
+			firstSet = true
+			continue
+		}
+		if v != first {
+			uniform = false
+			break
+		}
+	}
+	if uniform {
+		return first
+	}
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}

--- a/scraper/gcp/gcp_instance.go
+++ b/scraper/gcp/gcp_instance.go
@@ -56,6 +56,7 @@ type GCPInstance struct {
 	AvailabilityZones  map[string][]string   `json:"availability_zones,omitempty"`
 	LocalSSD           bool                  `json:"local_ssd"`
 	LocalSSDSize       int                   `json:"local_ssd_size,omitempty"`
+	CostPerGb          *CostPerGb            `json:"costPerGb"`
 	SharedCPU          bool                  `json:"shared_cpu"`
 	ComputeOptimized   bool                  `json:"compute_optimized,omitempty"`
 	MemoryOptimized    bool                  `json:"memory_optimized,omitempty"`

--- a/scraper/gcp/scrape.go
+++ b/scraper/gcp/scrape.go
@@ -153,9 +153,165 @@ func selectHourlyPrice(candidates []PriceInfo, preferLower bool) (float64, bool)
 	return selected, hasValue
 }
 
+// extractLocalSSDPricing scans SKUs for local SSD per-GB-month rates and
+// returns a map of region -> platform -> USD per GB-month. Both on-demand
+// and preemptible/spot rates are surfaced under platform keys "ondemand" and
+// "spot". Hourly SKUs (GiBy.h) are converted to GB-month using a 730 hour
+// month. Windows-licensed SKUs are skipped (local SSD has no OS variants).
+func extractLocalSSDPricing(skus []SKU, pricing map[string]PriceInfo) map[string]map[string]float64 {
+	out := make(map[string]map[string]float64)
+
+	for _, sku := range skus {
+		displayLower := strings.ToLower(sku.DisplayName)
+
+		// Local SSD SKUs have "ssd" and either "local" or "scratch" in their
+		// display name or taxonomy. Filter out unrelated storage SKUs
+		// (persistent disks, snapshots, image storage, etc.).
+		taxonomy := taxonomyValues(sku)
+		isLocalSSDByName := strings.Contains(displayLower, "ssd") &&
+			(strings.Contains(displayLower, "local") || strings.Contains(displayLower, "scratch"))
+		isLocalSSDByTax := taxonomyContainsAny(taxonomy, "localssd", "local ssd", "local-ssd")
+
+		if !isLocalSSDByName && !isLocalSSDByTax {
+			continue
+		}
+
+		// Skip non-storage SKUs that may match the loose name filter.
+		if strings.Contains(displayLower, "snapshot") ||
+			strings.Contains(displayLower, "image") ||
+			strings.Contains(displayLower, "persistent") {
+			continue
+		}
+
+		// Skip Windows-licensed SKUs (local SSD has no OS variants).
+		if strings.Contains(displayLower, "windows") {
+			continue
+		}
+
+		// Skip commitment/discount SKUs.
+		if strings.Contains(displayLower, "commit") ||
+			strings.Contains(displayLower, "cud") ||
+			strings.Contains(displayLower, "sustained") ||
+			strings.Contains(displayLower, "reservation") ||
+			strings.Contains(displayLower, "reserved") ||
+			strings.Contains(displayLower, "saving") {
+			continue
+		}
+
+		isSpot := strings.Contains(displayLower, "preemptible") || strings.Contains(displayLower, "spot")
+
+		price, hasPrice := pricing[sku.SkuId]
+		if !hasPrice {
+			continue
+		}
+
+		// Convert tier-0 list price to USD per GB-month.
+		// calculateHourlyPrice handles unit normalization for hourly/monthly
+		// units. For storage rates (GiBy.h or GiBy.mo), we want GB-month, so
+		// we re-compute here without the hourly conversion.
+		gbMonth, ok := localSSDGBMonth(price)
+		if !ok || gbMonth <= 0 {
+			continue
+		}
+
+		platform := "ondemand"
+		if isSpot {
+			platform = "spot"
+		}
+
+		targetRegions := targetRegionsForSKU(sku, "")
+		// Expand multi-regional SKUs to their constituent regions.
+		expanded := make([]string, 0, len(targetRegions))
+		for _, r := range targetRegions {
+			expanded = append(expanded, r)
+			expanded = append(expanded, expandedRegionsForMultiRegion(r)...)
+		}
+
+		for _, region := range expanded {
+			if region == "" || strings.HasPrefix(region, "multi-") {
+				continue
+			}
+			if out[region] == nil {
+				out[region] = make(map[string]float64)
+			}
+			// If multiple SKUs report the same platform for a region, keep
+			// the first non-zero value seen (subsequent SKUs are typically
+			// region-specific overrides of multi-regional fallbacks).
+			if _, exists := out[region][platform]; !exists {
+				out[region][platform] = gbMonth
+			}
+		}
+	}
+
+	return out
+}
+
+// localSSDGBMonth returns USD per GB-month for a local SSD price record.
+// Returns false if the unit is not understood.
+func localSSDGBMonth(price PriceInfo) (float64, bool) {
+	if strings.ToLower(price.ValueType) != "rate" || len(price.Rate.Tiers) == 0 {
+		return 0, false
+	}
+	tier := price.Rate.Tiers[0]
+	firstTierStart, ok := moneyToFloat(tier.StartAmount)
+	if !ok || firstTierStart != 0 {
+		return 0, false
+	}
+	dollars, ok := moneyToFloat(tier.ListPrice)
+	if !ok {
+		return 0, false
+	}
+	unitQuantity := normalizedUnitQuantity(price.Rate.Unit.UnitQuantity)
+	if unitQuantity > 0 {
+		dollars = dollars / unitQuantity
+	}
+
+	unit := strings.ToLower(strings.TrimSpace(price.Rate.Unit.Unit))
+	switch classifyGCPPriceUnit(unit) {
+	case "hourly":
+		// Convert per-GB-hour to per-GB-month (730 h/mo).
+		return dollars * 730, true
+	case "monthly":
+		return dollars, true
+	default:
+		return 0, false
+	}
+}
+
+// localSSDBundledGB returns the number of GB of local SSD bundled with a
+// machine type. For most GCP machine types this is 0 (local SSD is opt-in,
+// attached in 375 GB increments by the user). Legacy *-lssd variants (e.g.
+// "n1-standard-1-lssd") have mandatory bundled local SSDs; we don't have a
+// reliable count from the API for those so we conservatively return 0.
+// TODO: parse bundled disk counts from machine-type metadata if needed.
+func localSSDBundledGB(instanceType string) int {
+	return 0
+}
+
+// machineTypeSupportsLocalSSD reports whether attaching local SSD is
+// available for this machine type. The conservative default is true for all
+// standard predefined machine types (most GCP families allow attaching at
+// least one local SSD); shared-core/micro/small variants and a small set of
+// families do not. The cost surface is what matters here: if no local SSD
+// pricing is available for any region, callers will emit empty regions.
+func machineTypeSupportsLocalSSD(instanceType string, specs *MachineSpecs) bool {
+	if specs == nil {
+		return false
+	}
+	if specs.IsSharedCPU {
+		return false
+	}
+	return true
+}
+
 // Process SKUs and pricing data to generate GCP instances
 func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[string]*MachineSpecs, regions map[string]string) map[string]*GCPInstance {
 	instances := make(map[string]*GCPInstance)
+
+	// Pre-compute local SSD pricing per region/platform (shared by all
+	// instances since GCP charges a single per-GB-month rate per region for
+	// local SSD, independent of machine type).
+	localSSDPricing := extractLocalSSDPricing(skus, pricing)
 
 	// Group SKUs by machine type and region
 	type skuKey struct {
@@ -381,7 +537,8 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 			Pricing:            make(map[Region]map[OS]any),
 			Regions:            make(map[string]string),
 			AvailabilityZones:  make(map[string][]string),
-			LocalSSD:           false,
+			LocalSSD:           machineTypeSupportsLocalSSD(instanceType, specs),
+			LocalSSDSize:       localSSDBundledGB(instanceType),
 			SharedCPU:          specs.IsSharedCPU,
 			ComputeOptimized:   strings.Contains(specs.Family, "Compute optimized"),
 			MemoryOptimized:    strings.Contains(specs.Family, "Memory optimized"),
@@ -621,6 +778,37 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 	}
 
 	log.Printf("Added Windows pricing to %d instance-region combinations", windowsInstanceCount)
+
+	// Populate CostPerGb for every instance.
+	//
+	// Local SSD pricing is region/platform-scoped but not machine-type
+	// scoped on GCP (a single per-GB-month rate applies across machine
+	// types in a given region). For instances that support attaching local
+	// SSD, attach the per-region rate map; for instances that don't,
+	// emit baseline-only with empty regions. Always emit the field.
+	for _, instance := range instances {
+		baseline := float64(instance.LocalSSDSize)
+		regionMap := make(map[string]any)
+
+		if instance.LocalSSD {
+			for region, platforms := range localSSDPricing {
+				// Only surface regions where this instance is actually
+				// available (has compute pricing).
+				if _, ok := instance.Pricing[region]; !ok {
+					continue
+				}
+				if len(platforms) == 0 {
+					continue
+				}
+				regionMap[region] = collapseUniform(platforms)
+			}
+		}
+
+		instance.CostPerGb = &CostPerGb{
+			Baseline: baseline,
+			Regions:  regionMap,
+		}
+	}
 
 	return instances
 }


### PR DESCRIPTION
I imagine there's probably still stuff missing (or maybe not, this was made a while ago in another continent, I forgot a bunch), and I don't really have the will to figure that out for definite. Implements in the UI and API showing pricing based on what sized volume a user wants whilst keeping in mind the storage bundled with a instance. You'll want to update instanceskv to add the new attributes from this.

Feel free to edit my branch to make any changes. Probably won't check it much, I made this for a idea I had for a startup that I can't get funding for. Felt like a waste to keep it on my laptop though. The last commits timestamp is weird because I left it unchecked when I had to go somewhere. Also added some env vars that make it more tolerable if you use a bad ISP (you can thank Verizon FiOS for this change).