### PR TITLE
[Needs Verification] fix(ec2): correct Windows savings plan pricing for BYOL SKUs

### DIFF
--- a/scraper/aws/ec2/process_data.go
+++ b/scraper/aws/ec2/process_data.go
@@ -30,10 +30,11 @@ var EC2_ADD_METAL = map[string]bool{
 }
 
 type ec2SkuData struct {
-	instance    *EC2Instance
-	platform    string
-	hasBoxUsage bool
-	region      string
+	instance      *EC2Instance
+	platform      string
+	hasBoxUsage   bool
+	region        string
+	onDemandPrice float64
 }
 
 func processEC2Data(
@@ -118,7 +119,7 @@ func processEC2Data(
 				product.Attributes["operatingSystem"],
 				product.Attributes["preInstalledSw"],
 			)
-			if platform != "" {
+			if platform != "" && shouldIncludeEC2PricingSku(platform, product.Attributes["licenseModel"]) {
 				sku2SkuData[product.SKU] = ec2SkuData{
 					instance:    instance,
 					platform:    platform,
@@ -199,6 +200,8 @@ func processEC2Data(
 						if old < usdFloat {
 							pricingData.OnDemand = formatPrice(usdFloat)
 						}
+						skuData.onDemandPrice = usdFloat
+						sku2SkuData[offer.SKU] = skuData
 					}
 				}
 			}
@@ -218,9 +221,14 @@ func processEC2Data(
 					continue
 				}
 
+				pricingData := getPricingData(skuData.instance, skuData.platform)
+				if !skuOnDemandMatchesPlatform(skuData.onDemandPrice, pricingData.OnDemand) {
+					continue
+				}
+
 				// Process this reserved offer
 				processReservedOffer(
-					getPricingData(skuData.instance, skuData.platform),
+					pricingData,
 					offer.PriceDimensions,
 					offer.TermAttributes,
 					currency,
@@ -322,6 +330,9 @@ func processEC2Data(
 					regionPricing[skuInfo.platform] = osPricing
 				}
 				pricingData := osPricing.(*EC2PricingData)
+				if !skuOnDemandMatchesPlatform(skuInfo.onDemandPrice, pricingData.OnDemand) {
+					continue
+				}
 				if pricingData.Reserved == nil {
 					m := make(map[string]string)
 					pricingData.Reserved = &m

--- a/scraper/aws/ec2/sku_filter.go
+++ b/scraper/aws/ec2/sku_filter.go
@@ -1,0 +1,37 @@
+package ec2
+
+import (
+	"math"
+	"strconv"
+	"strings"
+)
+
+const ec2LicenseIncluded = "No License required"
+
+// shouldIncludeEC2PricingSku filters alternate Windows license SKUs that AWS
+// publishes alongside the standard license-included rate. BYOL and
+// infrastructure-license SKUs price compute only (matching Linux) and have their
+// own savings-plan rates; if we keep them, the last write wins and Windows
+// reserved/savings columns show Linux-equivalent prices.
+func shouldIncludeEC2PricingSku(platform, licenseModel string) bool {
+	if !strings.HasPrefix(platform, "mswin") {
+		return true
+	}
+	return licenseModel == ec2LicenseIncluded
+}
+
+// skuOnDemandMatchesPlatform reports whether a SKU's on-demand rate is the
+// canonical rate already stored for its platform. When multiple SKUs share a
+// platform (e.g. several "No License required" Windows variants), only the SKU
+// whose on-demand matches the stored platform price should contribute reserved
+// and savings-plan rates.
+func skuOnDemandMatchesPlatform(skuOnDemand float64, platformOnDemand string) bool {
+	if skuOnDemand <= 0 {
+		return true
+	}
+	platformPrice, err := strconv.ParseFloat(platformOnDemand, 64)
+	if err != nil || platformPrice <= 0 {
+		return true
+	}
+	return math.Abs(skuOnDemand-platformPrice) < 1e-9
+}

--- a/scraper/aws/ec2/sku_filter_test.go
+++ b/scraper/aws/ec2/sku_filter_test.go
@@ -1,0 +1,56 @@
+package ec2
+
+import "testing"
+
+func TestShouldIncludeEC2PricingSku(t *testing.T) {
+	tests := []struct {
+		platform     string
+		licenseModel string
+		want         bool
+	}{
+		{"linux", "", true},
+		{"linux", "No License required", true},
+		{"mswin", "No License required", true},
+		{"mswinSQLWeb", "No License required", true},
+		{"mswin", "Bring your own license", false},
+		{"mswin", "License Included - Infrastructure", false},
+		{"mswinSQL", "Bring your own license", false},
+	}
+	for _, tc := range tests {
+		if got := shouldIncludeEC2PricingSku(tc.platform, tc.licenseModel); got != tc.want {
+			t.Errorf(
+				"shouldIncludeEC2PricingSku(%q, %q) = %v, want %v",
+				tc.platform,
+				tc.licenseModel,
+				got,
+				tc.want,
+			)
+		}
+	}
+}
+
+func TestSkuOnDemandMatchesPlatform(t *testing.T) {
+	tests := []struct {
+		skuOnDemand        float64
+		platformOnDemand   string
+		want               bool
+	}{
+		{0.056, "0.056", true},
+		{0.056, "0.056000", true},
+		{0.046, "0.056", false},
+		{0, "0.056", true},
+		{0.056, "0", true},
+		{0.056, "bad", true},
+	}
+	for _, tc := range tests {
+		if got := skuOnDemandMatchesPlatform(tc.skuOnDemand, tc.platformOnDemand); got != tc.want {
+			t.Errorf(
+				"skuOnDemandMatchesPlatform(%v, %q) = %v, want %v",
+				tc.skuOnDemand,
+				tc.platformOnDemand,
+				got,
+				tc.want,
+			)
+		}
+	}
+}

--- a/scraper/aws/ec2/sku_filter_test.go
+++ b/scraper/aws/ec2/sku_filter_test.go
@@ -31,9 +31,9 @@ func TestShouldIncludeEC2PricingSku(t *testing.T) {
 
 func TestSkuOnDemandMatchesPlatform(t *testing.T) {
 	tests := []struct {
-		skuOnDemand        float64
-		platformOnDemand   string
-		want               bool
+		skuOnDemand      float64
+		platformOnDemand string
+		want             bool
 	}{
 		{0.056, "0.056", true},
 		{0.056, "0.056000", true},


### PR DESCRIPTION
This PR fixes some pricing bugs on a few instance types as detailed in #959 - I have not run the scraper locally yet and this PR needs to be validated locally by someone [maybe you? ;)] if they have time - or I can tackle later this week when I get a moment. The full explanation is on the comment I posted on the issue itself. 

If someone can run the scraper locally and validate the prices are coming in - we should be good to merge this in. 