### PR TITLE
fix(gcp): missing machine series, bundled Local SSD, M2/M4 rates, and CUDs

### DIFF
--- a/scraper/gcp/api.go
+++ b/scraper/gcp/api.go
@@ -165,10 +165,13 @@ type MachineSpecs struct {
 	MemoryGB    float64
 	Family      string
 	IsSharedCPU bool
-	GPU         int
-	GPUModel    string
-	GPUMemory   int
-	Zones       []string
+	// GPU is the attached GPU count, float64 because the fractional-slice G4
+	// shapes expose a partial GPU (0.125/0.25/0.5). It maps directly to the
+	// float64 GCPInstance.GPU output field.
+	GPU       float64
+	GPUModel  string
+	GPUMemory int
+	Zones     []string
 	// LocalSSDGB is the bundled Local SSD capacity in GB, 0 when the machine
 	// type has none. Optional (user-attachable) Local SSD is never counted.
 	LocalSSDGB int
@@ -181,16 +184,49 @@ type MachineSpecs struct {
 // https://cloud.google.com/compute/docs/accelerator-optimized-machines).
 // Unknown models return 0 so the field is omitted rather than fabricated.
 var gpuMemoryByModel = map[string]int{
-	"nvidia-h200-141gb":     141, // A3 Ultra
-	"nvidia-h100-80gb":      80,  // A3 High/Edge
-	"nvidia-h100-mega-80gb": 80,  // A3 Mega
-	"nvidia-a100-80gb":      80,  // A2 Ultra
-	"nvidia-tesla-a100":     40,  // A2 Standard (A100 40GB)
-	"nvidia-l4":             24,  // G2
+	"nvidia-h200-141gb":       141, // A3 Ultra
+	"nvidia-h100-80gb":        80,  // A3 High/Edge
+	"nvidia-h100-mega-80gb":   80,  // A3 Mega
+	"nvidia-a100-80gb":        80,  // A2 Ultra
+	"nvidia-tesla-a100":       40,  // A2 Standard (A100 40GB)
+	"nvidia-l4":               24,  // G2
+	"nvidia-b200":             180, // A4 (a4-highgpu-8g: 1,440 GB / 8 GPUs)
+	"nvidia-gb200":            186, // A4X (a4x-highgpu-4g: 744 GB / 4 GPUs)
+	"nvidia-gb300":            279, // A4X Max (a4x-maxgpu-4g-metal: 1,116 GB / 4 GPUs)
+	"nvidia-rtx-pro-6000":     96,  // G4 (g4-standard-48: one full 96 GB GPU)
+	"nvidia-rtx-pro-6000-vws": 96,  // G4 (same physical GPU, vWS variant)
+}
+
+// g4FractionalGPU describes the G4 shapes that expose a fractional slice (vGPU)
+// of a single RTX PRO 6000 rather than a whole GPU: g4-standard-6 = 1/8, -12 =
+// 1/4, -24 = 1/2, giving 12/24/48 GiB. The Compute Engine API reports these with
+// a whole-number GPU count, so both the count and count*96 memory would overstate
+// them; the machine-specs path reads the true fraction and memory here instead.
+// g4-standard-48 and larger are whole-GPU shapes (48 vCPU per GPU) and use the
+// normal count / count*96 derivation.
+var g4FractionalGPU = map[string]struct {
+	count     float64
+	memoryGiB int
+}{
+	"g4-standard-6":  {count: 0.125, memoryGiB: 12},
+	"g4-standard-12": {count: 0.25, memoryGiB: 24},
+	"g4-standard-24": {count: 0.5, memoryGiB: 48},
 }
 
 func totalGPUMemory(gpuCount int, gpuModel string) int {
 	return gpuCount * gpuMemoryByModel[gpuModel]
+}
+
+// gpuSpec resolves the reported GPU count and total GPU memory for a machine
+// type. Whole-GPU shapes multiply the API's accelerator count by the per-GPU
+// memory; the fractional-slice G4 shapes (which the API reports with a
+// whole-number count) instead report their true fraction and documented
+// per-slice memory from g4FractionalGPU.
+func gpuSpec(machineTypeName, gpuModel string, acceleratorCount int) (gpuCount float64, gpuMemoryGiB int) {
+	if fractional, ok := g4FractionalGPU[machineTypeName]; ok {
+		return fractional.count, fractional.memoryGiB
+	}
+	return float64(acceleratorCount), totalGPUMemory(acceleratorCount, gpuModel)
 }
 
 // localSSDPartitionGB returns the size in GB of a single bundled Local SSD
@@ -543,17 +579,17 @@ func fetchMachineTypes() (map[string]*MachineSpecs, error) {
 						LocalSSDGB:  bundledLocalSSDCapacityGB(mt),
 					}
 
-					// Handle GPUs/accelerators
+					// Handle GPUs/accelerators. Per-GPU memory is not exposed by
+					// the Compute Engine machineTypes API, so gpuSpec derives it
+					// from the model string (and handles the fractional-slice G4
+					// shapes whose whole-number count would otherwise overstate
+					// GPU memory).
 					if len(mt.Accelerators) > 0 {
-						specs.GPU = mt.Accelerators[0].GuestAcceleratorCount
 						specs.GPUModel = mt.Accelerators[0].GuestAcceleratorType
-						// Per-GPU memory is not exposed by the Compute Engine
-						// machineTypes API, so derive it from the model string
-						// using the documented per-GPU memory map. GPU_memory
-						// is total memory across all attached GPUs.
-						specs.GPUMemory = totalGPUMemory(
-							specs.GPU,
+						specs.GPU, specs.GPUMemory = gpuSpec(
+							mt.Name,
 							specs.GPUModel,
+							mt.Accelerators[0].GuestAcceleratorCount,
 						)
 					}
 

--- a/scraper/gcp/api.go
+++ b/scraper/gcp/api.go
@@ -521,6 +521,16 @@ func determineMachineFamily(name string) string {
 
 	// Check for specific patterns
 	switch {
+	// Storage optimized (checked ahead of the highmem rule below: every real
+	// Z3 shape is named z3-highmem-*, so the memory-optimized "highmem" check
+	// would otherwise shadow this case entirely)
+	case strings.HasPrefix(nameLower, "z3-"):
+		return "Storage optimized"
+
+	// Network optimized
+	case strings.HasPrefix(nameLower, "c4n-"):
+		return "Network optimized"
+
 	// Memory optimized
 	case strings.Contains(nameLower, "highmem"),
 		strings.Contains(nameLower, "megamem"),
@@ -529,6 +539,7 @@ func determineMachineFamily(name string) string {
 		strings.HasPrefix(nameLower, "m2-"),
 		strings.HasPrefix(nameLower, "m3-"),
 		strings.HasPrefix(nameLower, "m4-"),
+		strings.HasPrefix(nameLower, "m4n-"),
 		strings.HasPrefix(nameLower, "x4-"):
 		return "Memory optimized"
 
@@ -540,7 +551,9 @@ func determineMachineFamily(name string) string {
 		strings.HasPrefix(nameLower, "c3d-"),
 		strings.HasPrefix(nameLower, "c4-"),
 		strings.HasPrefix(nameLower, "c4a-"),
-		strings.HasPrefix(nameLower, "h3-"):
+		strings.HasPrefix(nameLower, "c4d-"),
+		strings.HasPrefix(nameLower, "h3-"),
+		strings.HasPrefix(nameLower, "h4d-"):
 		// c4-highmem and similar should be memory optimized
 		if strings.Contains(nameLower, "highmem") {
 			return "Memory optimized"
@@ -550,12 +563,11 @@ func determineMachineFamily(name string) string {
 	// Accelerator optimized (GPU)
 	case strings.HasPrefix(nameLower, "a2-"),
 		strings.HasPrefix(nameLower, "a3-"),
-		strings.HasPrefix(nameLower, "g2-"):
+		strings.HasPrefix(nameLower, "a4-"),
+		strings.HasPrefix(nameLower, "a4x-"),
+		strings.HasPrefix(nameLower, "g2-"),
+		strings.HasPrefix(nameLower, "g4-"):
 		return "Accelerator optimized"
-
-	// Storage optimized
-	case strings.HasPrefix(nameLower, "z3-"):
-		return "Storage optimized"
 
 	// General purpose (default)
 	default:
@@ -571,7 +583,38 @@ func determineMachineFamily(name string) string {
 // "Sole Tenancy Instance RAM running in Jakarta"
 // "Licensing Fee for Windows Server 2012 BYOL (CPU cost)"
 // "Licensing Fee for Windows Server 2012 BYOL (RAM cost)"
-var machineTypeRegex = regexp.MustCompile(`(?i)(n1|n2d|n2|n4d|n4|e2|e2a|c2|c2d|m1|m2|m3|m4|t2d|t2a|a2|a3|g2|h3|c3|c3d|z3|c4)\b.*(?:instance\s+(core|ram)|\((?:cpu|ram)\s+cost\))`)
+//
+// Accelerator exclusions: g4, a4 and a4x are deliberately absent. Their billing
+// is dominated by a GPU charge this scraper does not assemble (G4: the
+// "... RTX 6000 96GB ..." GPU SKUs; A4: it bills *solely* as bundled
+// "A4 Nvidia B200 (1 gpu slice)" SKUs with no core/RAM SKUs to sum; A4X: no
+// public SKUs yet), so emitting a core+RAM-only price would understate them.
+// a2, a3 and g2 stay: they are pre-existing upstream coverage and dropping them
+// would regress the current site. They share the same GPU-charge gap; a
+// follow-up will price the GPU component behind a completeness guard, after
+// which the excluded families can return.
+var machineTypeRegex = regexp.MustCompile(`(?i)(n1|n2d|n2|n4d|n4a|n4|e2|e2a|c2|c2d|m1|m2|m3|m4n|m4|x4|t2d|t2a|a2|a3|g2|h3|h4d|c3|c3d|z3|c4a|c4d|c4n|c4)\b.*(?:instance\s+(core|ram)|\((?:cpu|ram)\s+cost\))`)
+
+// legacySKURegex matches the first-generation SKU naming formats that predate
+// the "<FAMILY> Instance Core/Ram" convention and carry no machine family token
+// for machineTypeRegex to capture:
+//
+//	"Compute optimized Core running in Americas"          (C2, multi-regional)
+//	"Compute optimized Instance Core running in Madrid"   (C2, per-region)
+//	"Memory-optimized Instance Ram running in Frankfurt"  (M1)
+//
+// The "Instance" token is optional: C2's multi-regional SKUs omit it while its
+// ~13 per-region SKUs (africa-south1, the me-* / europe-* newer regions, etc.)
+// include it, and M1 always includes it. Without accepting the "Instance"
+// variant the per-region C2 SKUs get no on-demand/spot baseline, which also
+// drops their (correctly parsed) commitment SKUs at the CUD gate.
+//
+// Without this mapping the C2 and M1 series get no pricing at all and are
+// dropped from the dataset entirely. M2 is billed as the M1 rates plus a
+// separate "Memory Optimized Upgrade Premium for Memory-optimized Instance
+// ..." SKU; the premium SKUs are excluded by the caller so they never
+// pollute M1 baseline pricing.
+var legacySKURegex = regexp.MustCompile(`(?i)\b(compute optimized|memory-optimized)(?:\s+instance)?\s+(core|ram)\b`)
 
 // Resource-based committed use discount (CUD) SKUs use a distinct display-name
 // format from on-demand instance SKUs, e.g.:
@@ -582,7 +625,12 @@ var machineTypeRegex = regexp.MustCompile(`(?i)(n1|n2d|n2|n4d|n4|e2|e2a|c2|c2d|m
 // The family token may carry a vendor qualifier ("AMD") before the resource
 // keyword; the term is "1 Year" or "3 Year". An optional skip group consumes
 // such qualifiers so the resource keyword (Cpu/Ram) is captured directly.
-var cudSKURegex = regexp.MustCompile(`(?i)^commitment\s+v\d+:\s+(n1|n2d|n2|n4d|n4|e2|e2a|c2|c2d|m1|m2|m3|m4|t2d|t2a|a2|a3|g2|h3|c3|c3d|z3|c4)\s+(?:[a-z0-9]+\s+)*?(cpu|ram)\s+in\s+.+\s+for\s+(1|3)\s+year`)
+//
+// The g4/a4/a4x accelerator families are excluded here for the same reason as in
+// machineTypeRegex: their instances publish no core+RAM price, so their
+// commitment SKUs have nothing to attach to. Keep this allowlist in sync with
+// machineTypeRegex.
+var cudSKURegex = regexp.MustCompile(`(?i)^commitment\s+v\d+:\s+(n1|n2d|n2|n4d|n4a|n4|e2|e2a|c2|c2d|m1|m2|m3|m4n|m4|x4|t2d|t2a|a2|a3|g2|h3|h4d|c3|c3d|z3|c4a|c4d|c4n|c4)\s+(?:[a-z0-9]+\s+)*?(cpu|ram)\s+in\s+.+\s+for\s+(1|3)\s+year`)
 
 // CUD commitment terms used as keys in the CUD pricing buckets.
 const (
@@ -649,6 +697,22 @@ func parseMachineTypeFromSKU(sku SKU) (machineFamily string, resourceType string
 			} else if strings.Contains(displayLower, "ram cost") {
 				resourceType = "ram"
 			}
+		}
+	}
+
+	// Fall back to the legacy first-generation SKU naming used by C2 and M1,
+	// which carries no family token. The "Upgrade Premium" surcharge SKUs
+	// (how M2 is billed on top of the M1 rates) must not map to the M1
+	// baseline rates, so they are excluded here.
+	if machineFamily == "" && !strings.Contains(strings.ToLower(displayName), "premium") {
+		if legacyMatches := legacySKURegex.FindStringSubmatch(displayName); len(legacyMatches) >= 3 {
+			switch strings.ToLower(legacyMatches[1]) {
+			case "compute optimized":
+				machineFamily = "C2"
+			case "memory-optimized":
+				machineFamily = "M1"
+			}
+			resourceType = strings.ToLower(legacyMatches[2])
 		}
 	}
 

--- a/scraper/gcp/api.go
+++ b/scraper/gcp/api.go
@@ -47,9 +47,14 @@ type CategoryItem struct {
 }
 
 type GeoTaxonomy struct {
-	Type             string            `json:"type"`
-	RegionalMetadata *RegionalMetadata `json:"regionalMetadata,omitempty"`
-	Regions          []string          `json:"regions,omitempty"`
+	Type                  string                 `json:"type"`
+	RegionalMetadata      *RegionalMetadata      `json:"regionalMetadata,omitempty"`
+	MultiRegionalMetadata *MultiRegionalMetadata `json:"multiRegionalMetadata,omitempty"`
+	Regions               []string               `json:"regions,omitempty"`
+}
+
+type MultiRegionalMetadata struct {
+	Regions []RegionInfo `json:"regions"`
 }
 
 type RegionalMetadata struct {
@@ -123,6 +128,16 @@ type MachineType struct {
 	MaximumPersistentDisks       int           `json:"maximumPersistentDisks"`
 	MaximumPersistentDisksSizeGb string        `json:"maximumPersistentDisksSizeGb"`
 	Accelerators                 []Accelerator `json:"accelerators,omitempty"`
+	// BundledLocalSsds is only present for machine types that come with Local
+	// SSD built in (Z3, the -lssd shapes of C3/C3D/C4/C4A/C4D/H4D, and the
+	// accelerator-optimized series). Families where Local SSD is an optional
+	// per-VM attachment omit the field entirely.
+	BundledLocalSsds *BundledLocalSsds `json:"bundledLocalSsds,omitempty"`
+}
+
+type BundledLocalSsds struct {
+	DefaultInterface string `json:"defaultInterface"`
+	PartitionCount   int    `json:"partitionCount"`
 }
 
 type Accelerator struct {
@@ -154,6 +169,9 @@ type MachineSpecs struct {
 	GPUModel    string
 	GPUMemory   int
 	Zones       []string
+	// LocalSSDGB is the bundled Local SSD capacity in GB, 0 when the machine
+	// type has none. Optional (user-attachable) Local SSD is never counted.
+	LocalSSDGB int
 }
 
 // gpuMemoryByModel maps a GCP guestAcceleratorType (the model string the
@@ -173,6 +191,46 @@ var gpuMemoryByModel = map[string]int{
 
 func totalGPUMemory(gpuCount int, gpuModel string) int {
 	return gpuCount * gpuMemoryByModel[gpuModel]
+}
+
+// localSSDPartitionGB returns the size in GB of a single bundled Local SSD
+// partition for a machine type. Most machine series bundle Local SSD in
+// 375 GB partitions; Titanium SSD series use larger disks whose sizes only
+// appear in the per-series docs: Z3 is 3,000 GiB (6,000 GiB bare metal), C4
+// bare metal is 3,000 GiB (c4-standard-288-lssd-metal: 6 x 3,000 GiB), and
+// A4X/A4X Max bundle 12,000 GiB as 4 x 3,000 GiB (a4x-highgpu-4g and
+// a4x-maxgpu-4g-metal).
+func localSSDPartitionGB(machineTypeName string) int {
+	nameLower := strings.ToLower(machineTypeName)
+	isMetal := strings.HasSuffix(nameLower, "-metal")
+	switch {
+	case strings.HasPrefix(nameLower, "z3-") && isMetal:
+		return 6000
+	case strings.HasPrefix(nameLower, "z3-"):
+		return 3000
+	case strings.HasPrefix(nameLower, "c4-") && isMetal:
+		return 3000
+	case strings.HasPrefix(nameLower, "a4x-"):
+		return 3000
+	default:
+		return 375
+	}
+}
+
+// bundledLocalSSDCapacityGB returns the total bundled Local SSD capacity in GB
+// for a machine type, or 0 when the shape has none. Only bundled capacity is
+// reported: families where Local SSD is an optional per-VM attachment
+// (N1/N2/N2D/C2/...) return 0 because attached disks are a user choice, not
+// part of the machine type.
+func bundledLocalSSDCapacityGB(mt MachineType) int {
+	partitions := 0
+	if mt.BundledLocalSsds != nil {
+		partitions = mt.BundledLocalSsds.PartitionCount
+	}
+	if partitions <= 0 {
+		return 0
+	}
+	return partitions * localSSDPartitionGB(mt.Name)
 }
 
 // Fetch all SKUs for Compute Engine with pagination
@@ -482,6 +540,7 @@ func fetchMachineTypes() (map[string]*MachineSpecs, error) {
 						Family:      family,
 						IsSharedCPU: mt.IsSharedCpu,
 						Zones:       []string{zone},
+						LocalSSDGB:  bundledLocalSSDCapacityGB(mt),
 					}
 
 					// Handle GPUs/accelerators
@@ -672,6 +731,101 @@ func parseCUDSKU(sku SKU) (machineFamily string, resourceType string, term strin
 	return machineFamily, resourceType, term, true
 }
 
+// Local SSD usage SKU display names come in two forms: a per-family form used
+// by newer machine series and a generic catch-all form, each with a spot
+// variant:
+//
+//	"C4D Instance Local SSD running in Frankfurt"
+//	"Spot Preemptible C4D Instance Local SSD running in Frankfurt"
+//	"SSD backed Local Storage in Paris"
+//	"SSD backed Local Storage attached to Spot Preemptible VMs in Paris"
+//
+// The generic form's region tail varies ("in <city>", "running in <region>",
+// or none at all for the legacy multi-regional SKUs covering asia-east1,
+// europe-west1, us-central1, us-east1 and us-west1); the prefix-anchored
+// pattern matches all of them.
+//
+// Commitment SKUs ("Commitment v1: C4D Local SSD in ... for 1 Year") and
+// suspended-VM state SKUs ("VM state: preserved local SSD in ...") must not
+// feed baseline pricing; both anchored patterns reject them because the
+// display name does not start with a "<family> Instance Local SSD" or
+// "SSD backed Local Storage" prefix.
+var familyLocalSSDSKURegex = regexp.MustCompile(`(?i)^(?:spot\s+preemptible\s+)?([a-z][a-z0-9]{1,3})\s+instance\s+local\s+ssd\b`)
+var genericLocalSSDSKURegex = regexp.MustCompile(`(?i)^ssd\s+backed\s+local\s+storage\b`)
+
+// parseLocalSSDSKU parses a Local SSD usage SKU. It returns the machine family
+// the SKU is scoped to (uppercased, e.g. "C4D"; empty for the generic
+// "SSD backed Local Storage" SKUs that apply to any family) and whether the
+// SKU carries spot/preemptible rates. Rates are per GiB-month in the catalog;
+// calculateHourlyPrice converts them to per GiB-hour.
+func parseLocalSSDSKU(sku SKU) (machineFamily string, isSpot bool, ok bool) {
+	displayName := sku.DisplayName
+	displayLower := strings.ToLower(displayName)
+
+	// Reservation-scheduling products (DWS calendar mode / flex-start) bill
+	// Local SSD under their own SKUs and must not feed baseline pricing.
+	if strings.Contains(displayLower, "calendar") || strings.Contains(displayLower, "flex") {
+		return "", false, false
+	}
+
+	isSpot = strings.Contains(displayLower, "preemptible") || strings.Contains(displayLower, "spot")
+
+	if matches := familyLocalSSDSKURegex.FindStringSubmatch(displayName); len(matches) >= 2 {
+		return strings.ToUpper(matches[1]), isSpot, true
+	}
+	if genericLocalSSDSKURegex.MatchString(displayName) {
+		return "", isSpot, true
+	}
+	return "", false, false
+}
+
+// skuRegion resolves the region code for a SKU from its geo taxonomy, falling
+// back to the multi-regional grouping named in the display name (e.g.
+// "running in Americas" -> "multi-americas").
+// multiRegionalMetadataRegions returns the explicit region list of a
+// multi-regional SKU. Nearly all Local SSD SKUs are regional, with the region
+// resolvable from the display name ("SSD backed Local Storage in Milan").
+// The exception is Google's five original regions (asia-east1, europe-west1,
+// us-central1, us-east1, us-west1): they predate per-region SKU naming and
+// Google never retro-created regional SKUs for them, so their generic Local
+// SSD price exists only on the bare legacy SKUs ("SSD backed Local Storage"
+// and its Spot Preemptible variant), whose region list lives solely in this
+// metadata.
+func multiRegionalMetadataRegions(sku SKU) []string {
+	if sku.GeoTaxonomy.MultiRegionalMetadata == nil {
+		return nil
+	}
+	regions := make([]string, 0, len(sku.GeoTaxonomy.MultiRegionalMetadata.Regions))
+	for _, r := range sku.GeoTaxonomy.MultiRegionalMetadata.Regions {
+		if r.Region != "" {
+			regions = append(regions, r.Region)
+		}
+	}
+	return regions
+}
+
+func skuRegion(sku SKU) string {
+	if len(sku.GeoTaxonomy.Regions) > 0 {
+		// Use the first region as a fallback; callers can read full Regions.
+		return sku.GeoTaxonomy.Regions[0]
+	}
+	if sku.GeoTaxonomy.RegionalMetadata != nil {
+		return sku.GeoTaxonomy.RegionalMetadata.Region.Region
+	}
+	if sku.GeoTaxonomy.Type == "TYPE_MULTI_REGIONAL" {
+		displayLower := strings.ToLower(sku.DisplayName)
+		switch {
+		case strings.Contains(displayLower, "americas"):
+			return "multi-americas"
+		case strings.Contains(displayLower, "europe"):
+			return "multi-europe"
+		case strings.Contains(displayLower, "asia"):
+			return "multi-asia"
+		}
+	}
+	return ""
+}
+
 func parseMachineTypeFromSKU(sku SKU) (machineFamily string, resourceType string, region string, isSpot bool, isWindows bool) {
 	displayName := sku.DisplayName
 
@@ -716,24 +870,9 @@ func parseMachineTypeFromSKU(sku SKU) (machineFamily string, resourceType string
 		}
 	}
 
-	// Get region from geo taxonomy.
-	if len(sku.GeoTaxonomy.Regions) > 0 {
-		// Use the first region as a fallback; callers can read full Regions.
-		region = sku.GeoTaxonomy.Regions[0]
-	} else if sku.GeoTaxonomy.RegionalMetadata != nil {
-		region = sku.GeoTaxonomy.RegionalMetadata.Region.Region
-	} else if sku.GeoTaxonomy.Type == "TYPE_MULTI_REGIONAL" {
-		// Use multi-regional as a special "region" identifier
-		// Extract the location from display name (e.g., "running in Americas")
-		displayLower := strings.ToLower(displayName)
-		if strings.Contains(displayLower, "americas") {
-			region = "multi-americas"
-		} else if strings.Contains(displayLower, "europe") {
-			region = "multi-europe"
-		} else if strings.Contains(displayLower, "asia") {
-			region = "multi-asia"
-		}
-	}
+	// Get region from geo taxonomy (multi-regional SKUs resolve to a special
+	// "multi-*" region identifier).
+	region = skuRegion(sku)
 
 	return
 }

--- a/scraper/gcp/api.go
+++ b/scraper/gcp/api.go
@@ -642,6 +642,10 @@ func determineMachineFamily(name string) string {
 // "Sole Tenancy Instance RAM running in Jakarta"
 // "Licensing Fee for Windows Server 2012 BYOL (CPU cost)"
 // "Licensing Fee for Windows Server 2012 BYOL (RAM cost)"
+// m4ultramem224 is listed ahead of m4n/m4: m4-ultramem-224 is billed under its
+// own dedicated "M4Ultramem224 Instance Core/Ram" SKU pair rather than the
+// plain M4 rates that cover every other M4 shape (see the family-override
+// comment in processGCPData for why this needs its own bucket).
 //
 // Accelerator exclusions: g4, a4 and a4x are deliberately absent. Their billing
 // is dominated by a GPU charge this scraper does not assemble (G4: the
@@ -652,7 +656,7 @@ func determineMachineFamily(name string) string {
 // would regress the current site. They share the same GPU-charge gap; a
 // follow-up will price the GPU component behind a completeness guard, after
 // which the excluded families can return.
-var machineTypeRegex = regexp.MustCompile(`(?i)(n1|n2d|n2|n4d|n4a|n4|e2|e2a|c2|c2d|m1|m2|m3|m4n|m4|x4|t2d|t2a|a2|a3|g2|h3|h4d|c3|c3d|z3|c4a|c4d|c4n|c4)\b.*(?:instance\s+(core|ram)|\((?:cpu|ram)\s+cost\))`)
+var machineTypeRegex = regexp.MustCompile(`(?i)(n1|n2d|n2|n4d|n4a|n4|e2|e2a|c2|c2d|m1|m2|m3|m4ultramem224|m4n|m4|x4|t2d|t2a|a2|a3|g2|h3|h4d|c3|c3d|z3|c4a|c4d|c4n|c4)\b.*(?:instance\s+(core|ram)|\((?:cpu|ram)\s+cost\))`)
 
 // legacySKURegex matches the first-generation SKU naming formats that predate
 // the "<FAMILY> Instance Core/Ram" convention and carry no machine family token
@@ -689,7 +693,7 @@ var legacySKURegex = regexp.MustCompile(`(?i)\b(compute optimized|memory-optimiz
 // machineTypeRegex: their instances publish no core+RAM price, so their
 // commitment SKUs have nothing to attach to. Keep this allowlist in sync with
 // machineTypeRegex.
-var cudSKURegex = regexp.MustCompile(`(?i)^commitment\s+v\d+:\s+(n1|n2d|n2|n4d|n4a|n4|e2|e2a|c2|c2d|m1|m2|m3|m4n|m4|x4|t2d|t2a|a2|a3|g2|h3|h4d|c3|c3d|z3|c4a|c4d|c4n|c4)\s+(?:[a-z0-9]+\s+)*?(cpu|ram)\s+in\s+.+\s+for\s+(1|3)\s+year`)
+var cudSKURegex = regexp.MustCompile(`(?i)^commitment\s+v\d+:\s+(n1|n2d|n2|n4d|n4a|n4|e2|e2a|c2|c2d|m1|m2|m3|m4ultramem224|m4n|m4|x4|t2d|t2a|a2|a3|g2|h3|h4d|c3|c3d|z3|c4a|c4d|c4n|c4)\s+(?:[a-z0-9]+\s+)*?(cpu|ram)\s+in\s+.+\s+for\s+(1|3)\s+year`)
 
 // CUD commitment terms used as keys in the CUD pricing buckets.
 const (
@@ -934,8 +938,22 @@ func calculateHourlyPrice(price PriceInfo) float64 {
 		return 0
 	}
 
+	// Almost every RAM SKU is rated per binary GiB ("GiBy.h"), matching
+	// MachineSpecs.MemoryGB (== memoryMb/1024, i.e. GiB). A handful of newer
+	// SKU families (seen so far: C4D, M4Ultramem224) are instead rated per
+	// decimal GB ("GBy.h"). Scale those up to a per-GiB rate so the shared
+	// vCPU/RAM total-price math downstream can keep treating every rate as
+	// per-GiB regardless of which unit the catalog happened to use.
+	if unit == "gby.h" {
+		dollars *= gibPerDecimalGB
+	}
+
 	return dollars
 }
+
+// gibPerDecimalGB is how many decimal gigabytes (1000^3 bytes) fit in one
+// binary gibibyte (1024^3 bytes).
+const gibPerDecimalGB = 1024 * 1024 * 1024 / 1e9
 
 // GCP Region from API
 type GCPRegion struct {

--- a/scraper/gcp/api.go
+++ b/scraper/gcp/api.go
@@ -779,6 +779,29 @@ func parseLocalSSDSKU(sku SKU) (machineFamily string, isSpot bool, ok bool) {
 	return "", false, false
 }
 
+// memoryOptimizedPremiumSKURegex matches the "Memory Optimized Upgrade
+// Premium" surcharge SKUs that, added on top of the M1 base core/RAM rates,
+// constitute M2 pricing (M2 has no dedicated SKUs of its own):
+//
+//	"Memory Optimized Upgrade Premium for Memory-optimized Instance Core running in Americas"
+//	"Memory Optimized Upgrade Premium for Memory-optimized Instance Ram running in Frankfurt"
+//
+// These exist only as plain on-demand SKUs; the catalog has no Spot or
+// committed-use variant of the premium, so M2 Spot and CUD prices cannot be
+// synthesized (see processGCPData).
+var memoryOptimizedPremiumSKURegex = regexp.MustCompile(`(?i)^memory optimized upgrade premium for memory-optimized instance\s+(core|ram)\b`)
+
+// parseMemoryOptimizedPremiumSKU reports whether a SKU is a Memory Optimized
+// Upgrade Premium surcharge and, if so, which resource ("core" or "ram") it
+// applies to. Region resolution is left to the shared geo-taxonomy machinery.
+func parseMemoryOptimizedPremiumSKU(sku SKU) (resourceType string, ok bool) {
+	matches := memoryOptimizedPremiumSKURegex.FindStringSubmatch(sku.DisplayName)
+	if len(matches) < 2 {
+		return "", false
+	}
+	return strings.ToLower(matches[1]), true
+}
+
 // skuRegion resolves the region code for a SKU from its geo taxonomy, falling
 // back to the multi-regional grouping named in the display name (e.g.
 // "running in Americas" -> "multi-americas").

--- a/scraper/gcp/api.go
+++ b/scraper/gcp/api.go
@@ -686,7 +686,7 @@ var legacySKURegex = regexp.MustCompile(`(?i)\b(compute optimized|memory-optimiz
 //	"Commitment v1: C2D AMD Ram in EMEA for 3 Year"
 //
 // The family token may carry a vendor qualifier ("AMD") before the resource
-// keyword; the term is "1 Year" or "3 Year". An optional skip group consumes
+// keyword; the term is "1 Year" or "3 Year[s]". An optional skip group consumes
 // such qualifiers so the resource keyword (Cpu/Ram) is captured directly.
 //
 // The g4/a4/a4x accelerator families are excluded here for the same reason as in
@@ -694,6 +694,30 @@ var legacySKURegex = regexp.MustCompile(`(?i)\b(compute optimized|memory-optimiz
 // commitment SKUs have nothing to attach to. Keep this allowlist in sync with
 // machineTypeRegex.
 var cudSKURegex = regexp.MustCompile(`(?i)^commitment\s+v\d+:\s+(n1|n2d|n2|n4d|n4a|n4|e2|e2a|c2|c2d|m1|m2|m3|m4ultramem224|m4n|m4|x4|t2d|t2a|a2|a3|g2|h3|h4d|c3|c3d|z3|c4a|c4d|c4n|c4)\s+(?:[a-z0-9]+\s+)*?(cpu|ram)\s+in\s+.+\s+for\s+(1|3)\s+year`)
+
+// legacyCUDSKURegex matches the first-generation commitment SKU naming used by
+// C2 and M1, which carries no machine-family token (mirroring how
+// legacySKURegex handles their on-demand twins). The catalog uses two distinct
+// spellings that between them cover different region sets, so both must map:
+//
+//	"Commitment v1: Compute optimized Cpu in Berlin for 1 Year"        (C2, ~13 newer regions)
+//	"Commitment: Compute optimized Core running in Americas for 1 Year" (C2, major regions incl. multi-Americas/EMEA/APAC)
+//	"Commitment v1: Memory-optimized Ram in Frankfurt for 3 Years"     (M1)
+//
+// The version token ("v1") and the resource keyword ("Cpu" vs "Core") and the
+// region connector ("in" vs "running in") all vary between the two spellings;
+// only C2 uses the version-less "Compute optimized Core" form (M1 and Local SSD
+// commitments are version-only). Without this, C2 and M1 shapes get no
+// cud_1yr/cud_3yr at all -- and the version-less C2 form is what covers
+// us-central1 (via the multi-Americas grouping).
+//
+// The "M3 Memory-optimized ..." commitment SKUs are not matched: their family
+// token precedes "Memory-optimized", so the "memory-optimized" alternative here
+// (anchored immediately after the "Commitment[ v1]: " prefix) cannot reach them.
+// The Memory Optimized Upgrade Premium surcharge (how M2 is billed on top of M1)
+// has no commitment variant in the catalog, so it can never leak into M1's CUD
+// bucket through this pattern.
+var legacyCUDSKURegex = regexp.MustCompile(`(?i)^commitment(?:\s+v\d+)?:\s+(compute optimized|memory-optimized)\s+(cpu|core|ram)\s+(?:running\s+)?in\s+.+\s+for\s+(1|3)\s+year`)
 
 // CUD commitment terms used as keys in the CUD pricing buckets.
 const (
@@ -708,14 +732,23 @@ const (
 // on-demand SKUs use), so the region groupings in the display name are ignored.
 func parseCUDSKU(sku SKU) (machineFamily string, resourceType string, term string, ok bool) {
 	matches := cudSKURegex.FindStringSubmatch(sku.DisplayName)
-	if len(matches) < 4 {
+	if len(matches) >= 4 {
+		machineFamily = strings.ToUpper(matches[1])
+	} else if legacyMatches := legacyCUDSKURegex.FindStringSubmatch(sku.DisplayName); len(legacyMatches) >= 4 {
+		// Legacy first-generation commitment naming carries no family token.
+		switch strings.ToLower(legacyMatches[1]) {
+		case "compute optimized":
+			machineFamily = "C2"
+		case "memory-optimized":
+			machineFamily = "M1"
+		}
+		matches = legacyMatches
+	} else {
 		return "", "", "", false
 	}
 
-	machineFamily = strings.ToUpper(matches[1])
-
 	switch strings.ToLower(matches[2]) {
-	case "cpu":
+	case "cpu", "core":
 		resourceType = "core"
 	case "ram":
 		resourceType = "ram"
@@ -753,7 +786,8 @@ func parseCUDSKU(sku SKU) (machineFamily string, resourceType string, term strin
 // suspended-VM state SKUs ("VM state: preserved local SSD in ...") must not
 // feed baseline pricing; both anchored patterns reject them because the
 // display name does not start with a "<family> Instance Local SSD" or
-// "SSD backed Local Storage" prefix.
+// "SSD backed Local Storage" prefix. Local SSD commitment SKUs are instead
+// parsed by parseLocalSSDCommitmentSKU and folded into CUD pricing.
 var familyLocalSSDSKURegex = regexp.MustCompile(`(?i)^(?:spot\s+preemptible\s+)?([a-z][a-z0-9]{1,3})\s+instance\s+local\s+ssd\b`)
 var genericLocalSSDSKURegex = regexp.MustCompile(`(?i)^ssd\s+backed\s+local\s+storage\b`)
 
@@ -781,6 +815,48 @@ func parseLocalSSDSKU(sku SKU) (machineFamily string, isSpot bool, ok bool) {
 		return "", isSpot, true
 	}
 	return "", false, false
+}
+
+// Local SSD committed-use discount SKUs share the "Commitment v1:" prefix with
+// resource CUDs but commit Local SSD capacity rather than core/RAM, e.g.:
+//
+//	"Commitment v1: Local SSD in Iowa for 1 Year"          (generic, any family)
+//	"Commitment v1: Z3 Local SSD in Alabama for 3 Years"   (family-scoped)
+//
+// The generic form has no family token; the family form carries one before
+// "Local SSD". The "Commitment v1: vGPU G4 Local SSD ..." variant is
+// deliberately not matched, mirroring the on-demand path (familyLocalSSDSKURegex)
+// which likewise ignores the vGPU twin of the G4 Local SSD SKU, so a g4 shape's
+// SSD price comes from the same source for on-demand and CUD. "Reserved ..." and
+// "DWS ..." Local SSD SKUs never reach this pattern: they lack the
+// "Commitment v1:" prefix entirely.
+var localSSDCommitmentSKURegex = regexp.MustCompile(`(?i)^commitment\s+v\d+:\s+(?:([a-z][a-z0-9]{1,3})\s+)?local\s+ssd\s+in\s+.+\s+for\s+(1|3)\s+year`)
+
+// parseLocalSSDCommitmentSKU parses a Local SSD committed-use discount SKU. It
+// returns the machine family the commitment is scoped to (uppercased, e.g.
+// "Z3"; empty for the generic "Commitment v1: Local SSD" SKUs that apply to any
+// family), the commitment term ("1yr" or "3yr"), and whether the SKU is a Local
+// SSD commitment at all. Region resolution is left to the shared CUD geo-taxonomy
+// machinery (cudTargetRegions). Rates are per GiB-month in the catalog;
+// calculateHourlyPrice converts them to per GiB-hour.
+func parseLocalSSDCommitmentSKU(sku SKU) (machineFamily string, term string, ok bool) {
+	matches := localSSDCommitmentSKURegex.FindStringSubmatch(sku.DisplayName)
+	if len(matches) < 3 {
+		return "", "", false
+	}
+
+	machineFamily = strings.ToUpper(matches[1]) // "" for the generic form
+
+	switch matches[2] {
+	case "1":
+		term = cudTerm1Yr
+	case "3":
+		term = cudTerm3Yr
+	default:
+		return "", "", false
+	}
+
+	return machineFamily, term, true
 }
 
 // memoryOptimizedPremiumSKURegex matches the "Memory Optimized Upgrade

--- a/scraper/gcp/api.go
+++ b/scraper/gcp/api.go
@@ -249,8 +249,43 @@ func localSSDPartitionGB(machineTypeName string) int {
 	case strings.HasPrefix(nameLower, "a4x-"):
 		return 3000
 	default:
+		series, _, _ := strings.Cut(nameLower, "-")
+		if isMetal || !localSSD375Series[series] {
+			utils.SendWarning("GCP machine type", machineTypeName,
+				"bundles Local SSD but has no documented partition size (unlisted series, or a bare-metal variant,"+
+					"which for Z3 and C4 uses larger Titanium SSD disks); assuming 375 GB per partition")
+		}
 		return 375
 	}
+}
+
+// localSSD375Series are the machine series documented to bundle Local SSD in
+// 375 GB partitions. The Compute Engine API reports partition count but not
+// partition size, so a series outside this set would be silently mispriced at
+// 375 GB per partition; localSSDPartitionGB warns instead of assuming quietly.
+//
+// Membership is per series, not per shape, so it cannot vouch for a bare-metal
+// variant: Z3 and C4 metal shapes use larger disks than their own series does.
+// localSSDPartitionGB therefore warns about every unhandled -metal shape too,
+// however its series is listed here.
+//
+// Every series here was checked against the live machineTypes API: each
+// shape's partitionCount x 375 GB equals the capacity Google documents for it.
+// C4N and G4 are included from the docs alone (375 GiB disks) because as of
+// July 2026 neither exposes bundled Local SSD in the catalog; listing them
+// early keeps their rollout from raising a false alarm.
+var localSSD375Series = map[string]bool{
+	"a2":  true,
+	"a3":  true,
+	"a4":  true,
+	"c3":  true,
+	"c3d": true,
+	"c4":  true,
+	"c4a": true,
+	"c4d": true,
+	"c4n": true,
+	"g4":  true,
+	"h4d": true,
 }
 
 // bundledLocalSSDCapacityGB returns the total bundled Local SSD capacity in GB
@@ -1057,15 +1092,15 @@ func calculateHourlyPrice(price PriceInfo) float64 {
 	// vCPU/RAM total-price math downstream can keep treating every rate as
 	// per-GiB regardless of which unit the catalog happened to use.
 	if unit == "gby.h" {
-		dollars *= gibPerDecimalGB
+		dollars *= decimalGBPerGiB
 	}
 
 	return dollars
 }
 
-// gibPerDecimalGB is how many decimal gigabytes (1000^3 bytes) fit in one
+// decimalGBPerGiB is how many decimal gigabytes (1000^3 bytes) fit in one
 // binary gibibyte (1024^3 bytes).
-const gibPerDecimalGB = 1024 * 1024 * 1024 / 1e9
+const decimalGBPerGiB = 1024 * 1024 * 1024 / 1e9
 
 // GCP Region from API
 type GCPRegion struct {
@@ -1140,13 +1175,13 @@ func getRegionFriendlyName(region string) string {
 		"southamerica-west1":      "Santiago",
 		"europe-central2":         "Warsaw",
 		"europe-north1":           "Finland",
-		"europe-north2":           "Sweden",
+		"europe-north2":           "Stockholm",
 		"europe-southwest1":       "Madrid",
 		"europe-west1":            "Belgium",
 		"europe-west2":            "London",
 		"europe-west3":            "Frankfurt",
 		"europe-west4":            "Netherlands",
-		"europe-west5":            "Zurich",
+		"europe-west5":            "Galaxy Frankfurt",
 		"europe-west6":            "Zurich",
 		"europe-west8":            "Milan",
 		"europe-west9":            "Paris",

--- a/scraper/gcp/api_test.go
+++ b/scraper/gcp/api_test.go
@@ -8,12 +8,16 @@ import "testing"
 // map the GPU_memory column was empty for every GCP GPU instance.
 func TestGPUMemoryByModel(t *testing.T) {
 	cases := map[string]int{
-		"nvidia-h200-141gb":     141,
-		"nvidia-h100-80gb":      80,
-		"nvidia-h100-mega-80gb": 80,
-		"nvidia-a100-80gb":      80,
-		"nvidia-tesla-a100":     40,
-		"nvidia-l4":             24,
+		"nvidia-h200-141gb":       141,
+		"nvidia-h100-80gb":        80,
+		"nvidia-h100-mega-80gb":   80,
+		"nvidia-a100-80gb":        80,
+		"nvidia-tesla-a100":       40,
+		"nvidia-l4":               24,
+		"nvidia-b200":             180,
+		"nvidia-gb200":            186,
+		"nvidia-rtx-pro-6000":     96,
+		"nvidia-rtx-pro-6000-vws": 96,
 	}
 	for model, want := range cases {
 		if got := gpuMemoryByModel[model]; got != want {
@@ -187,6 +191,43 @@ func TestTotalGPUMemory(t *testing.T) {
 			got := totalGPUMemory(c.count, c.model)
 			if got != c.expected {
 				t.Errorf("totalGPUMemory(%d, %q) = %d, want %d", c.count, c.model, got, c.expected)
+			}
+		})
+	}
+}
+
+// TestGPUSpec covers the machine-specs GPU derivation: the fractional-slice G4
+// shapes report count 1 with their documented per-slice memory, whole-GPU shapes
+// multiply the API count by per-GPU memory, and A4X Max's GB300 (279 GB/GPU)
+// yields the documented 1,116 GB total.
+func TestGPUSpec(t *testing.T) {
+	if got := gpuMemoryByModel["nvidia-gb300"]; got != 279 {
+		t.Errorf("gpuMemoryByModel[nvidia-gb300] = %d, want 279", got)
+	}
+
+	cases := []struct {
+		name       string
+		machine    string
+		model      string
+		count      int
+		wantGPU    float64
+		wantMemory int
+	}{
+		{"g4-standard-6 is 1/8 GPU", "g4-standard-6", "nvidia-rtx-pro-6000", 1, 0.125, 12},
+		{"g4-standard-12 is 1/4 GPU", "g4-standard-12", "nvidia-rtx-pro-6000", 1, 0.25, 24},
+		{"g4-standard-24 is 1/2 GPU", "g4-standard-24", "nvidia-rtx-pro-6000", 1, 0.5, 48},
+		{"g4-standard-48 is one whole GPU", "g4-standard-48", "nvidia-rtx-pro-6000", 1, 1, 96},
+		{"g4-standard-96 is two whole GPUs", "g4-standard-96", "nvidia-rtx-pro-6000", 2, 2, 192},
+		{"a4x max is four GB300 GPUs", "a4x-maxgpu-4g-metal", "nvidia-gb300", 4, 4, 1116},
+		{"a2 standard eight A100s (int not truncated)", "a2-highgpu-8g", "nvidia-tesla-a100", 8, 8, 320},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gpu, mem := gpuSpec(c.machine, c.model, c.count)
+			if gpu != c.wantGPU || mem != c.wantMemory {
+				t.Errorf("gpuSpec(%q, %q, %d) = (%v, %d), want (%v, %d)",
+					c.machine, c.model, c.count, gpu, mem, c.wantGPU, c.wantMemory)
 			}
 		})
 	}

--- a/scraper/gcp/api_test.go
+++ b/scraper/gcp/api_test.go
@@ -28,6 +28,120 @@ func TestGPUMemoryByModel(t *testing.T) {
 	}
 }
 
+// TestDetermineMachineFamily covers every currently-shipping GCP machine
+// series, including the ones previously missing from the prefix list (C4D,
+// C4N, H4D, M4N, A4, A4X, G4). Series without an explicit prefix must fall
+// back to General purpose.
+func TestDetermineMachineFamily(t *testing.T) {
+	cases := map[string]string{
+		// General purpose
+		"e2-standard-4":  "General purpose",
+		"n1-standard-8":  "General purpose",
+		"n2-standard-8":  "General purpose",
+		"n2d-standard-8": "General purpose",
+		"n4-standard-8":  "General purpose",
+		"n4a-standard-8": "General purpose",
+		"n4d-standard-8": "General purpose",
+		"t2a-standard-8": "General purpose",
+		"t2d-standard-8": "General purpose",
+		// Compute optimized
+		"c2-standard-8":    "Compute optimized",
+		"c2d-standard-8":   "Compute optimized",
+		"c3-standard-8":    "Compute optimized",
+		"c3d-standard-8":   "Compute optimized",
+		"c4-standard-8":    "Compute optimized",
+		"c4a-standard-8":   "Compute optimized",
+		"c4d-standard-8":   "Compute optimized",
+		"h3-standard-88":   "Compute optimized",
+		"h4d-standard-192": "Compute optimized",
+		// Network optimized
+		"c4n-standard-8": "Network optimized",
+		// Memory optimized (highmem/megamem/ultramem variants match the
+		// contains checks; prefixes cover the rest)
+		"c4d-highmem-8":   "Memory optimized",
+		"m1-megamem-96":   "Memory optimized",
+		"m2-ultramem-208": "Memory optimized",
+		"m3-megamem-64":   "Memory optimized",
+		"m4-hypermem-16":  "Memory optimized",
+		"m4n-hypermem-16": "Memory optimized",
+		"x4-megamem-960":  "Memory optimized",
+		// Accelerator optimized
+		"a2-highgpu-1g":  "Accelerator optimized",
+		"a3-highgpu-8g":  "Accelerator optimized",
+		"a4-highgpu-8g":  "Accelerator optimized",
+		"a4x-highgpu-4g": "Accelerator optimized",
+		"g2-standard-4":  "Accelerator optimized",
+		"g4-standard-48": "Accelerator optimized",
+		// Storage optimized (real Z3 shapes are all z3-highmem-*, so the z3-
+		// prefix must be checked ahead of the highmem rule above)
+		"z3-highmem-88-highlssd":        "Storage optimized",
+		"z3-highmem-192-highlssd-metal": "Storage optimized",
+	}
+
+	for name, want := range cases {
+		if got := determineMachineFamily(name); got != want {
+			t.Errorf("determineMachineFamily(%q) = %q, want %q", name, got, want)
+		}
+	}
+}
+
+// TestParseMachineTypeFromSKU verifies SKU display-name parsing, in
+// particular the family tokens that were previously missing from
+// machineTypeRegex (which caused whole series to be dropped from the dataset
+// for lack of pricing) and the legacy C2/M1 naming fallback.
+func TestParseMachineTypeFromSKU(t *testing.T) {
+	cases := []struct {
+		display      string
+		wantFamily   string
+		wantResource string
+		wantSpot     bool
+	}{
+		{"N1 Predefined Instance Ram running in Zurich", "N1", "ram", false},
+		{"Spot Preemptible E2 Instance Core running in Paris", "E2", "core", true},
+		{"C4A Arm Instance Core running in Northern Virginia", "C4A", "core", false},
+		{"C4D Instance Core running in Americas", "C4D", "core", false},
+		{"C4D Instance Ram running in Tokyo", "C4D", "ram", false},
+		{"C4N Instance Core running in Iowa", "C4N", "core", false},
+		{"N4A Instance Ram running in Iowa", "N4A", "ram", false},
+		{"M4N Instance Core running in Frankfurt", "M4N", "core", false},
+		{"H4D Instance Core running in Iowa", "H4D", "core", false},
+		{"X4 Instance Ram running in Frankfurt", "X4", "ram", false},
+		// a2/a3/g2 remain in the allowlist (pre-existing upstream coverage).
+		{"A2 Instance Core running in Iowa", "A2", "core", false},
+		{"A3 Instance Ram running in Iowa", "A3", "ram", false},
+		{"G2 Instance Ram running in Iowa", "G2", "ram", false},
+		// g4/a4/a4x are deliberately excluded: their GPU charge is not assembled,
+		// so they must parse to no family (dropping the shape) rather than publish
+		// a core+RAM-only price.
+		{"G4 Instance Ram running in Iowa", "", "", false},
+		{"Spot Preemptible G4 Instance Core running in Iowa", "", "", true},
+		{"A4 Instance Core running in Iowa", "", "", false},
+		{"A4X Instance Core running in Iowa", "", "", false},
+		// Legacy first-generation naming with no family token.
+		{"Compute optimized Core running in Americas", "C2", "core", false},
+		{"Compute optimized Ram running in Americas", "C2", "ram", false},
+		{"Spot Preemptible Compute optimized Core running in Paris", "C2", "core", true},
+		// C2's per-region SKUs (the newer me-*/europe-*/africa-south1 regions)
+		// add an "Instance" token the multi-regional form omits; both map to C2.
+		{"Compute optimized Instance Core running in Madrid", "C2", "core", false},
+		{"Compute optimized Instance Ram running in Mexico", "C2", "ram", false},
+		{"Spot Preemptible Compute optimized Instance Core running in Johannesburg", "C2", "core", true},
+		{"Memory-optimized Instance Core running in Northern Virginia", "M1", "core", false},
+		{"Memory-optimized Instance Ram running in Tokyo", "M1", "ram", false},
+		// The M2 surcharge SKU must not be attributed to M1 baseline rates.
+		{"Memory Optimized Upgrade Premium for Memory-optimized Instance Core running in Singapore", "", "", false},
+	}
+
+	for _, tc := range cases {
+		family, resource, _, isSpot, _ := parseMachineTypeFromSKU(SKU{DisplayName: tc.display})
+		if family != tc.wantFamily || resource != tc.wantResource || isSpot != tc.wantSpot {
+			t.Errorf("parseMachineTypeFromSKU(%q) = (%q, %q, spot=%v), want (%q, %q, spot=%v)",
+				tc.display, family, resource, isSpot,
+				tc.wantFamily, tc.wantResource, tc.wantSpot)
+		}
+	}
+}
+
 func TestTotalGPUMemory(t *testing.T) {
 	cases := []struct {
 		name     string

--- a/scraper/gcp/api_test.go
+++ b/scraper/gcp/api_test.go
@@ -130,6 +130,13 @@ func TestParseMachineTypeFromSKU(t *testing.T) {
 		{"Memory-optimized Instance Ram running in Tokyo", "M1", "ram", false},
 		// The M2 surcharge SKU must not be attributed to M1 baseline rates.
 		{"Memory Optimized Upgrade Premium for Memory-optimized Instance Core running in Singapore", "", "", false},
+		// m4-ultramem-224 bills from its own dedicated SKU pair; the plain M4
+		// SKU shared by every other M4 shape must not be conflated with it.
+		{"M4Ultramem224 Instance Core running in Americas", "M4ULTRAMEM224", "core", false},
+		{"M4Ultramem224 Instance Ram running in Americas", "M4ULTRAMEM224", "ram", false},
+		{"Spot Preemptible M4Ultramem224 Instance Core running in Frankfurt", "M4ULTRAMEM224", "core", true},
+		{"M4 Instance Core running in Americas", "M4", "core", false},
+		{"M4 Instance Ram running in Americas", "M4", "ram", false},
 	}
 
 	for _, tc := range cases {

--- a/scraper/gcp/cud_test.go
+++ b/scraper/gcp/cud_test.go
@@ -52,6 +52,8 @@ func TestParseCUDSKU(t *testing.T) {
 		{"Commitment v1: N2 Ram in Americas for 3 Year", "N2", "ram", cudTerm3Yr, true},
 		{"Commitment v1: C2D AMD Cpu in EMEA for 1 Year", "C2D", "core", cudTerm1Yr, true},
 		{"Commitment v1: C2D AMD Ram in EMEA for 3 Year", "C2D", "ram", cudTerm3Yr, true},
+		{"Commitment v1: M4Ultramem224 Cpu in Americas for 1 Year", "M4ULTRAMEM224", "core", cudTerm1Yr, true},
+		{"Commitment v1: M4Ultramem224 Ram in Americas for 3 Year", "M4ULTRAMEM224", "ram", cudTerm3Yr, true},
 		// On-demand and spot SKUs must NOT be treated as CUD.
 		{"N2 Instance Core running in Americas", "", "", "", false},
 		{"Spot Preemptible N2 Instance Ram running in Paris", "", "", "", false},

--- a/scraper/gcp/cud_test.go
+++ b/scraper/gcp/cud_test.go
@@ -54,11 +54,35 @@ func TestParseCUDSKU(t *testing.T) {
 		{"Commitment v1: C2D AMD Ram in EMEA for 3 Year", "C2D", "ram", cudTerm3Yr, true},
 		{"Commitment v1: M4Ultramem224 Cpu in Americas for 1 Year", "M4ULTRAMEM224", "core", cudTerm1Yr, true},
 		{"Commitment v1: M4Ultramem224 Ram in Americas for 3 Year", "M4ULTRAMEM224", "ram", cudTerm3Yr, true},
+		// Legacy first-generation commitment naming carries no family token; C2
+		// and M1 are recovered from the "Compute optimized" / "Memory-optimized"
+		// wording (mirroring the on-demand legacySKURegex). "3 Years" (plural) is
+		// the live term wording and must parse identically to "3 Year".
+		{"Commitment v1: Compute optimized Cpu in Iowa for 1 Year", "C2", "core", cudTerm1Yr, true},
+		{"Commitment v1: Compute optimized Ram in Berlin for 3 Years", "C2", "ram", cudTerm3Yr, true},
+		{"Commitment v1: Memory-optimized Cpu in Frankfurt for 1 Year", "M1", "core", cudTerm1Yr, true},
+		{"Commitment v1: Memory-optimized Ram in Americas for 3 Years", "M1", "ram", cudTerm3Yr, true},
+		// C2 also uses a second, version-less spelling ("Commitment:" with no
+		// version, "Core"/"Ram" not "Cpu", "running in" not "in") that covers the
+		// major regions -- including the multi-Americas grouping that resolves to
+		// us-central1. Both spellings must map to C2.
+		{"Commitment: Compute optimized Core running in Americas for 1 Year", "C2", "core", cudTerm1Yr, true},
+		{"Commitment: Compute optimized Ram running in Americas for 3 Year", "C2", "ram", cudTerm3Yr, true},
+		{"Commitment: Compute optimized Core running in Frankfurt for 1 Year", "C2", "core", cudTerm1Yr, true},
+		// The M2 Upgrade Premium has no commitment variant in the catalog; a
+		// premium-worded commitment must never be attributed to M1's CUD bucket.
+		{"Commitment v1: Memory Optimized Upgrade Premium for Memory-optimized Instance Cpu in Americas for 1 Year", "", "", "", false},
 		// On-demand and spot SKUs must NOT be treated as CUD.
 		{"N2 Instance Core running in Americas", "", "", "", false},
 		{"Spot Preemptible N2 Instance Ram running in Paris", "", "", "", false},
 		// Spend-based / flexible CUDs are not resource-based and must be ignored.
 		{"Commitment - dollar based v1: GCE for 1 year", "", "", "", false},
+		// Local SSD commitments are handled by parseLocalSSDCommitmentSKU, not here.
+		{"Commitment v1: Z3 Local SSD in Iowa for 1 Year", "", "", "", false},
+		// g4 is excluded from the CUD allowlist (its instances publish no
+		// core+RAM price for a commitment to attach to), so its resource
+		// commitment SKU must no longer parse.
+		{"Commitment v1: G4 Cpu in Americas for 1 Year", "", "", "", false},
 	}
 
 	for _, tc := range cases {
@@ -155,6 +179,275 @@ func TestProcessGCPDataCUDPricing(t *testing.T) {
 		t.Errorf("expected 3yr < 1yr < ondemand, got ondemand=%f 1yr=%f 3yr=%f",
 			wantOnDemand, want1Yr, want3Yr)
 	}
+}
+
+// TestParseLocalSSDCommitmentSKU covers the two Local SSD commitment display
+// forms (generic and family-scoped) with both terms, and asserts that the vGPU
+// variant, resource CUDs, on-demand SSD SKUs, and reservation SKUs are excluded.
+func TestParseLocalSSDCommitmentSKU(t *testing.T) {
+	cases := []struct {
+		display    string
+		wantFamily string
+		wantTerm   string
+		wantOK     bool
+	}{
+		{"Commitment v1: Local SSD in Iowa for 1 Year", "", cudTerm1Yr, true},
+		{"Commitment v1: Local SSD in Americas for 3 Years", "", cudTerm3Yr, true},
+		{"Commitment v1: Z3 Local SSD in Alabama for 3 Years", "Z3", cudTerm3Yr, true},
+		{"Commitment v1: C4A Local SSD in Frankfurt for 1 Year", "C4A", cudTerm1Yr, true},
+		{"Commitment v1: H4D Local SSD in Iowa for 3 Years", "H4D", cudTerm3Yr, true},
+		// The vGPU G4 Local SSD commitment is ignored, mirroring the on-demand
+		// path which likewise skips the vGPU twin of the G4 Local SSD SKU.
+		{"Commitment v1: vGPU G4 Local SSD in Iowa for 1 Year", "", "", false},
+		// Resource CUDs, on-demand SSD SKUs, and reservation SKUs must not match.
+		{"Commitment v1: N2 Cpu in Americas for 1 Year", "", "", false},
+		{"Z3 Instance Local SSD running in Netherlands", "", "", false},
+		{"Reserved C4A Standard Local SSD in Iowa for 1 Year", "", "", false},
+	}
+
+	for _, tc := range cases {
+		family, term, ok := parseLocalSSDCommitmentSKU(SKU{DisplayName: tc.display})
+		if ok != tc.wantOK {
+			t.Errorf("%q: ok=%v want %v", tc.display, ok, tc.wantOK)
+			continue
+		}
+		if !tc.wantOK {
+			continue
+		}
+		if family != tc.wantFamily || term != tc.wantTerm {
+			t.Errorf("%q: got (family=%s, term=%s) want (family=%s, term=%s)",
+				tc.display, family, term, tc.wantFamily, tc.wantTerm)
+		}
+	}
+}
+
+// TestProcessGCPDataLegacyCUDPricing proves the legacy-named C2 and M1
+// commitment SKUs (no family token) now yield cud_1yr, where before the fix they
+// fell through unparsed and those shapes carried no CUD price at all. It uses the
+// real multi-Americas grammar: C2 in the version-less "Commitment: Compute
+// optimized Core running in Americas" spelling and M1 in the "Commitment v1:
+// Memory-optimized Cpu in Americas" spelling, and asserts the CUD lands on
+// us-central1 via the multi-Americas expansion (the region with no per-region C2
+// commitment SKU, which the version-less form is the only source for).
+func TestProcessGCPDataLegacyCUDPricing(t *testing.T) {
+	const region = "us-central1" // resolved via the multi-americas expansion
+
+	c2odCore, c2odRam := 0.03398, 0.00455
+	c2cudCore, c2cudRam := 0.021414, 0.002869
+	m1odCore, m1odRam := 0.0348, 0.0051
+	m1cudCore, m1cudRam := 0.021924, 0.003213
+
+	skus := []SKU{
+		multiRegionalSKU("c2-od-core", "Compute optimized Core running in Americas"),
+		multiRegionalSKU("c2-od-ram", "Compute optimized Ram running in Americas"),
+		multiRegionalSKU("c2-cud-core", "Commitment: Compute optimized Core running in Americas for 1 Year"),
+		multiRegionalSKU("c2-cud-ram", "Commitment: Compute optimized Ram running in Americas for 1 Year"),
+		multiRegionalSKU("m1-od-core", "Memory-optimized Instance Core running in Americas"),
+		multiRegionalSKU("m1-od-ram", "Memory-optimized Instance Ram running in Americas"),
+		multiRegionalSKU("m1-cud-core", "Commitment v1: Memory-optimized Cpu in Americas for 1 Year"),
+		multiRegionalSKU("m1-cud-ram", "Commitment v1: Memory-optimized Ram in Americas for 1 Year"),
+	}
+
+	pricing := map[string]PriceInfo{
+		"c2-od-core":  usdRate("h", c2odCore),
+		"c2-od-ram":   usdRate("giby.h", c2odRam),
+		"c2-cud-core": usdRate("h", c2cudCore),
+		"c2-cud-ram":  usdRate("giby.h", c2cudRam),
+		"m1-od-core":  usdRate("h", m1odCore),
+		"m1-od-ram":   usdRate("giby.h", m1odRam),
+		"m1-cud-core": usdRate("h", m1cudCore),
+		"m1-cud-ram":  usdRate("giby.h", m1cudRam),
+	}
+
+	machineSpecs := map[string]*MachineSpecs{
+		"c2-standard-8": {VCPU: 8, MemoryGB: 32.0, Family: "Compute optimized"},
+		"m1-megamem-96": {VCPU: 96, MemoryGB: 1433.6, Family: "Memory optimized"},
+	}
+
+	instances := processGCPData(skus, pricing, machineSpecs, map[string]string{region: "Iowa"})
+
+	c2 := linuxPricing(t, mustInstance(t, instances, "c2-standard-8"), region)
+	assertPrice(t, "c2 cud_1yr", c2.CUD1Yr, 8*c2cudCore+32.0*c2cudRam)
+
+	m1 := linuxPricing(t, mustInstance(t, instances, "m1-megamem-96"), region)
+	assertPrice(t, "m1 cud_1yr", m1.CUD1Yr, 96*m1cudCore+1433.6*m1cudRam)
+}
+
+// TestProcessGCPDataC2InstanceRegionPricing proves the per-region C2 spelling
+// ("Compute optimized Instance Core/Ram running in <City>", plus its Spot twin)
+// now yields an on-demand/spot baseline, which in turn lets the per-region C2
+// commitment SKUs attach a CUD. Before the fix the "Instance" token defeated
+// legacySKURegex, so these 12 newer regions had neither on-demand nor CUD.
+// Rates are the live africa-south1 (Johannesburg) commitment rates; the assert
+// reproduces the triage anchor c2-standard-16 cud_1yr = 0.578784.
+func TestProcessGCPDataC2InstanceRegionPricing(t *testing.T) {
+	const region = "africa-south1"
+
+	odCore, odRam := 0.03654, 0.004896
+	spotCore, spotRam := 0.011, 0.0015
+	cudCore, cudRam := 0.02355, 0.003156
+
+	skus := []SKU{
+		onDemandSKU("c2-od-core", "Compute optimized Instance Core running in Johannesburg", []string{region}),
+		onDemandSKU("c2-od-ram", "Compute optimized Instance Ram running in Johannesburg", []string{region}),
+		onDemandSKU("c2-spot-core", "Spot Preemptible Compute optimized Instance Core running in Johannesburg", []string{region}),
+		onDemandSKU("c2-spot-ram", "Spot Preemptible Compute optimized Instance Ram running in Johannesburg", []string{region}),
+		cudSKU("c2-cud-core", "Commitment v1: Compute optimized Cpu in Johannesburg for 1 Year", []string{region}),
+		cudSKU("c2-cud-ram", "Commitment v1: Compute optimized Ram in Johannesburg for 1 Year", []string{region}),
+	}
+
+	pricing := map[string]PriceInfo{
+		"c2-od-core":   usdRate("h", odCore),
+		"c2-od-ram":    usdRate("giby.h", odRam),
+		"c2-spot-core": usdRate("h", spotCore),
+		"c2-spot-ram":  usdRate("giby.h", spotRam),
+		"c2-cud-core":  usdRate("h", cudCore),
+		"c2-cud-ram":   usdRate("giby.h", cudRam),
+	}
+
+	machineSpecs := map[string]*MachineSpecs{
+		"c2-standard-16": {VCPU: 16, MemoryGB: 64.0, Family: "Compute optimized"},
+	}
+
+	instances := processGCPData(skus, pricing, machineSpecs, map[string]string{region: "Johannesburg"})
+	c2 := linuxPricing(t, mustInstance(t, instances, "c2-standard-16"), region)
+
+	assertPrice(t, "c2 ondemand", c2.OnDemand, 16*odCore+64.0*odRam)
+	assertPrice(t, "c2 spot", c2.Spot, 16*spotCore+64.0*spotRam)
+	assertPrice(t, "c2 cud_1yr (anchor 0.578784)", c2.CUD1Yr, 16*cudCore+64.0*cudRam)
+}
+
+// TestProcessGCPDataM2CUDPricing proves M2 CUD is synthesized as the M1
+// commitment core/RAM rates plus the on-demand Upgrade Premium (the premium has
+// no commitment variant), and that M2 CUD is absent when the premium is absent.
+func TestProcessGCPDataM2CUDPricing(t *testing.T) {
+	const region = "us-central1"
+
+	baseCore, baseRam := 0.0348, 0.0051
+	m1cudCore, m1cudRam := 0.021924, 0.003213
+	premCore, premRam := 0.004524, 0.000663
+
+	const m2VCPU, m2MemGB = 208, 5888.0
+
+	build := func(withPremium bool) []SKU {
+		skus := []SKU{
+			multiRegionalSKU("m1-core", "Memory-optimized Instance Core running in Americas"),
+			multiRegionalSKU("m1-ram", "Memory-optimized Instance Ram running in Americas"),
+			multiRegionalSKU("m1-cud-core", "Commitment v1: Memory-optimized Cpu in Americas for 1 Year"),
+			multiRegionalSKU("m1-cud-ram", "Commitment v1: Memory-optimized Ram in Americas for 1 Year"),
+		}
+		if withPremium {
+			skus = append(skus,
+				multiRegionalSKU("prem-core", "Memory Optimized Upgrade Premium for Memory-optimized Instance Core running in Americas"),
+				multiRegionalSKU("prem-ram", "Memory Optimized Upgrade Premium for Memory-optimized Instance Ram running in Americas"),
+			)
+		}
+		return skus
+	}
+
+	pricing := map[string]PriceInfo{
+		"m1-core":     usdRate("h", baseCore),
+		"m1-ram":      usdRate("giby.h", baseRam),
+		"m1-cud-core": usdRate("h", m1cudCore),
+		"m1-cud-ram":  usdRate("giby.h", m1cudRam),
+		"prem-core":   usdRate("h", premCore),
+		"prem-ram":    usdRate("giby.h", premRam),
+	}
+
+	machineSpecs := map[string]*MachineSpecs{
+		"m2-ultramem-208": {VCPU: m2VCPU, MemoryGB: m2MemGB, Family: "Memory optimized"},
+	}
+	regions := map[string]string{region: "Iowa"}
+
+	// Premium present: M2 CUD = (M1 commitment + on-demand premium) rates.
+	withPrem := processGCPData(build(true), pricing, machineSpecs, regions)
+	m2 := linuxPricing(t, mustInstance(t, withPrem, "m2-ultramem-208"), region)
+	wantCUD := m2VCPU*(m1cudCore+premCore) + m2MemGB*(m1cudRam+premRam)
+	assertPrice(t, "m2 cud_1yr", m2.CUD1Yr, wantCUD)
+	if m2.CUD3Yr != "" {
+		t.Errorf("m2 cud_3yr = %q, want empty (no 3yr commitment SKU)", m2.CUD3Yr)
+	}
+
+	// Premium absent: M2 has neither on-demand nor CUD, so no CUD price surfaces.
+	noPrem := processGCPData(build(false), pricing, machineSpecs, regions)
+	if inst, ok := noPrem["m2-ultramem-208"]; ok {
+		if linux, ok := inst.Pricing[region]["linux"].(*GCPPricingData); ok && (linux.CUD1Yr != "" || linux.CUD3Yr != "") {
+			t.Errorf("m2 CUD without premium = (%q, %q), want empty", linux.CUD1Yr, linux.CUD3Yr)
+		}
+	}
+}
+
+// TestProcessGCPDataSSDCUDPricing proves the bundled Local SSD commitment rate
+// is folded into a shape's CUD price with family-specific-then-generic
+// precedence: a Z3 shape uses the Z3-scoped SSD commitment SKU while a C3 shape
+// (no C3-specific SSD commitment) falls back to the generic one.
+func TestProcessGCPDataSSDCUDPricing(t *testing.T) {
+	const region = "us-central1"
+
+	// Core/RAM rates (on-demand for a baseline price, commitment for the CUD).
+	z3odCore, z3odRam := 0.03398, 0.00455
+	z3cudCore, z3cudRam := 0.021414, 0.002869
+	c3odCore, c3odRam := 0.03398, 0.00455
+	c3cudCore, c3cudRam := 0.021414, 0.002869
+
+	// SSD commitment rates (per GiB-month). The Z3-specific rate differs from
+	// the generic one to prove precedence; C3 has no specific SKU so it uses
+	// the generic rate.
+	z3ssdMonthly := 0.048
+	genericSSDMonthly := 0.064
+
+	const z3VCPU, z3MemGB, z3SSDGB = 88, 704.0, 36000
+	const c3VCPU, c3MemGB, c3SSDGB = 8, 32.0, 750
+
+	skus := []SKU{
+		onDemandSKU("z3-od-core", "Z3 Instance Core running in Iowa", []string{region}),
+		onDemandSKU("z3-od-ram", "Z3 Instance Ram running in Iowa", []string{region}),
+		cudSKU("z3-cud-core", "Commitment v1: Z3 Cpu in Iowa for 1 Year", []string{region}),
+		cudSKU("z3-cud-ram", "Commitment v1: Z3 Ram in Iowa for 1 Year", []string{region}),
+		cudSKU("z3-ssd-cud", "Commitment v1: Z3 Local SSD in Iowa for 1 Year", []string{region}),
+		onDemandSKU("c3-od-core", "C3 Instance Core running in Iowa", []string{region}),
+		onDemandSKU("c3-od-ram", "C3 Instance Ram running in Iowa", []string{region}),
+		cudSKU("c3-cud-core", "Commitment v1: C3 Cpu in Iowa for 1 Year", []string{region}),
+		cudSKU("c3-cud-ram", "Commitment v1: C3 Ram in Iowa for 1 Year", []string{region}),
+		cudSKU("generic-ssd-cud", "Commitment v1: Local SSD in Iowa for 1 Year", []string{region}),
+	}
+
+	pricing := map[string]PriceInfo{
+		"z3-od-core":      usdRate("h", z3odCore),
+		"z3-od-ram":       usdRate("giby.h", z3odRam),
+		"z3-cud-core":     usdRate("h", z3cudCore),
+		"z3-cud-ram":      usdRate("giby.h", z3cudRam),
+		"z3-ssd-cud":      usdRate("giby.mo", z3ssdMonthly),
+		"c3-od-core":      usdRate("h", c3odCore),
+		"c3-od-ram":       usdRate("giby.h", c3odRam),
+		"c3-cud-core":     usdRate("h", c3cudCore),
+		"c3-cud-ram":      usdRate("giby.h", c3cudRam),
+		"generic-ssd-cud": usdRate("giby.mo", genericSSDMonthly),
+	}
+
+	machineSpecs := map[string]*MachineSpecs{
+		"z3-highmem-88-highlssd": {VCPU: z3VCPU, MemoryGB: z3MemGB, Family: "Storage optimized", LocalSSDGB: z3SSDGB},
+		"c3-standard-8-lssd":     {VCPU: c3VCPU, MemoryGB: c3MemGB, Family: "Compute optimized", LocalSSDGB: c3SSDGB},
+	}
+
+	instances := processGCPData(skus, pricing, machineSpecs, map[string]string{region: "Iowa"})
+
+	z3 := linuxPricing(t, mustInstance(t, instances, "z3-highmem-88-highlssd"), region)
+	wantZ3 := z3VCPU*z3cudCore + z3MemGB*z3cudRam + z3SSDGB*(z3ssdMonthly/730)
+	assertPrice(t, "z3 cud_1yr (family-specific SSD)", z3.CUD1Yr, wantZ3)
+
+	c3 := linuxPricing(t, mustInstance(t, instances, "c3-standard-8-lssd"), region)
+	wantC3 := c3VCPU*c3cudCore + c3MemGB*c3cudRam + c3SSDGB*(genericSSDMonthly/730)
+	assertPrice(t, "c3 cud_1yr (generic SSD)", c3.CUD1Yr, wantC3)
+}
+
+func mustInstance(t *testing.T, instances map[string]*GCPInstance, name string) *GCPInstance {
+	t.Helper()
+	inst, ok := instances[name]
+	if !ok {
+		t.Fatalf("expected %s instance to be built", name)
+	}
+	return inst
 }
 
 func assertPrice(t *testing.T, label, got string, want float64) {

--- a/scraper/gcp/cud_test.go
+++ b/scraper/gcp/cud_test.go
@@ -378,9 +378,13 @@ func TestProcessGCPDataM2CUDPricing(t *testing.T) {
 }
 
 // TestProcessGCPDataSSDCUDPricing proves the bundled Local SSD commitment rate
-// is folded into a shape's CUD price with family-specific-then-generic
-// precedence: a Z3 shape uses the Z3-scoped SSD commitment SKU while a C3 shape
-// (no C3-specific SSD commitment) falls back to the generic one.
+// is folded into a shape's CUD price, and that the family-versus-generic choice
+// follows ssdFamilyPrecedence. Z3 is in bundledSSDBillsAtGenericRate, so it
+// takes the generic commitment rate even though a Z3-scoped SSD commitment SKU
+// is present in the fixture; C3 has no Z3-style exception and no C3-specific
+// SSD commitment SKU, so it reaches the same generic rate the other way.
+//
+// The two SSD rates differ, so this fails if either path stops discriminating.
 func TestProcessGCPDataSSDCUDPricing(t *testing.T) {
 	const region = "us-central1"
 
@@ -391,8 +395,8 @@ func TestProcessGCPDataSSDCUDPricing(t *testing.T) {
 	c3cudCore, c3cudRam := 0.021414, 0.002869
 
 	// SSD commitment rates (per GiB-month). The Z3-specific rate differs from
-	// the generic one to prove precedence; C3 has no specific SKU so it uses
-	// the generic rate.
+	// the generic one so the precedence is observable: Z3 must ignore its own
+	// rate here, and C3 has no specific SKU to ignore.
 	z3ssdMonthly := 0.048
 	genericSSDMonthly := 0.064
 
@@ -410,6 +414,10 @@ func TestProcessGCPDataSSDCUDPricing(t *testing.T) {
 		cudSKU("c3-cud-core", "Commitment v1: C3 Cpu in Iowa for 1 Year", []string{region}),
 		cudSKU("c3-cud-ram", "Commitment v1: C3 Ram in Iowa for 1 Year", []string{region}),
 		cudSKU("generic-ssd-cud", "Commitment v1: Local SSD in Iowa for 1 Year", []string{region}),
+		// On-demand SSD rate, present in every real region. Only the CUD prices
+		// are asserted below; this keeps the fixture from tripping the
+		// missing-on-demand-SSD-rate warning.
+		onDemandSKU("generic-ssd-od", "SSD backed Local Storage running in Iowa", []string{region}),
 	}
 
 	pricing := map[string]PriceInfo{
@@ -423,6 +431,7 @@ func TestProcessGCPDataSSDCUDPricing(t *testing.T) {
 		"c3-cud-core":     usdRate("h", c3cudCore),
 		"c3-cud-ram":      usdRate("giby.h", c3cudRam),
 		"generic-ssd-cud": usdRate("giby.mo", genericSSDMonthly),
+		"generic-ssd-od":  usdRate("giby.mo", 0.08),
 	}
 
 	machineSpecs := map[string]*MachineSpecs{
@@ -433,8 +442,11 @@ func TestProcessGCPDataSSDCUDPricing(t *testing.T) {
 	instances := processGCPData(skus, pricing, machineSpecs, map[string]string{region: "Iowa"})
 
 	z3 := linuxPricing(t, mustInstance(t, instances, "z3-highmem-88-highlssd"), region)
-	wantZ3 := z3VCPU*z3cudCore + z3MemGB*z3cudRam + z3SSDGB*(z3ssdMonthly/730)
-	assertPrice(t, "z3 cud_1yr (family-specific SSD)", z3.CUD1Yr, wantZ3)
+	wantZ3 := z3VCPU*z3cudCore + z3MemGB*z3cudRam + z3SSDGB*(genericSSDMonthly/730)
+	assertPrice(t, "z3 cud_1yr (generic SSD despite a Z3-scoped SKU)", z3.CUD1Yr, wantZ3)
+	if z3ssdMonthly == genericSSDMonthly {
+		t.Fatal("the two SSD commitment rates must differ or this test cannot observe the precedence")
+	}
 
 	c3 := linuxPricing(t, mustInstance(t, instances, "c3-standard-8-lssd"), region)
 	wantC3 := c3VCPU*c3cudCore + c3MemGB*c3cudRam + c3SSDGB*(genericSSDMonthly/730)

--- a/scraper/gcp/local_ssd_test.go
+++ b/scraper/gcp/local_ssd_test.go
@@ -1,0 +1,307 @@
+package gcp
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestBundledLocalSSDCapacityGB verifies capacity discovery from the Compute
+// Engine machineTypes API payload: the structured bundledLocalSsds field is
+// the primary source (partitionCount x per-partition size, 375 GB for every
+// series except Z3's 3,000 GiB Titanium SSD disks, or 6,000 GiB for the
+// bare-metal Z3 shapes), with the disk count in the human-readable
+// description as a fallback. Shapes without bundled Local SSD must report 0
+// so attachable-SSD families keep local_ssd=false.
+func TestBundledLocalSSDCapacityGB(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want int
+	}{
+		{
+			name: "c3 lssd shape with bundledLocalSsds",
+			raw:  `{"name":"c3-standard-8-lssd","guestCpus":8,"memoryMb":32768,"bundledLocalSsds":{"defaultInterface":"NVME","partitionCount":2}}`,
+			want: 750,
+		},
+		{
+			name: "single partition c4a lssd shape",
+			raw:  `{"name":"c4a-standard-4-lssd","guestCpus":4,"memoryMb":16384,"bundledLocalSsds":{"defaultInterface":"NVME","partitionCount":1}}`,
+			want: 375,
+		},
+		{
+			name: "z3 titanium ssd disks are 3000 GiB each",
+			raw:  `{"name":"z3-highmem-88-highlssd","guestCpus":88,"memoryMb":720896,"bundledLocalSsds":{"defaultInterface":"NVME","partitionCount":12}}`,
+			want: 36000,
+		},
+		{
+			name: "z3 bare-metal titanium ssd disks are 6000 GiB each",
+			raw:  `{"name":"z3-highmem-192-highlssd-metal","guestCpus":192,"memoryMb":1572864,"bundledLocalSsds":{"defaultInterface":"NVME","partitionCount":12}}`,
+			want: 72000,
+		},
+		{
+			name: "c4 bare-metal titanium ssd disks are 3000 GiB each",
+			raw:  `{"name":"c4-standard-288-lssd-metal","guestCpus":288,"memoryMb":1105920,"bundledLocalSsds":{"defaultInterface":"NVME","partitionCount":6}}`,
+			want: 18000,
+		},
+		{
+			name: "a4x titanium ssd disks are 3000 GiB each (12,000 GiB total)",
+			raw:  `{"name":"a4x-highgpu-4g","guestCpus":140,"memoryMb":905216,"bundledLocalSsds":{"defaultInterface":"NVME","partitionCount":4}}`,
+			want: 12000,
+		},
+		{
+			name: "a4x max bare-metal titanium ssd disks are 3000 GiB each",
+			raw:  `{"name":"a4x-maxgpu-4g-metal","guestCpus":144,"memoryMb":983040,"bundledLocalSsds":{"defaultInterface":"NVME","partitionCount":4}}`,
+			want: 12000,
+		},
+		{
+			name: "attachable-only family has no bundled capacity",
+			raw:  `{"name":"n2-standard-8","description":"8 vCPUs 32 GB RAM","guestCpus":8,"memoryMb":32768}`,
+			want: 0,
+		},
+		{
+			name: "zero partition count is treated as no bundled SSD",
+			raw:  `{"name":"c3-standard-8","guestCpus":8,"memoryMb":32768,"bundledLocalSsds":{"defaultInterface":"NVME","partitionCount":0}}`,
+			want: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var mt MachineType
+			if err := json.Unmarshal([]byte(tc.raw), &mt); err != nil {
+				t.Fatalf("unmarshal machine type: %v", err)
+			}
+			if got := bundledLocalSSDCapacityGB(mt); got != tc.want {
+				t.Errorf("bundledLocalSSDCapacityGB(%s) = %d, want %d", mt.Name, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestParseLocalSSDSKU covers the two Local SSD usage SKU display-name forms
+// (per-family and generic) with their spot variants, and asserts that
+// commitment, suspended-VM state, and reservation-scheduling SKUs never feed
+// baseline pricing.
+func TestParseLocalSSDSKU(t *testing.T) {
+	cases := []struct {
+		display    string
+		wantFamily string
+		wantSpot   bool
+		wantOK     bool
+	}{
+		{"C4D Instance Local SSD running in Frankfurt", "C4D", false, true},
+		{"Spot Preemptible C4D Instance Local SSD running in Frankfurt", "C4D", true, true},
+		{"C3 Instance Local SSD running in Iowa", "C3", false, true},
+		{"Z3 Instance Local SSD running in Netherlands", "Z3", false, true},
+		{"SSD backed Local Storage running in Paris", "", false, true},
+		{"SSD backed Local Storage attached to Spot Preemptible VMs running in Paris", "", true, true},
+		{"SSD backed Local Storage in Bangkok", "", false, true},
+		// Commitment SKUs must be excluded from baseline pricing.
+		{"Commitment v1: Local SSD in Americas for 1 Year", "", false, false},
+		{"Commitment v1: C4D Local SSD in Americas for 3 Year", "", false, false},
+		// Suspended-VM state storage is not instance pricing.
+		{"VM state: preserved local SSD in Bangkok", "", false, false},
+		// Reservation-scheduling (DWS) SKUs bill separately.
+		{"C3 Instance Local SSD attached to Calendar mode reservations running in Iowa", "", false, false},
+		// Core/RAM and unrelated storage SKUs must not match.
+		{"N2 Instance Core running in Americas", "", false, false},
+		{"Storage PD Capacity in Paris", "", false, false},
+	}
+
+	for _, tc := range cases {
+		family, isSpot, ok := parseLocalSSDSKU(SKU{DisplayName: tc.display})
+		if ok != tc.wantOK {
+			t.Errorf("%q: ok=%v want %v", tc.display, ok, tc.wantOK)
+			continue
+		}
+		if !tc.wantOK {
+			continue
+		}
+		if family != tc.wantFamily || isSpot != tc.wantSpot {
+			t.Errorf("%q: got (family=%s, spot=%v) want (family=%s, spot=%v)",
+				tc.display, family, isSpot, tc.wantFamily, tc.wantSpot)
+		}
+	}
+}
+
+// TestProcessGCPDataLocalSSDPricing verifies the end-to-end assembly for a
+// bundled Local SSD shape against its base twin: the -lssd shape's on-demand
+// and spot prices carry the bundled capacity at the per GiB-hour SSD rate
+// (per-family SKU preferred, generic SKU as fallback), its LocalSSD fields
+// are populated, and the base shape's price and fields are untouched.
+func TestProcessGCPDataLocalSSDPricing(t *testing.T) {
+	const region = "us-central1"
+
+	odCore := 0.03398
+	odRam := 0.00456
+	spotCore := 0.00885
+	spotRam := 0.00119
+
+	// Local SSD catalog rates are per GiB-month. The per-family on-demand rate
+	// intentionally differs from the generic one to prove precedence; spot has
+	// no per-family SKU so it must fall back to the generic spot rate.
+	ssdFamilyMonthly := 0.08
+	ssdGenericMonthly := 0.10
+	ssdSpotMonthly := 0.032
+
+	skus := []SKU{
+		onDemandSKU("od-core", "C3 Instance Core running in Iowa", []string{region}),
+		onDemandSKU("od-ram", "C3 Instance Ram running in Iowa", []string{region}),
+		onDemandSKU("spot-core", "Spot Preemptible C3 Instance Core running in Iowa", []string{region}),
+		onDemandSKU("spot-ram", "Spot Preemptible C3 Instance Ram running in Iowa", []string{region}),
+		onDemandSKU("ssd-family", "C3 Instance Local SSD running in Iowa", []string{region}),
+		onDemandSKU("ssd-generic", "SSD backed Local Storage running in Iowa", []string{region}),
+		onDemandSKU("ssd-spot", "SSD backed Local Storage attached to Spot Preemptible VMs running in Iowa", []string{region}),
+	}
+
+	pricing := map[string]PriceInfo{
+		"od-core":     usdRate("h", odCore),
+		"od-ram":      usdRate("giby.h", odRam),
+		"spot-core":   usdRate("h", spotCore),
+		"spot-ram":    usdRate("giby.h", spotRam),
+		"ssd-family":  usdRate("giby.mo", ssdFamilyMonthly),
+		"ssd-generic": usdRate("giby.mo", ssdGenericMonthly),
+		"ssd-spot":    usdRate("giby.mo", ssdSpotMonthly),
+	}
+
+	const vcpu = 8
+	const memGB = 32.0
+	const ssdGB = 750
+	machineSpecs := map[string]*MachineSpecs{
+		"c3-standard-8": {
+			VCPU:     vcpu,
+			MemoryGB: memGB,
+			Family:   "Compute optimized",
+		},
+		"c3-standard-8-lssd": {
+			VCPU:       vcpu,
+			MemoryGB:   memGB,
+			Family:     "Compute optimized",
+			LocalSSDGB: ssdGB,
+		},
+	}
+
+	regions := map[string]string{region: "Iowa"}
+
+	instances := processGCPData(skus, pricing, machineSpecs, regions)
+
+	base, ok := instances["c3-standard-8"]
+	if !ok {
+		t.Fatalf("expected c3-standard-8 instance to be built")
+	}
+	lssd, ok := instances["c3-standard-8-lssd"]
+	if !ok {
+		t.Fatalf("expected c3-standard-8-lssd instance to be built")
+	}
+
+	// Capacity fields: set on the bundled shape, untouched on the base twin.
+	if base.LocalSSD || base.LocalSSDSize != 0 {
+		t.Errorf("base shape: LocalSSD=%v LocalSSDSize=%d, want false/0", base.LocalSSD, base.LocalSSDSize)
+	}
+	if !lssd.LocalSSD || lssd.LocalSSDSize != ssdGB {
+		t.Errorf("lssd shape: LocalSSD=%v LocalSSDSize=%d, want true/%d", lssd.LocalSSD, lssd.LocalSSDSize, ssdGB)
+	}
+
+	baseLinux := linuxPricing(t, base, region)
+	lssdLinux := linuxPricing(t, lssd, region)
+
+	wantBaseOnDemand := float64(vcpu)*odCore + memGB*odRam
+	wantBaseSpot := float64(vcpu)*spotCore + memGB*spotRam
+
+	// GiB-month -> GiB-hour uses the 730 hours/month convention shared by
+	// calculateHourlyPrice.
+	wantLssdOnDemand := wantBaseOnDemand + ssdGB*(ssdFamilyMonthly/730)
+	wantLssdSpot := wantBaseSpot + ssdGB*(ssdSpotMonthly/730)
+
+	assertPrice(t, "base ondemand", baseLinux.OnDemand, wantBaseOnDemand)
+	assertPrice(t, "base spot", baseLinux.Spot, wantBaseSpot)
+	assertPrice(t, "lssd ondemand", lssdLinux.OnDemand, wantLssdOnDemand)
+	assertPrice(t, "lssd spot", lssdLinux.Spot, wantLssdSpot)
+}
+
+// TestProcessGCPDataLocalSSDLegacyRegions mirrors the live catalog metadata
+// for the five legacy regions (asia-east1, europe-west1, us-central1,
+// us-east1, us-west1): the generic Local SSD SKUs there have no region tail
+// in the display name and scope regions only via multiRegionalMetadata, and
+// Google categorizes even the Spot-attached variant's taxonomy as
+// "On Demand" — the two properties the SSD path must handle explicitly.
+func TestProcessGCPDataLocalSSDLegacyRegions(t *testing.T) {
+	const region = "us-central1"
+
+	odCore := 0.03398
+	odRam := 0.00456
+	spotCore := 0.00885
+	spotRam := 0.00119
+	ssdGenericMonthly := 0.08
+	ssdSpotMonthly := 0.0389
+
+	legacyGeo := GeoTaxonomy{
+		Type: "TYPE_MULTI_REGIONAL",
+		MultiRegionalMetadata: &MultiRegionalMetadata{
+			Regions: []RegionInfo{
+				{Region: "asia-east1"}, {Region: "europe-west1"},
+				{Region: "us-central1"}, {Region: "us-east1"}, {Region: "us-west1"},
+			},
+		},
+	}
+	onDemandTaxonomy := ProductTaxonomy{TaxonomyCategories: []CategoryItem{
+		{Category: "GCP"}, {Category: "Compute"}, {Category: "Local SSD"}, {Category: "On Demand"},
+	}}
+
+	skus := []SKU{
+		onDemandSKU("od-core", "C3 Instance Core running in Iowa", []string{region}),
+		onDemandSKU("od-ram", "C3 Instance Ram running in Iowa", []string{region}),
+		onDemandSKU("spot-core", "Spot Preemptible C3 Instance Core running in Iowa", []string{region}),
+		onDemandSKU("spot-ram", "Spot Preemptible C3 Instance Ram running in Iowa", []string{region}),
+		{SkuId: "ssd-generic", DisplayName: "SSD backed Local Storage", GeoTaxonomy: legacyGeo, ProductTaxonomy: onDemandTaxonomy},
+		{SkuId: "ssd-spot", DisplayName: "SSD backed Local Storage attached to Spot Preemptible VMs", GeoTaxonomy: legacyGeo, ProductTaxonomy: onDemandTaxonomy},
+	}
+
+	pricing := map[string]PriceInfo{
+		"od-core":     usdRate("h", odCore),
+		"od-ram":      usdRate("giby.h", odRam),
+		"spot-core":   usdRate("h", spotCore),
+		"spot-ram":    usdRate("giby.h", spotRam),
+		"ssd-generic": usdRate("giby.mo", ssdGenericMonthly),
+		"ssd-spot":    usdRate("giby.mo", ssdSpotMonthly),
+	}
+
+	const vcpu = 8
+	const memGB = 32.0
+	const ssdGB = 750
+	machineSpecs := map[string]*MachineSpecs{
+		"c3-standard-8-lssd": {
+			VCPU:       vcpu,
+			MemoryGB:   memGB,
+			Family:     "Compute optimized",
+			LocalSSDGB: ssdGB,
+		},
+	}
+
+	instances := processGCPData(skus, pricing, machineSpecs, map[string]string{region: "Iowa"})
+
+	lssd, ok := instances["c3-standard-8-lssd"]
+	if !ok {
+		t.Fatalf("expected c3-standard-8-lssd instance to be built")
+	}
+	lssdLinux := linuxPricing(t, lssd, region)
+
+	wantOnDemand := float64(vcpu)*odCore + memGB*odRam + ssdGB*(ssdGenericMonthly/730)
+	wantSpot := float64(vcpu)*spotCore + memGB*spotRam + ssdGB*(ssdSpotMonthly/730)
+
+	assertPrice(t, "lssd ondemand (legacy multi-regional SKU)", lssdLinux.OnDemand, wantOnDemand)
+	assertPrice(t, "lssd spot (On Demand taxonomy)", lssdLinux.Spot, wantSpot)
+}
+
+func linuxPricing(t *testing.T, instance *GCPInstance, region string) *GCPPricingData {
+	t.Helper()
+	regionPricing, ok := instance.Pricing[region]
+	if !ok {
+		t.Fatalf("%s: expected pricing for region %s", instance.InstanceType, region)
+	}
+	linux, ok := regionPricing["linux"].(*GCPPricingData)
+	if !ok {
+		t.Fatalf("%s: expected linux pricing data", instance.InstanceType)
+	}
+	return linux
+}

--- a/scraper/gcp/local_ssd_test.go
+++ b/scraper/gcp/local_ssd_test.go
@@ -1,17 +1,21 @@
 package gcp
 
 import (
+	"bytes"
 	"encoding/json"
+	"log"
+	"os"
+	"strings"
 	"testing"
 )
 
 // TestBundledLocalSSDCapacityGB verifies capacity discovery from the Compute
-// Engine machineTypes API payload: the structured bundledLocalSsds field is
-// the primary source (partitionCount x per-partition size, 375 GB for every
-// series except Z3's 3,000 GiB Titanium SSD disks, or 6,000 GiB for the
-// bare-metal Z3 shapes), with the disk count in the human-readable
-// description as a fallback. Shapes without bundled Local SSD must report 0
-// so attachable-SSD families keep local_ssd=false.
+// Engine machineTypes API payload: capacity is partitionCount x per-partition
+// size, which is 375 GB except for the Titanium SSD shapes (Z3 at 3,000 GiB,
+// bare-metal Z3 at 6,000 GiB, bare-metal C4 at 3,000 GiB, and A4X at 3,000
+// GiB). Every expectation below equals the capacity Google documents for that
+// shape. Shapes without bundled Local SSD must report 0 so attachable-SSD
+// families keep local_ssd=false.
 func TestBundledLocalSSDCapacityGB(t *testing.T) {
 	cases := []struct {
 		name string
@@ -37,6 +41,11 @@ func TestBundledLocalSSDCapacityGB(t *testing.T) {
 			name: "z3 bare-metal titanium ssd disks are 6000 GiB each",
 			raw:  `{"name":"z3-highmem-192-highlssd-metal","guestCpus":192,"memoryMb":1572864,"bundledLocalSsds":{"defaultInterface":"NVME","partitionCount":12}}`,
 			want: 72000,
+		},
+		{
+			name: "non-metal c4 lssd shape keeps 375 GB partitions",
+			raw:  `{"name":"c4-standard-8-lssd","guestCpus":8,"memoryMb":30720,"bundledLocalSsds":{"defaultInterface":"NVME","partitionCount":1}}`,
+			want: 375,
 		},
 		{
 			name: "c4 bare-metal titanium ssd disks are 3000 GiB each",
@@ -291,6 +300,208 @@ func TestProcessGCPDataLocalSSDLegacyRegions(t *testing.T) {
 
 	assertPrice(t, "lssd ondemand (legacy multi-regional SKU)", lssdLinux.OnDemand, wantOnDemand)
 	assertPrice(t, "lssd spot (On Demand taxonomy)", lssdLinux.Spot, wantSpot)
+}
+
+// captureWarnings collects what utils.SendWarning logs while fn runs. It logs
+// through the standard logger, so redirecting that is enough to assert on a
+// warning without a test-only hook in the scraper itself.
+func captureWarnings(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+	fn()
+	return buf.String()
+}
+
+// TestMissingLocalSSDRateIsReported pins the reason the SSD fold-in reports
+// misses at all: a bundled Local SSD shape in a region with no Local SSD rate
+// is priced core+RAM only, which is indistinguishable from the SSD-less bug
+// this scraper had. Silence there would ship a too-low price unnoticed.
+func TestMissingLocalSSDRateIsReported(t *testing.T) {
+	const region = "us-central1"
+
+	skus := []SKU{
+		onDemandSKU("od-core", "C3 Instance Core running in Iowa", []string{region}),
+		onDemandSKU("od-ram", "C3 Instance Ram running in Iowa", []string{region}),
+	}
+	pricing := map[string]PriceInfo{
+		"od-core": usdRate("h", 0.03398),
+		"od-ram":  usdRate("giby.h", 0.00456),
+	}
+	machineSpecs := map[string]*MachineSpecs{
+		"c3-standard-8-lssd": {VCPU: 8, MemoryGB: 32, Family: "Compute optimized", LocalSSDGB: 750},
+	}
+
+	var instances map[string]*GCPInstance
+	warnings := captureWarnings(t, func() {
+		instances = processGCPData(skus, pricing, machineSpecs, map[string]string{region: "Iowa"})
+	})
+
+	if !strings.Contains(warnings, "C3/us-central1/spot=false") {
+		t.Errorf("expected a missing Local SSD rate warning naming C3/us-central1, got:\n%s", warnings)
+	}
+
+	// The shape still ships at its core+RAM price; the warning is the only
+	// signal that the price is incomplete.
+	lssd := linuxPricing(t, mustInstance(t, instances, "c3-standard-8-lssd"), region)
+	assertPrice(t, "lssd ondemand without an SSD rate", lssd.OnDemand, 8*0.03398+32*0.00456)
+}
+
+// TestUnknownLocalSSDPartitionSizeIsReported covers the other silent-mispricing
+// path: partition size is a per-series constant the API never returns, so a
+// series (or bare-metal variant) that deviates from 375 GB must not be assumed
+// away. Bare metal is checked separately because Z3 and C4 metal shapes use
+// larger disks than the rest of their own series.
+func TestUnknownLocalSSDPartitionSizeIsReported(t *testing.T) {
+	cases := []struct {
+		name     string
+		wantWarn bool
+	}{
+		{"c3-standard-8-lssd", false},
+		{"c4-standard-288-lssd-metal", false},
+		{"z3-highmem-192-highlssd-metal", false},
+		{"a4x-maxgpu-4g-metal", false},
+		{"w9-standard-8-lssd", true},
+		{"c4d-standard-384-lssd-metal", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mt := MachineType{Name: tc.name, BundledLocalSsds: &BundledLocalSsds{PartitionCount: 2}}
+			warnings := captureWarnings(t, func() { bundledLocalSSDCapacityGB(mt) })
+			if got := strings.Contains(warnings, tc.name); got != tc.wantWarn {
+				t.Errorf("warned=%v want %v for %s (output: %s)", got, tc.wantWarn, tc.name, warnings)
+			}
+		})
+	}
+}
+
+// TestGenericLocalSSDFallbackIsReported covers the live c4/asia-southeast3
+// gap: Google offers c4-*-lssd shapes in Bangkok and sells C4 core and RAM
+// there, but publishes no "C4 Instance Local SSD running in Bangkok" SKU, so
+// the shape resolves to the legacy generic rate. Per-family Titanium SSD rates
+// run about twice the generic rate, so the shape ships understated by roughly
+// half its SSD component with no other symptom: the rate is present and is
+// identical across every C4 shape in the region, so neither the missing-rate
+// warning nor an implied-rate consistency check can see it.
+//
+// C3 is the control. It has no per-family Local SSD SKU in any region, so the
+// generic rate is the correct rate for it and must not warn.
+func TestGenericLocalSSDFallbackIsReported(t *testing.T) {
+	const iowa, bangkok = "us-central1", "asia-southeast3"
+	both := []string{iowa, bangkok}
+
+	skus := []SKU{
+		onDemandSKU("c4-core", "C4 Instance Core running in Iowa", both),
+		onDemandSKU("c4-ram", "C4 Instance Ram running in Iowa", both),
+		onDemandSKU("c3-core", "C3 Instance Core running in Iowa", both),
+		onDemandSKU("c3-ram", "C3 Instance Ram running in Iowa", both),
+		onDemandSKU("c4-ssd-iowa", "C4 Instance Local SSD running in Iowa", []string{iowa}),
+		onDemandSKU("generic-ssd", "SSD backed Local Storage", both),
+	}
+	pricing := map[string]PriceInfo{
+		"c4-core":     usdRate("h", 0.03638),
+		"c4-ram":      usdRate("giby.h", 0.004135),
+		"c3-core":     usdRate("h", 0.03398),
+		"c3-ram":      usdRate("giby.h", 0.00456),
+		"c4-ssd-iowa": usdRate("giby.mo", 0.16),
+		"generic-ssd": usdRate("giby.mo", 0.084),
+	}
+	machineSpecs := map[string]*MachineSpecs{
+		"c4-standard-8-lssd": {VCPU: 8, MemoryGB: 30, Family: "Compute optimized", LocalSSDGB: 375},
+		"c3-standard-8-lssd": {VCPU: 8, MemoryGB: 32, Family: "Compute optimized", LocalSSDGB: 750},
+	}
+
+	var instances map[string]*GCPInstance
+	warnings := captureWarnings(t, func() {
+		instances = processGCPData(skus, pricing, machineSpecs,
+			map[string]string{iowa: "Iowa", bangkok: "Bangkok"})
+	})
+
+	if !strings.Contains(warnings, "C4/asia-southeast3") {
+		t.Errorf("expected a generic Local SSD fallback warning naming C4/asia-southeast3, got:\n%s", warnings)
+	}
+	if strings.Contains(warnings, "C4/us-central1") {
+		t.Errorf("C4 has its own Iowa Local SSD SKU and must not warn there, got:\n%s", warnings)
+	}
+	for _, region := range both {
+		if strings.Contains(warnings, "C3/"+region) {
+			t.Errorf("C3 has no per-family Local SSD SKU anywhere, so the generic rate is correct; got:\n%s", warnings)
+		}
+	}
+
+	// The warned shape still ships, priced from the generic rate.
+	c4 := mustInstance(t, instances, "c4-standard-8-lssd")
+	assertPrice(t, "c4 lssd Bangkok on the generic SSD rate",
+		linuxPricing(t, c4, bangkok).OnDemand, 8*0.03638+30*0.004135+375*0.084/730)
+	assertPrice(t, "c4 lssd Iowa on its own C4 SSD rate",
+		linuxPricing(t, c4, iowa).OnDemand, 8*0.03638+30*0.004135+375*0.16/730)
+}
+
+// TestZ3BundledLocalSSDUsesGenericRate pins the one family whose bundled Local
+// SSD is billed at the generic rate despite having per-family Local SSD SKUs.
+// Google's published Z3 prices reconstruct from the generic rate and never from
+// the per-family one; see bundledSSDBillsAtGenericRate.
+//
+// The rates below are deliberately far apart so the assertions fail if the
+// precedence reverts. That matters more than usual here: bundledSSDBillsAtGenericRate
+// is keyed on the uppercased machine family, so a lowercase key would leave the
+// old behaviour in place with nothing else to notice it.
+func TestZ3BundledLocalSSDUsesGenericRate(t *testing.T) {
+	const iowa, berlin = "us-central1", "europe-west10"
+	both := []string{iowa, berlin}
+	const z3SSDMonthly, genericSSDMonthly = 0.16, 0.08
+
+	skus := []SKU{
+		onDemandSKU("z3-core", "Z3 Instance Core running in Iowa", both),
+		onDemandSKU("z3-ram", "Z3 Instance Ram running in Iowa", both),
+		onDemandSKU("c4-core", "C4 Instance Core running in Iowa", both),
+		onDemandSKU("c4-ram", "C4 Instance Ram running in Iowa", both),
+		onDemandSKU("z3-ssd", "Z3 Instance Local SSD running in Iowa", both),
+		onDemandSKU("c4-ssd", "C4 Instance Local SSD running in Iowa", both),
+		// Generic rate exists in Iowa only, so Berlin exercises the fallback to
+		// the per-family bucket that reversing the precedence has to preserve.
+		onDemandSKU("generic-ssd", "SSD backed Local Storage in Iowa", []string{iowa}),
+	}
+	pricing := map[string]PriceInfo{
+		"z3-core": usdRate("h", 0.0459), "z3-ram": usdRate("giby.h", 0.00614),
+		"c4-core": usdRate("h", 0.03638), "c4-ram": usdRate("giby.h", 0.004135),
+		"z3-ssd": usdRate("giby.mo", z3SSDMonthly), "c4-ssd": usdRate("giby.mo", 0.16),
+		"generic-ssd": usdRate("giby.mo", genericSSDMonthly),
+	}
+	machineSpecs := map[string]*MachineSpecs{
+		"z3-highmem-22-highlssd": {VCPU: 22, MemoryGB: 176, Family: "Storage optimized", LocalSSDGB: 9000},
+		"c4-standard-8-lssd":     {VCPU: 8, MemoryGB: 30, Family: "Compute optimized", LocalSSDGB: 375},
+	}
+
+	var instances map[string]*GCPInstance
+	warnings := captureWarnings(t, func() {
+		instances = processGCPData(skus, pricing, machineSpecs,
+			map[string]string{iowa: "Iowa", berlin: "Berlin"})
+	})
+
+	z3 := mustInstance(t, instances, "z3-highmem-22-highlssd")
+	z3Core, z3Mem := 22*0.0459+176*0.00614, 9000.0
+	assertPrice(t, "z3 uses the generic SSD rate where one exists",
+		linuxPricing(t, z3, iowa).OnDemand, z3Core+z3Mem*genericSSDMonthly/730)
+	assertPrice(t, "z3 falls back to its per-family rate where no generic rate exists",
+		linuxPricing(t, z3, berlin).OnDemand, z3Core+z3Mem*z3SSDMonthly/730)
+
+	// C4 must be untouched: the reversal is per-family, not global.
+	assertPrice(t, "c4 still uses its per-family SSD rate",
+		linuxPricing(t, mustInstance(t, instances, "c4-standard-8-lssd"), iowa).OnDemand,
+		8*0.03638+30*0.004135+375*0.16/730)
+
+	// Z3 resolving through the generic bucket is intended, so it must not be
+	// reported as a fallback. Berlin losing its generic rate is the new failure
+	// mode the reversal introduces, and that one must be reported.
+	if strings.Contains(warnings, "Z3/us-central1") {
+		t.Errorf("Z3 on the generic rate is intended and must not warn, got:\n%s", warnings)
+	}
+	if !strings.Contains(warnings, "Z3/europe-west10") {
+		t.Errorf("expected a warning that Z3 had no generic rate in europe-west10, got:\n%s", warnings)
+	}
 }
 
 func linuxPricing(t *testing.T, instance *GCPInstance, region string) *GCPPricingData {

--- a/scraper/gcp/m2_test.go
+++ b/scraper/gcp/m2_test.go
@@ -42,9 +42,10 @@ func TestParseMemoryOptimizedPremiumSKU(t *testing.T) {
 
 // TestProcessGCPDataM2Pricing verifies the end-to-end M2 synthesis: m2-* has no
 // SKUs of its own, so its on-demand price is the M1 base core/RAM rates plus the
-// Memory Optimized Upgrade Premium surcharge. It also asserts the two intended
-// omissions (no Spot, no CUD for M2, since the catalog has no premium Spot or
-// commitment SKU) and that the premium never leaks into M1's own pricing.
+// Memory Optimized Upgrade Premium surcharge. It asserts M2 Spot stays unset
+// (no premium Spot SKU exists) and that the premium never leaks into M1's own
+// pricing. This fixture has no M1 commitment SKUs, so M2 CUD is also unset here;
+// M2 CUD synthesis from M1 commitments is covered by TestProcessGCPDataM2CUDPricing.
 func TestProcessGCPDataM2Pricing(t *testing.T) {
 	const region = "us-central1" // resolved via the multi-americas expansion
 
@@ -93,7 +94,8 @@ func TestProcessGCPDataM2Pricing(t *testing.T) {
 	wantM2OnDemand := m2VCPU*(baseCore+premCore) + m2MemGB*(baseRam+premRam)
 	assertPrice(t, "m2 ondemand", m2Linux.OnDemand, wantM2OnDemand)
 
-	// M2 has no Spot or committed-use SKU, so those fields stay unset.
+	// M2 Spot stays unset (no premium Spot SKU). M2 CUD is unset here because
+	// this fixture supplies no M1 commitment SKUs to synthesize it from.
 	if m2Linux.Spot != "" {
 		t.Errorf("m2 spot = %q, want empty", m2Linux.Spot)
 	}

--- a/scraper/gcp/m2_test.go
+++ b/scraper/gcp/m2_test.go
@@ -1,0 +1,112 @@
+package gcp
+
+import "testing"
+
+// multiRegionalSKU builds a multi-regional ("running in Americas") SKU with the
+// TYPE_MULTI_REGIONAL geo taxonomy the live catalog uses for the M1 base and
+// Memory Optimized Upgrade Premium SKUs (their region list is expressed only as
+// the "Americas" grouping, which resolves to the multi-americas identifier).
+func multiRegionalSKU(id, displayName string) SKU {
+	return SKU{
+		SkuId:       id,
+		DisplayName: displayName,
+		GeoTaxonomy: GeoTaxonomy{Type: "TYPE_MULTI_REGIONAL"},
+	}
+}
+
+// TestParseMemoryOptimizedPremiumSKU verifies the surcharge SKUs that make up
+// M2 pricing are recognized, and that the base/CUD/spot SKUs sharing the
+// "Memory-optimized Instance ..." wording are not misclassified as premiums.
+func TestParseMemoryOptimizedPremiumSKU(t *testing.T) {
+	cases := []struct {
+		display      string
+		wantResource string
+		wantOK       bool
+	}{
+		{"Memory Optimized Upgrade Premium for Memory-optimized Instance Core running in Americas", "core", true},
+		{"Memory Optimized Upgrade Premium for Memory-optimized Instance Ram running in Frankfurt", "ram", true},
+		// The M1 base SKUs the premium is layered on top of are not premiums.
+		{"Memory-optimized Instance Core running in Americas", "", false},
+		{"Memory-optimized Instance Ram running in Tokyo", "", false},
+		{"N2 Instance Core running in Iowa", "", false},
+	}
+
+	for _, tc := range cases {
+		resource, ok := parseMemoryOptimizedPremiumSKU(SKU{DisplayName: tc.display})
+		if ok != tc.wantOK || resource != tc.wantResource {
+			t.Errorf("parseMemoryOptimizedPremiumSKU(%q) = (%q, %v), want (%q, %v)",
+				tc.display, resource, ok, tc.wantResource, tc.wantOK)
+		}
+	}
+}
+
+// TestProcessGCPDataM2Pricing verifies the end-to-end M2 synthesis: m2-* has no
+// SKUs of its own, so its on-demand price is the M1 base core/RAM rates plus the
+// Memory Optimized Upgrade Premium surcharge. It also asserts the two intended
+// omissions (no Spot, no CUD for M2, since the catalog has no premium Spot or
+// commitment SKU) and that the premium never leaks into M1's own pricing.
+func TestProcessGCPDataM2Pricing(t *testing.T) {
+	const region = "us-central1" // resolved via the multi-americas expansion
+
+	// Live us-central1/Americas rates (SKUs AE53/9DFC base, 19A3/646C premium).
+	baseCore := 0.0348
+	baseRam := 0.0051
+	premCore := 0.004524
+	premRam := 0.000663
+
+	skus := []SKU{
+		multiRegionalSKU("m1-core", "Memory-optimized Instance Core running in Americas"),
+		multiRegionalSKU("m1-ram", "Memory-optimized Instance Ram running in Americas"),
+		// M1 spot rates exist; M2 must NOT inherit them.
+		multiRegionalSKU("m1-spot-core", "Spot Preemptible Memory-optimized Instance Core running in Americas"),
+		multiRegionalSKU("m1-spot-ram", "Spot Preemptible Memory-optimized Instance Ram running in Americas"),
+		multiRegionalSKU("prem-core", "Memory Optimized Upgrade Premium for Memory-optimized Instance Core running in Americas"),
+		multiRegionalSKU("prem-ram", "Memory Optimized Upgrade Premium for Memory-optimized Instance Ram running in Americas"),
+	}
+
+	pricing := map[string]PriceInfo{
+		"m1-core":      usdRate("h", baseCore),
+		"m1-ram":       usdRate("giby.h", baseRam),
+		"m1-spot-core": usdRate("h", 0.0104),
+		"m1-spot-ram":  usdRate("giby.h", 0.0015),
+		"prem-core":    usdRate("h", premCore),
+		"prem-ram":     usdRate("giby.h", premRam),
+	}
+
+	const m1VCPU, m1MemGB = 40, 961.0
+	const m2VCPU, m2MemGB = 208, 5888.0
+	machineSpecs := map[string]*MachineSpecs{
+		"m1-ultramem-40":  {VCPU: m1VCPU, MemoryGB: m1MemGB, Family: "Memory optimized"},
+		"m2-ultramem-208": {VCPU: m2VCPU, MemoryGB: m2MemGB, Family: "Memory optimized"},
+	}
+
+	regions := map[string]string{region: "Iowa"}
+
+	instances := processGCPData(skus, pricing, machineSpecs, regions)
+
+	m2, ok := instances["m2-ultramem-208"]
+	if !ok {
+		t.Fatalf("expected m2-ultramem-208 instance to be built")
+	}
+	m2Linux := linuxPricing(t, m2, region)
+
+	wantM2OnDemand := m2VCPU*(baseCore+premCore) + m2MemGB*(baseRam+premRam)
+	assertPrice(t, "m2 ondemand", m2Linux.OnDemand, wantM2OnDemand)
+
+	// M2 has no Spot or committed-use SKU, so those fields stay unset.
+	if m2Linux.Spot != "" {
+		t.Errorf("m2 spot = %q, want empty", m2Linux.Spot)
+	}
+	if m2Linux.CUD1Yr != "" || m2Linux.CUD3Yr != "" {
+		t.Errorf("m2 CUD = (%q, %q), want empty", m2Linux.CUD1Yr, m2Linux.CUD3Yr)
+	}
+
+	// M1's own on-demand price must be the base rates only; the premium must
+	// not have inflated it.
+	m1, ok := instances["m1-ultramem-40"]
+	if !ok {
+		t.Fatalf("expected m1-ultramem-40 instance to be built")
+	}
+	m1Linux := linuxPricing(t, m1, region)
+	assertPrice(t, "m1 ondemand", m1Linux.OnDemand, m1VCPU*baseCore+m1MemGB*baseRam)
+}

--- a/scraper/gcp/m4_ultramem224_test.go
+++ b/scraper/gcp/m4_ultramem224_test.go
@@ -1,0 +1,113 @@
+package gcp
+
+import "testing"
+
+// TestProcessGCPDataM4Ultramem224Pricing verifies the end-to-end synthesis for
+// m4-ultramem-224, the only M4 shape billed under its own dedicated
+// "M4Ultramem224 Instance Core/Ram" SKU pair (with matching Spot and CUD
+// variants) rather than the plain "M4 Instance Core/Ram" rates shared by every
+// other M4 shape. It also asserts the plain M4 rates still price m4-megamem-28
+// and never leak into the ultramem-224 bucket (or vice versa).
+//
+// The M4Ultramem224 Ram SKUs are cataloged per decimal GB ("GBy.h"), unlike
+// almost every other RAM SKU (including plain M4's) which is per binary GiB
+// ("GiBy.h"); calculateHourlyPrice's gibPerDecimalGB scaling is what makes the
+// on-demand total below land exactly on Google's published
+// us-central1 price (41.464125836).
+func TestProcessGCPDataM4Ultramem224Pricing(t *testing.T) {
+	const region = "us-central1" // resolved via the multi-americas region list
+
+	// Live us-central1/Americas rates for M4Ultramem224.
+	core := 0.02317
+	ramPerGB := 0.00567588
+	spotCore := 0.00924
+	spotRamPerGB := 0.002265
+	cud1Core := 0.0136703
+	cud1RamPerGB := 0.0033487700
+	cud3Core := 0.006951
+	cud3RamPerGB := 0.00170276
+
+	// Live us-central1/Americas rates for plain M4 (per binary GiB already).
+	m4Core := 0.0182784
+	m4Ram := 0.00457
+
+	skus := []SKU{
+		multiRegionalSKU("m4um224-core", "M4Ultramem224 Instance Core running in Americas"),
+		multiRegionalSKU("m4um224-ram", "M4Ultramem224 Instance Ram running in Americas"),
+		multiRegionalSKU("m4um224-spot-core", "Spot Preemptible M4Ultramem224 Instance Core running in Americas"),
+		multiRegionalSKU("m4um224-spot-ram", "Spot Preemptible M4Ultramem224 Instance Ram running in Americas"),
+		multiRegionalSKU("m4um224-cud1-core", "Commitment v1: M4Ultramem224 Cpu in Americas for 1 Year"),
+		multiRegionalSKU("m4um224-cud1-ram", "Commitment v1: M4Ultramem224 Ram in Americas for 1 Year"),
+		multiRegionalSKU("m4um224-cud3-core", "Commitment v1: M4Ultramem224 Cpu in Americas for 3 Years"),
+		multiRegionalSKU("m4um224-cud3-ram", "Commitment v1: M4Ultramem224 Ram in Americas for 3 Years"),
+		// Plain M4, shared by every non-ultramem-224 M4 shape. Must not be
+		// conflated with the M4Ultramem224 bucket above.
+		multiRegionalSKU("m4-core", "M4 Instance Core running in Americas"),
+		multiRegionalSKU("m4-ram", "M4 Instance Ram running in Americas"),
+	}
+
+	pricing := map[string]PriceInfo{
+		"m4um224-core":      usdRate("h", core),
+		"m4um224-ram":       usdRate("gby.h", ramPerGB),
+		"m4um224-spot-core": usdRate("h", spotCore),
+		"m4um224-spot-ram":  usdRate("gby.h", spotRamPerGB),
+		"m4um224-cud1-core": usdRate("h", cud1Core),
+		"m4um224-cud1-ram":  usdRate("gby.h", cud1RamPerGB),
+		"m4um224-cud3-core": usdRate("h", cud3Core),
+		"m4um224-cud3-ram":  usdRate("gby.h", cud3RamPerGB),
+		"m4-core":           usdRate("h", m4Core),
+		"m4-ram":            usdRate("giby.h", m4Ram),
+	}
+
+	const ultramemVCPU, ultramemMemGB = 224, 5952.0
+	const megamemVCPU, megamemMemGB = 28, 372.0
+	machineSpecs := map[string]*MachineSpecs{
+		"m4-ultramem-224": {VCPU: ultramemVCPU, MemoryGB: ultramemMemGB, Family: "Memory optimized"},
+		"m4-megamem-28":   {VCPU: megamemVCPU, MemoryGB: megamemMemGB, Family: "Memory optimized"},
+	}
+
+	regions := map[string]string{region: "Iowa"}
+
+	instances := processGCPData(skus, pricing, machineSpecs, regions)
+
+	gibPerGB := 1073741824.0 / 1e9
+
+	ultramem, ok := instances["m4-ultramem-224"]
+	if !ok {
+		t.Fatalf("expected m4-ultramem-224 instance to be built")
+	}
+	ultramemLinux := linuxPricing(t, ultramem, region)
+
+	wantOnDemand := ultramemVCPU*core + ultramemMemGB*ramPerGB*gibPerGB
+	wantSpot := ultramemVCPU*spotCore + ultramemMemGB*spotRamPerGB*gibPerGB
+	wantCUD1Yr := ultramemVCPU*cud1Core + ultramemMemGB*cud1RamPerGB*gibPerGB
+	wantCUD3Yr := ultramemVCPU*cud3Core + ultramemMemGB*cud3RamPerGB*gibPerGB
+
+	assertPrice(t, "m4-ultramem-224 ondemand", ultramemLinux.OnDemand, wantOnDemand)
+	assertPrice(t, "m4-ultramem-224 spot", ultramemLinux.Spot, wantSpot)
+	assertPrice(t, "m4-ultramem-224 cud_1yr", ultramemLinux.CUD1Yr, wantCUD1Yr)
+	assertPrice(t, "m4-ultramem-224 cud_3yr", ultramemLinux.CUD3Yr, wantCUD3Yr)
+
+	// Google's published us-central1 on-demand price for m4-ultramem-224.
+	assertPrice(t, "m4-ultramem-224 ondemand vs published price", ultramemLinux.OnDemand, 41.464125836)
+
+	// m4-megamem-28 must still be priced from the plain M4 rates, not the
+	// M4Ultramem224 bucket.
+	megamem, ok := instances["m4-megamem-28"]
+	if !ok {
+		t.Fatalf("expected m4-megamem-28 instance to be built")
+	}
+	megamemLinux := linuxPricing(t, megamem, region)
+	wantMegamem := megamemVCPU*m4Core + megamemMemGB*m4Ram
+	assertPrice(t, "m4-megamem-28 ondemand", megamemLinux.OnDemand, wantMegamem)
+
+	// m4-megamem-28 has no CUD/Spot fixtures of its own in this test (only
+	// the plain M4 on-demand SKUs above), so those fields must stay unset --
+	// proof the M4Ultramem224 CUD/Spot buckets did not leak into it.
+	if megamemLinux.Spot != "" {
+		t.Errorf("m4-megamem-28 spot = %q, want empty", megamemLinux.Spot)
+	}
+	if megamemLinux.CUD1Yr != "" || megamemLinux.CUD3Yr != "" {
+		t.Errorf("m4-megamem-28 CUD = (%q, %q), want empty", megamemLinux.CUD1Yr, megamemLinux.CUD3Yr)
+	}
+}

--- a/scraper/gcp/m4_ultramem224_test.go
+++ b/scraper/gcp/m4_ultramem224_test.go
@@ -11,7 +11,7 @@ import "testing"
 //
 // The M4Ultramem224 Ram SKUs are cataloged per decimal GB ("GBy.h"), unlike
 // almost every other RAM SKU (including plain M4's) which is per binary GiB
-// ("GiBy.h"); calculateHourlyPrice's gibPerDecimalGB scaling is what makes the
+// ("GiBy.h"); calculateHourlyPrice's decimalGBPerGiB scaling is what makes the
 // on-demand total below land exactly on Google's published
 // us-central1 price (41.464125836).
 func TestProcessGCPDataM4Ultramem224Pricing(t *testing.T) {
@@ -70,18 +70,16 @@ func TestProcessGCPDataM4Ultramem224Pricing(t *testing.T) {
 
 	instances := processGCPData(skus, pricing, machineSpecs, regions)
 
-	gibPerGB := 1073741824.0 / 1e9
-
 	ultramem, ok := instances["m4-ultramem-224"]
 	if !ok {
 		t.Fatalf("expected m4-ultramem-224 instance to be built")
 	}
 	ultramemLinux := linuxPricing(t, ultramem, region)
 
-	wantOnDemand := ultramemVCPU*core + ultramemMemGB*ramPerGB*gibPerGB
-	wantSpot := ultramemVCPU*spotCore + ultramemMemGB*spotRamPerGB*gibPerGB
-	wantCUD1Yr := ultramemVCPU*cud1Core + ultramemMemGB*cud1RamPerGB*gibPerGB
-	wantCUD3Yr := ultramemVCPU*cud3Core + ultramemMemGB*cud3RamPerGB*gibPerGB
+	wantOnDemand := ultramemVCPU*core + ultramemMemGB*ramPerGB*decimalGBPerGiB
+	wantSpot := ultramemVCPU*spotCore + ultramemMemGB*spotRamPerGB*decimalGBPerGiB
+	wantCUD1Yr := ultramemVCPU*cud1Core + ultramemMemGB*cud1RamPerGB*decimalGBPerGiB
+	wantCUD3Yr := ultramemVCPU*cud3Core + ultramemMemGB*cud3RamPerGB*decimalGBPerGiB
 
 	assertPrice(t, "m4-ultramem-224 ondemand", ultramemLinux.OnDemand, wantOnDemand)
 	assertPrice(t, "m4-ultramem-224 spot", ultramemLinux.Spot, wantSpot)

--- a/scraper/gcp/region_precedence_test.go
+++ b/scraper/gcp/region_precedence_test.go
@@ -1,0 +1,253 @@
+package gcp
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRegionScopedSKUBeatsMultiRegional pins the precedence in selectHourlyPrice:
+// a SKU scoped to the region wins over a rate inherited from a multi-regional
+// SKU expanded into that region, regardless of which is cheaper.
+//
+// The live case that motivated it is Z3 Spot in us-east5, where "Spot Preemptible
+// Z3 Instance Core running in Columbus" ($0.02518) and "... running in Americas"
+// ($0.01935) both resolve to the region. Spot used to select the minimum across
+// both tiers, so the Americas rate won and every Americas region collapsed to one
+// number, 27% under Google's published price. On-demand had the mirror-image
+// exposure via max, so both directions are asserted here: a rate that loses on
+// price must still win on scope.
+func TestRegionScopedSKUBeatsMultiRegional(t *testing.T) {
+	// us-east5 is a member of multi-americas; us-west2 is a member with no
+	// region-scoped SKU in this fixture, so it must inherit the Americas rate.
+	const columbus, losAngeles = "us-east5", "us-west2"
+
+	const (
+		columbusCore, columbusRam = 0.02518, 0.003375
+		americasCore, americasRam = 0.01935, 0.002594 // cheaper: loses on scope
+		columbusODCore            = 0.0900            // cheaper than Americas on demand
+		americasODCore            = 0.1100            // dearer: must still lose on scope
+		ramOD                     = 0.001
+	)
+
+	skus := []SKU{
+		onDemandSKU("z3-spot-core-col", "Spot Preemptible Z3 Instance Core running in Columbus", []string{columbus}),
+		onDemandSKU("z3-spot-ram-col", "Spot Preemptible Z3 Instance Ram running in Columbus", []string{columbus}),
+		multiRegionalSKU("z3-spot-core-ame", "Spot Preemptible Z3 Instance Core running in Americas"),
+		multiRegionalSKU("z3-spot-ram-ame", "Spot Preemptible Z3 Instance Ram running in Americas"),
+		onDemandSKU("z3-od-core-col", "Z3 Instance Core running in Columbus", []string{columbus}),
+		multiRegionalSKU("z3-od-core-ame", "Z3 Instance Core running in Americas"),
+		multiRegionalSKU("z3-od-ram-ame", "Z3 Instance Ram running in Americas"),
+	}
+	pricing := map[string]PriceInfo{
+		"z3-spot-core-col": usdRate("h", columbusCore),
+		"z3-spot-ram-col":  usdRate("giby.h", columbusRam),
+		"z3-spot-core-ame": usdRate("h", americasCore),
+		"z3-spot-ram-ame":  usdRate("giby.h", americasRam),
+		"z3-od-core-col":   usdRate("h", columbusODCore),
+		"z3-od-core-ame":   usdRate("h", americasODCore),
+		"z3-od-ram-ame":    usdRate("giby.h", ramOD),
+	}
+
+	const vcpu, memGB = 22, 176.0
+	machineSpecs := map[string]*MachineSpecs{
+		"z3-highmem-22": {VCPU: vcpu, MemoryGB: memGB, Family: "Storage optimized"},
+	}
+	regions := map[string]string{columbus: "Columbus", losAngeles: "Los Angeles"}
+
+	instances := processGCPData(skus, pricing, machineSpecs, regions)
+	shape := mustInstance(t, instances, "z3-highmem-22")
+
+	col := linuxPricing(t, shape, columbus)
+	assertPrice(t, "spot takes the region-scoped rate even though Americas is cheaper",
+		col.Spot, vcpu*columbusCore+memGB*columbusRam)
+	// RAM has no region-scoped on-demand SKU here, so on-demand mixes a scoped
+	// core with an inherited RAM rate -- the precedence is per bucket, not per shape.
+	assertPrice(t, "on-demand takes the region-scoped core even though Americas is dearer",
+		col.OnDemand, vcpu*columbusODCore+memGB*ramOD)
+
+	// A member region with no scoped SKU must still inherit, or the fix would
+	// trade a wrong price for a missing one.
+	la := linuxPricing(t, shape, losAngeles)
+	assertPrice(t, "region with no scoped SKU inherits the Americas spot rate",
+		la.Spot, vcpu*americasCore+memGB*americasRam)
+	assertPrice(t, "region with no scoped SKU inherits the Americas on-demand rate",
+		la.OnDemand, vcpu*americasODCore+memGB*ramOD)
+}
+
+// TestDuplicateRegionScopedSKUPrefersHigherRate pins the rule inside the winning
+// tier: when two SKUs Google scopes to the same region disagree on price, the
+// higher rate is the one it bills.
+//
+// Rates are the live us-east4 M1 memory-optimized pair, where the catalog carries
+// both "Memory-optimized Instance Core running in Virginia" and "... running in
+// Northern Virginia" at different prices with the same geoTaxonomy region. Taking
+// the minimum on Spot put m1-ultramem-40 at 1.159750 against Google's published
+// 1.495132, 22.4% low. Both columns are asserted because the choice is not
+// symmetric by luck: H4D's duplicate is a Dynamic Workload Scheduler product at
+// 1.25x the standard rate, and it is only the max direction that leaves H4D
+// on-demand correct.
+func TestDuplicateRegionScopedSKUPrefersHigherRate(t *testing.T) {
+	const virginia = "us-east4"
+
+	// Live us-east4 M1 rates; the "Virginia" spelling carries the higher rate on
+	// both columns and is the one Google bills.
+	const (
+		spotCoreHigh, spotCoreLow = 0.00826, 0.00617
+		spotRAMHigh, spotRAMLow   = 0.001212, 0.00095
+		odCoreHigh, odCoreLow     = 0.0392322, 0.0392
+		odRAMHigh, odRAMLow       = 0.0053, 0.0052
+	)
+
+	skus := []SKU{
+		onDemandSKU("m1-spot-core-va", "Spot Preemptible Memory-optimized Instance Core running in Virginia", []string{virginia}),
+		onDemandSKU("m1-spot-core-nova", "Spot Preemptible Memory-optimized Instance Core running in Northern Virginia", []string{virginia}),
+		onDemandSKU("m1-spot-ram-va", "Spot Preemptible Memory-optimized Instance Ram running in Virginia", []string{virginia}),
+		onDemandSKU("m1-spot-ram-nova", "Spot Preemptible Memory-optimized Instance Ram running in Northern Virginia", []string{virginia}),
+		onDemandSKU("m1-od-core-va", "Memory-optimized Instance Core running in Virginia", []string{virginia}),
+		onDemandSKU("m1-od-core-nova", "Memory-optimized Instance Core running in Northern Virginia", []string{virginia}),
+		onDemandSKU("m1-od-ram-va", "Memory-optimized Instance Ram running in Virginia", []string{virginia}),
+		onDemandSKU("m1-od-ram-nova", "Memory-optimized Instance Ram running in Northern Virginia", []string{virginia}),
+	}
+	pricing := map[string]PriceInfo{
+		"m1-spot-core-va":   usdRate("h", spotCoreHigh),
+		"m1-spot-core-nova": usdRate("h", spotCoreLow),
+		"m1-spot-ram-va":    usdRate("giby.h", spotRAMHigh),
+		"m1-spot-ram-nova":  usdRate("giby.h", spotRAMLow),
+		"m1-od-core-va":     usdRate("h", odCoreHigh),
+		"m1-od-core-nova":   usdRate("h", odCoreLow),
+		"m1-od-ram-va":      usdRate("giby.h", odRAMHigh),
+		"m1-od-ram-nova":    usdRate("giby.h", odRAMLow),
+	}
+
+	const vcpu, memGB = 40, 961.0
+	machineSpecs := map[string]*MachineSpecs{
+		"m1-ultramem-40": {VCPU: vcpu, MemoryGB: memGB, Family: "Memory optimized"},
+	}
+
+	instances := processGCPData(skus, pricing, machineSpecs, map[string]string{virginia: "Virginia"})
+	prices := linuxPricing(t, mustInstance(t, instances, "m1-ultramem-40"), virginia)
+
+	// Expected values are built from the same constants rather than written as
+	// literals: usdRate converts through float64 nanos and does not round-trip
+	// a hand-typed decimal exactly.
+	assertPrice(t, "spot takes the higher of two region-scoped rates",
+		prices.Spot, vcpu*spotCoreHigh+memGB*spotRAMHigh)
+	assertPrice(t, "on-demand takes the higher of two region-scoped rates",
+		prices.OnDemand, vcpu*odCoreHigh+memGB*odRAMHigh)
+}
+
+// TestMultiRegionalOnlyCandidatesTakeHigherRate covers the fallback tier on its
+// own. Every other test in this file has at least one region-scoped candidate, so
+// without this the multi-regional-only path is never exercised with more than one
+// rate and the selection rule there is untested.
+func TestMultiRegionalOnlyCandidatesTakeHigherRate(t *testing.T) {
+	const region = "us-west2"
+	const coreHigh, coreLow, ram = 0.0400, 0.0300, 0.001
+
+	skus := []SKU{
+		multiRegionalSKU("z3-core-ame-a", "Z3 Instance Core running in Americas"),
+		multiRegionalSKU("z3-core-ame-b", "Z3 Instance Core running in Americas"),
+		multiRegionalSKU("z3-ram-ame", "Z3 Instance Ram running in Americas"),
+	}
+	pricing := map[string]PriceInfo{
+		"z3-core-ame-a": usdRate("h", coreHigh),
+		"z3-core-ame-b": usdRate("h", coreLow),
+		"z3-ram-ame":    usdRate("giby.h", ram),
+	}
+
+	const vcpu, memGB = 22, 176.0
+	machineSpecs := map[string]*MachineSpecs{
+		"z3-highmem-22": {VCPU: vcpu, MemoryGB: memGB, Family: "Storage optimized"},
+	}
+
+	instances := processGCPData(skus, pricing, machineSpecs, map[string]string{region: "Los Angeles"})
+	prices := linuxPricing(t, mustInstance(t, instances, "z3-highmem-22"), region)
+
+	assertPrice(t, "inherited multi-regional rates also take the higher value",
+		prices.OnDemand, vcpu*coreHigh+memGB*ram)
+}
+
+// TestDWSSKUsExcludedFromInstancePricing pins the exclusion of
+// reservation-scheduling products from baseline pricing.
+//
+// "DWS Calendar Mode H4D Instance Core" is the one DWS spelling that reaches
+// machineTypeRegex -- the other families spell theirs "<FAMILY> Core" with no
+// "Instance" -- and it is a separately-priced product, not a cheaper way to buy
+// the same VM. The fixture prices the DWS twin ABOVE the standard rate so that a
+// missing filter cannot hide behind selectHourlyPrice's max.
+func TestDWSSKUsExcludedFromInstancePricing(t *testing.T) {
+	const region = "us-central1"
+	const stdCore, stdRAM = 0.050505, 0.004
+	const dwsCore, dwsRAM = 0.063131, 0.005 // 1.25x, the live DWS ratio
+
+	skus := []SKU{
+		onDemandSKU("h4d-core", "H4D Instance Core running in Iowa", []string{region}),
+		onDemandSKU("h4d-ram", "H4D Instance Ram running in Iowa", []string{region}),
+		onDemandSKU("h4d-dws-core", "DWS Calendar Mode H4D Instance Core running in Iowa", []string{region}),
+		onDemandSKU("h4d-dws-ram", "DWS Calendar Mode H4D Instance Ram running in Iowa", []string{region}),
+		onDemandSKU("h4d-flex-core", "DWS Flex Start H4D Standard Core running in Iowa", []string{region}),
+	}
+	pricing := map[string]PriceInfo{
+		"h4d-core":      usdRate("h", stdCore),
+		"h4d-ram":       usdRate("giby.h", stdRAM),
+		"h4d-dws-core":  usdRate("h", dwsCore),
+		"h4d-dws-ram":   usdRate("giby.h", dwsRAM),
+		"h4d-flex-core": usdRate("h", dwsCore),
+	}
+
+	const vcpu, memGB = 192, 720.0
+	machineSpecs := map[string]*MachineSpecs{
+		"h4d-highmem-192": {VCPU: vcpu, MemoryGB: memGB, Family: "Compute optimized"},
+	}
+
+	warnings := captureWarnings(t, func() {
+		instances := processGCPData(skus, pricing, machineSpecs, map[string]string{region: "Iowa"})
+		prices := linuxPricing(t, mustInstance(t, instances, "h4d-highmem-192"), region)
+		assertPrice(t, "DWS rates do not feed baseline on-demand pricing",
+			prices.OnDemand, vcpu*stdCore+memGB*stdRAM)
+	})
+
+	// Excluded, not merely out-selected: a DWS rate that reached the bucket would
+	// make it ambiguous and be reported.
+	if strings.Contains(warnings, "H4D/us-central1") {
+		t.Errorf("DWS SKUs reached the H4D rate bucket, warning: %s", warnings)
+	}
+}
+
+// TestAmbiguousRegionScopedRatesAreReported pins the telemetry that makes a
+// duplicated catalog entry visible. selectHourlyPrice resolves the disagreement
+// by taking the higher rate, which is correct for every live case today, but the
+// choice stands in for a product-classification question and must not be silent:
+// a future region where Google bills the lower twin would otherwise ship wrong
+// with no signal.
+func TestAmbiguousRegionScopedRatesAreReported(t *testing.T) {
+	const region = "us-east4"
+	const coreHigh, coreLow, ram = 0.0392322, 0.0392, 0.0053
+
+	skus := []SKU{
+		onDemandSKU("m1-core-va", "Memory-optimized Instance Core running in Virginia", []string{region}),
+		onDemandSKU("m1-core-nova", "Memory-optimized Instance Core running in Northern Virginia", []string{region}),
+		onDemandSKU("m1-ram-va", "Memory-optimized Instance Ram running in Virginia", []string{region}),
+	}
+	pricing := map[string]PriceInfo{
+		"m1-core-va":   usdRate("h", coreHigh),
+		"m1-core-nova": usdRate("h", coreLow),
+		"m1-ram-va":    usdRate("giby.h", ram),
+	}
+	machineSpecs := map[string]*MachineSpecs{
+		"m1-ultramem-40": {VCPU: 40, MemoryGB: 961, Family: "Memory optimized"},
+	}
+
+	warnings := captureWarnings(t, func() {
+		processGCPData(skus, pricing, machineSpecs, map[string]string{region: "Virginia"})
+	})
+
+	if !strings.Contains(warnings, "M1/us-east4/core/ondemand") {
+		t.Errorf("duplicated core rate bucket not reported, warnings: %s", warnings)
+	}
+	// The RAM bucket has a single rate and must not be reported, or the warning
+	// degenerates into noise on every scrape.
+	if strings.Contains(warnings, "M1/us-east4/ram/ondemand") {
+		t.Errorf("unambiguous ram bucket was reported, warnings: %s", warnings)
+	}
+}

--- a/scraper/gcp/scrape.go
+++ b/scraper/gcp/scrape.go
@@ -543,6 +543,18 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 			baseFamily = "M1"
 		}
 
+		// m4-ultramem-224 is the only M4 shape billed under its own dedicated
+		// "M4Ultramem224 Instance Core/Ram" SKU pair (with matching Spot and
+		// CUD variants of its own); every other M4 shape (megamem, hypermem,
+		// ultramem-56/112) bills the plain M4 rates that machineFamily/baseFamily
+		// already resolve to. Route both the on-demand/spot and CUD lookups to
+		// its own bucket instead.
+		cudFamily := machineFamily
+		if instanceType == "m4-ultramem-224" {
+			baseFamily = "M4ULTRAMEM224"
+			cudFamily = "M4ULTRAMEM224"
+		}
+
 		// Group pricing by region, spot status, and OS
 		type regionKey struct {
 			region    string
@@ -682,7 +694,7 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 		})
 
 		for key, candidates := range cudData {
-			if key.machineType != machineFamily {
+			if key.machineType != cudFamily {
 				continue
 			}
 

--- a/scraper/gcp/scrape.go
+++ b/scraper/gcp/scrape.go
@@ -569,7 +569,7 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 			PrettyName:         createPrettyName(instanceType),
 			NetworkPerformance: "Variable",
 			Generation:         "current",
-			GPU:                float64(specs.GPU),
+			GPU:                specs.GPU,
 			GPUModel:           gpuModel,
 			GPUMemory:          specs.GPUMemory,
 			Pricing:            make(map[Region]map[OS]any),

--- a/scraper/gcp/scrape.go
+++ b/scraper/gcp/scrape.go
@@ -193,6 +193,19 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 	cudData := make(map[cudKey][]PriceInfo)
 	cudSKUCount := 0
 
+	// Local SSD committed-use discount pricing, keyed by machine family ("" for
+	// the generic "Commitment v1: Local SSD" SKUs), region, and term. These per
+	// GiB-month commitment rates are folded into the CUD price of bundled
+	// Local SSD shapes exactly as the on-demand ssdData rates are folded into
+	// on-demand/spot pricing, so a shape's CUD price covers its bundled SSD too.
+	type ssdCudKey struct {
+		family string
+		region string
+		term   string // cudTerm1Yr or cudTerm3Yr
+	}
+	ssdCudData := make(map[ssdCudKey][]PriceInfo)
+	ssdCudSKUCount := 0
+
 	// Local SSD usage pricing, keyed by machine family ("" for the generic
 	// "SSD backed Local Storage" SKUs), region, and spot. These per GiB-month
 	// rates are folded into the total price of machine types that come with
@@ -265,43 +278,67 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 			continue // Don't process as instance SKU
 		}
 
-		// Capture resource-based committed use discount (CUD) SKUs into a
-		// dedicated bucket. These use the "Commitment v1: <family> Cpu/Ram in
-		// <region> for <1|3> Year" naming and are intentionally never mixed into
-		// on-demand/spot pricing. Done before the on-demand "instance" gate
-		// (their display name has no "instance" token) and before the
-		// commitment/discount taxonomy filter that drops them.
-		if strings.Contains(displayLower, "commitment v") {
-			cudFamily, cudResource, cudCommitTerm, isCUD := parseCUDSKU(sku)
-			if !isCUD {
-				continue
-			}
-
-			price, hasPricing := pricing[sku.SkuId]
-			if !hasPricing {
-				continue
-			}
-			cudSKUCount++
-
-			for _, targetRegion := range cudTargetRegions(sku) {
-				key := cudKey{
-					machineType:  cudFamily,
-					region:       targetRegion,
-					term:         cudCommitTerm,
-					resourceType: cudResource,
+		// Capture committed-use discount (CUD) SKUs into dedicated buckets. All
+		// carry a "Commitment[ v1]: ..." prefix and are intentionally never mixed
+		// into on-demand/spot pricing. Done before the on-demand "instance" gate
+		// (their display names have no "instance" token) and before the
+		// commitment/discount taxonomy filter that drops them. Resource CUDs
+		// ("... <family> Cpu/Ram in <region> for <1|3> Year") feed cudData;
+		// Local SSD CUDs ("... [<family> ]Local SSD in <region> for <1|3> Year")
+		// feed ssdCudData and are folded into bundled-SSD shapes' CUD price below.
+		// The gate is "commitment" (not "commitment v") so the version-less C2
+		// legacy form ("Commitment: Compute optimized Core running in ...") is
+		// caught too; non-CUD "commitment" SKUs fall through to the final continue
+		// exactly as they were dropped on the on-demand path before.
+		if strings.Contains(displayLower, "commitment") {
+			if cudFamily, cudResource, cudCommitTerm, isCUD := parseCUDSKU(sku); isCUD {
+				price, hasPricing := pricing[sku.SkuId]
+				if !hasPricing {
+					continue
 				}
-				cudData[key] = append(cudData[key], price)
+				cudSKUCount++
 
-				for _, expandedRegion := range expandedRegionsForMultiRegion(targetRegion) {
-					expandedKey := cudKey{
+				for _, targetRegion := range cudTargetRegions(sku) {
+					key := cudKey{
 						machineType:  cudFamily,
-						region:       expandedRegion,
+						region:       targetRegion,
 						term:         cudCommitTerm,
 						resourceType: cudResource,
 					}
-					cudData[expandedKey] = append(cudData[expandedKey], price)
+					cudData[key] = append(cudData[key], price)
+
+					for _, expandedRegion := range expandedRegionsForMultiRegion(targetRegion) {
+						expandedKey := cudKey{
+							machineType:  cudFamily,
+							region:       expandedRegion,
+							term:         cudCommitTerm,
+							resourceType: cudResource,
+						}
+						cudData[expandedKey] = append(cudData[expandedKey], price)
+					}
 				}
+				continue
 			}
+
+			if ssdFamily, ssdTerm, isSSDCUD := parseLocalSSDCommitmentSKU(sku); isSSDCUD {
+				price, hasPricing := pricing[sku.SkuId]
+				if !hasPricing {
+					continue
+				}
+				ssdCudSKUCount++
+
+				for _, targetRegion := range cudTargetRegions(sku) {
+					key := ssdCudKey{family: ssdFamily, region: targetRegion, term: ssdTerm}
+					ssdCudData[key] = append(ssdCudData[key], price)
+
+					for _, expandedRegion := range expandedRegionsForMultiRegion(targetRegion) {
+						expandedKey := ssdCudKey{family: ssdFamily, region: expandedRegion, term: ssdTerm}
+						ssdCudData[expandedKey] = append(ssdCudData[expandedKey], price)
+					}
+				}
+				continue
+			}
+
 			continue
 		}
 
@@ -310,7 +347,8 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 		// Storage" SKUs carry no "instance" token, and the per-family
 		// "<FAMILY> Instance Local SSD" SKUs would otherwise fail the
 		// core/ram parse. Local SSD commitment SKUs never reach this point:
-		// they contain "commitment v" and are consumed (and dropped) above.
+		// they contain "commitment v" and are consumed by the CUD block above
+		// (routed to ssdCudData), so only usage SKUs remain here.
 		if ssdFamily, ssdSpot, isLocalSSD := parseLocalSSDSKU(sku); isLocalSSD {
 			if !shouldUseLocalSSDSKUForPricing(sku, displayLower) {
 				skippedByTaxonomyCount++
@@ -460,12 +498,13 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 	}
 
 	log.Printf(
-		"GCP SKU filtering: parsed=%d priced=%d skippedByTaxonomy=%d duplicateCandidateKeys=%d cudSKUs=%d localSSDSKUs=%d memoryPremiumSKUs=%d",
+		"GCP SKU filtering: parsed=%d priced=%d skippedByTaxonomy=%d duplicateCandidateKeys=%d cudSKUs=%d ssdCudSKUs=%d localSSDSKUs=%d memoryPremiumSKUs=%d",
 		parsedSKUCount,
 		pricedSKUCount,
 		skippedByTaxonomyCount,
 		duplicatePriceKeys,
 		cudSKUCount,
+		ssdCudSKUCount,
 		localSSDSKUCount,
 		memoryPremiumSKUCount,
 	)
@@ -480,6 +519,23 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 				continue
 			}
 			if rate, hasRate := selectHourlyPrice(candidates, isSpot); hasRate {
+				return rate, true
+			}
+		}
+		return 0, false
+	}
+
+	// ssdCudRate resolves the per GiB-hour Local SSD committed-use rate for a
+	// machine family in a region and term. Per-family commitment SKUs take
+	// precedence over the generic "Commitment v1: Local SSD" SKUs, matching the
+	// on-demand localSSDRate precedence.
+	ssdCudRate := func(family, region, term string) (float64, bool) {
+		for _, candidateFamily := range []string{family, ""} {
+			candidates, ok := ssdCudData[ssdCudKey{family: candidateFamily, region: region, term: term}]
+			if !ok {
+				continue
+			}
+			if rate, hasRate := selectHourlyPrice(candidates, false); hasRate {
 				return rate, true
 			}
 		}
@@ -532,11 +588,17 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 
 		// M2 machine types have no SKUs of their own: Google bills M2 as the M1
 		// base core/RAM rates plus a per-region Memory Optimized Upgrade Premium
-		// surcharge. Read M2's base rates from the M1 bucket and fold the
-		// premium in below. Only on-demand is synthesized -- the catalog has no
-		// premium Spot or committed-use SKU, so M2 Spot and CUD prices are
-		// intentionally left unset (a known limitation, like the Local SSD
-		// commitment exclusion above).
+		// surcharge. Read M2's base rates from the M1 bucket and fold the premium
+		// in below, for both on-demand and CUD.
+		//
+		// Committed-use discounts are family-scoped resource pools: M2's base
+		// core/RAM usage draws down an M1 (memory-optimized) commitment, so M2's
+		// CUD base rates come from the M1 commitment bucket. The Upgrade Premium
+		// has no commitment variant in the catalog, so the premium keeps billing
+		// at its on-demand rate on top of the discounted base -- M2 CUD is thus
+		// the M1 commitment core/RAM rates plus the same on-demand premium used
+		// for M2 on-demand. M2 Spot stays unset: there is no premium Spot SKU to
+		// add to M1's spot rates.
 		isM2 := machineFamily == "M2"
 		baseFamily := machineFamily
 		if isM2 {
@@ -553,6 +615,13 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 		if instanceType == "m4-ultramem-224" {
 			baseFamily = "M4ULTRAMEM224"
 			cudFamily = "M4ULTRAMEM224"
+		}
+
+		// M2 draws its committed-use base rates from the M1 commitment bucket
+		// (see the family-scoped resource-pool note above); the premium is added
+		// on top per region in the CUD assembly loop.
+		if isM2 {
+			cudFamily = "M1"
 		}
 
 		// Group pricing by region, spot status, and OS
@@ -673,15 +742,11 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 			}
 		}
 
-		// Assemble resource-based committed use discount (CUD) pricing the same
-		// way on-demand is built: per-region, per-term, total =
-		// core_rate*vCPU + ram_rate*RAM. CUDs apply to the Linux compute price
-		// (no OS license), so they attach to the Linux pricing data.
-		//
-		// Known simplification: Local SSD commitment SKUs ("Commitment v1:
-		// Local SSD in ..." / "Commitment v1: <FAMILY> Local SSD in ...") are
-		// not folded in, so CUD prices for bundled-Local-SSD shapes cover
-		// core+RAM only while their on-demand/spot prices include the SSD.
+		// Assemble committed use discount (CUD) pricing the same way on-demand is
+		// built: per-region, per-term, total = core_rate*vCPU + ram_rate*RAM,
+		// plus the bundled Local SSD commitment rate for shapes that have one.
+		// CUDs apply to the Linux compute price (no OS license), so they attach
+		// to the Linux pricing data.
 		type cudRegionKey struct {
 			region string
 			term   string
@@ -705,6 +770,18 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 				continue
 			}
 
+			// M2 draws its CUD base rates from the M1 commitment bucket and, like
+			// M2 on-demand, adds the on-demand Upgrade Premium (which has no
+			// commitment variant). A region without a premium rate for this
+			// resource yields no M2 CUD price there.
+			if isM2 {
+				premium, hasPremium := premiumRate(key.region, key.resourceType)
+				if !hasPremium {
+					continue
+				}
+				hourlyPrice += premium
+			}
+
 			crk := cudRegionKey{region: key.region, term: key.term}
 			p := cudRegionPricing[crk]
 			switch key.resourceType {
@@ -725,6 +802,17 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 			}
 
 			totalCUD := (float64(specs.VCPU) * p.corePrice) + (specs.MemoryGB * p.ramPrice)
+
+			// Fold in the bundled Local SSD commitment rate, mirroring the
+			// on-demand SSD fold-in, so a bundled-SSD shape's CUD price covers
+			// its SSD too instead of core+RAM only. Shapes with no bundled SSD
+			// have LocalSSDGB == 0 and are unaffected.
+			if specs.LocalSSDGB > 0 {
+				if ssdRate, hasSSDRate := ssdCudRate(machineFamily, crk.region, crk.term); hasSSDRate {
+					totalCUD += float64(specs.LocalSSDGB) * ssdRate
+				}
+			}
+
 			if totalCUD == 0 {
 				continue
 			}

--- a/scraper/gcp/scrape.go
+++ b/scraper/gcp/scrape.go
@@ -267,8 +267,12 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 			continue
 		}
 
-		// Process both instance SKUs and Windows licensing SKUs
-		isInstanceSKU := strings.Contains(displayLower, "instance")
+		// Process both instance SKUs and Windows licensing SKUs. C2's legacy
+		// SKUs ("Compute optimized Core/Ram running in ...") predate the
+		// "<FAMILY> Instance Core/Ram" naming and carry no "instance" token,
+		// so admit them explicitly.
+		isInstanceSKU := strings.Contains(displayLower, "instance") ||
+			legacySKURegex.MatchString(displayLower)
 		isWindowsLicense := strings.Contains(displayLower, "licensing fee for windows")
 
 		if !isInstanceSKU && !isWindowsLicense {

--- a/scraper/gcp/scrape.go
+++ b/scraper/gcp/scrape.go
@@ -72,6 +72,20 @@ func shouldUseSKUForPricing(sku SKU, isSpot bool, displayLower string) bool {
 	return true
 }
 
+// shouldUseLocalSSDSKUForPricing gates Local SSD usage SKUs. Unlike instance
+// SKUs, spot cannot be validated against the taxonomy: Google categorizes the
+// generic "SSD backed Local Storage attached to Spot Preemptible VMs" SKUs as
+// "On Demand", so the display name (already parsed by parseLocalSSDSKU) is
+// authoritative for spot. Commitment/reservation-style categories are still
+// excluded as a backstop to parseLocalSSDSKU's display-name anchoring.
+func shouldUseLocalSSDSKUForPricing(sku SKU, displayLower string) bool {
+	if strings.Contains(displayLower, "sole tenancy") {
+		return false
+	}
+	return !taxonomyContainsAny(taxonomyValues(sku),
+		"commit", "cud", "discount", "sustained", "reservation", "reserved", "saving")
+}
+
 func targetRegionsForSKU(sku SKU, fallbackRegion string) []string {
 	if len(sku.GeoTaxonomy.Regions) > 0 {
 		return sku.GeoTaxonomy.Regions
@@ -179,6 +193,19 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 	cudData := make(map[cudKey][]PriceInfo)
 	cudSKUCount := 0
 
+	// Local SSD usage pricing, keyed by machine family ("" for the generic
+	// "SSD backed Local Storage" SKUs), region, and spot. These per GiB-month
+	// rates are folded into the total price of machine types that come with
+	// bundled Local SSD (Z3, the -lssd shapes, accelerator series), because
+	// Google bills the bundled capacity on top of the core/RAM rates.
+	type localSSDKey struct {
+		family string
+		region string
+		isSpot bool
+	}
+	ssdData := make(map[localSSDKey][]PriceInfo)
+	localSSDSKUCount := 0
+
 	// Store Windows license fees separately (they're global, not region-specific)
 	type windowsLicenseType struct {
 		resourceType string // "core" or "ram"
@@ -262,6 +289,45 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 						resourceType: cudResource,
 					}
 					cudData[expandedKey] = append(cudData[expandedKey], price)
+				}
+			}
+			continue
+		}
+
+		// Capture Local SSD usage SKUs into their own bucket. Handled before
+		// the on-demand "instance" gate because the generic "SSD backed Local
+		// Storage" SKUs carry no "instance" token, and the per-family
+		// "<FAMILY> Instance Local SSD" SKUs would otherwise fail the
+		// core/ram parse. Local SSD commitment SKUs never reach this point:
+		// they contain "commitment v" and are consumed (and dropped) above.
+		if ssdFamily, ssdSpot, isLocalSSD := parseLocalSSDSKU(sku); isLocalSSD {
+			if !shouldUseLocalSSDSKUForPricing(sku, displayLower) {
+				skippedByTaxonomyCount++
+				continue
+			}
+			price, hasPricing := pricing[sku.SkuId]
+			if !hasPricing {
+				continue
+			}
+			localSSDSKUCount++
+
+			targetRegions := targetRegionsForSKU(sku, skuRegion(sku))
+			if len(targetRegions) == 0 {
+				// The legacy generic SKUs ("SSD backed Local Storage" with no
+				// region tail) are multi-regional with the region list only
+				// in multiRegionalMetadata and no grouping keyword in the
+				// display name for skuRegion to resolve.
+				targetRegions = multiRegionalMetadataRegions(sku)
+			}
+			for _, targetRegion := range targetRegions {
+				key := localSSDKey{family: ssdFamily, region: targetRegion, isSpot: ssdSpot}
+				ssdData[key] = append(ssdData[key], price)
+
+				// Keep multi-regional prices as fallback candidates for
+				// specific regions, mirroring the core/ram handling.
+				for _, expandedRegion := range expandedRegionsForMultiRegion(targetRegion) {
+					expandedKey := localSSDKey{family: ssdFamily, region: expandedRegion, isSpot: ssdSpot}
+					ssdData[expandedKey] = append(ssdData[expandedKey], price)
 				}
 			}
 			continue
@@ -354,13 +420,30 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 	}
 
 	log.Printf(
-		"GCP SKU filtering: parsed=%d priced=%d skippedByTaxonomy=%d duplicateCandidateKeys=%d cudSKUs=%d",
+		"GCP SKU filtering: parsed=%d priced=%d skippedByTaxonomy=%d duplicateCandidateKeys=%d cudSKUs=%d localSSDSKUs=%d",
 		parsedSKUCount,
 		pricedSKUCount,
 		skippedByTaxonomyCount,
 		duplicatePriceKeys,
 		cudSKUCount,
+		localSSDSKUCount,
 	)
+
+	// localSSDRate resolves the per GiB-hour Local SSD rate for a machine
+	// family in a region. Per-family SKUs take precedence over the generic
+	// "SSD backed Local Storage" SKUs.
+	localSSDRate := func(family, region string, isSpot bool) (float64, bool) {
+		for _, candidateFamily := range []string{family, ""} {
+			candidates, ok := ssdData[localSSDKey{family: candidateFamily, region: region, isSpot: isSpot}]
+			if !ok {
+				continue
+			}
+			if rate, hasRate := selectHourlyPrice(candidates, isSpot); hasRate {
+				return rate, true
+			}
+		}
+		return 0, false
+	}
 
 	// Build instances from machine specs
 	matchedInstances := 0
@@ -385,7 +468,8 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 			Pricing:            make(map[Region]map[OS]any),
 			Regions:            make(map[string]string),
 			AvailabilityZones:  make(map[string][]string),
-			LocalSSD:           false,
+			LocalSSD:           specs.LocalSSDGB > 0,
+			LocalSSDSize:       specs.LocalSSDGB,
 			SharedCPU:          specs.IsSharedCPU,
 			ComputeOptimized:   strings.Contains(specs.Family, "Compute optimized"),
 			MemoryOptimized:    strings.Contains(specs.Family, "Memory optimized"),
@@ -445,6 +529,18 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 			// Total price = (vCPUs * core price) + (memory GB * RAM price)
 			totalPrice := (float64(specs.VCPU) * pricing.corePrice) + (specs.MemoryGB * pricing.ramPrice)
 
+			// Machine types with bundled Local SSD are billed for that
+			// capacity on top of the core/RAM rates, so fold it into the
+			// shape's price. Without this a c3-standard-8-lssd shows the same
+			// price as a c3-standard-8 even though Google bills the bundled
+			// Titanium SSD. Shapes where Local SSD is an optional attachment
+			// have LocalSSDGB == 0 and are unaffected.
+			if specs.LocalSSDGB > 0 {
+				if ssdRate, hasSSDRate := localSSDRate(machineFamily, rk.region, rk.isSpot); hasSSDRate {
+					totalPrice += float64(specs.LocalSSDGB) * ssdRate
+				}
+			}
+
 			if totalPrice == 0 {
 				continue
 			}
@@ -489,6 +585,11 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 		// way on-demand is built: per-region, per-term, total =
 		// core_rate*vCPU + ram_rate*RAM. CUDs apply to the Linux compute price
 		// (no OS license), so they attach to the Linux pricing data.
+		//
+		// Known simplification: Local SSD commitment SKUs ("Commitment v1:
+		// Local SSD in ..." / "Commitment v1: <FAMILY> Local SSD in ...") are
+		// not folded in, so CUD prices for bundled-Local-SSD shapes cover
+		// core+RAM only while their on-demand/spot prices include the SSD.
 		type cudRegionKey struct {
 			region string
 			term   string

--- a/scraper/gcp/scrape.go
+++ b/scraper/gcp/scrape.go
@@ -206,6 +206,17 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 	ssdData := make(map[localSSDKey][]PriceInfo)
 	localSSDSKUCount := 0
 
+	// Memory Optimized Upgrade Premium pricing, keyed by region and resource
+	// ("core"/"ram"). M2 has no SKUs of its own; Google bills it as the M1 base
+	// core/RAM rates plus this per-region surcharge, so these rates are folded
+	// into synthesized M2 on-demand pricing below.
+	type premiumKey struct {
+		region       string
+		resourceType string
+	}
+	premiumData := make(map[premiumKey][]PriceInfo)
+	memoryPremiumSKUCount := 0
+
 	// Store Windows license fees separately (they're global, not region-specific)
 	type windowsLicenseType struct {
 		resourceType string // "core" or "ram"
@@ -333,6 +344,35 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 			continue
 		}
 
+		// Capture the Memory Optimized Upgrade Premium surcharge SKUs into their
+		// own bucket. Done before the on-demand instance gate: the premium
+		// display name contains "Memory-optimized Instance Core/Ram", which
+		// parseMachineTypeFromSKU deliberately refuses to map to M1 (so the
+		// surcharge never inflates M1's own rates), leaving it family-less and
+		// otherwise dropped. Only on-demand premiums exist, so isSpot is false.
+		if premiumResource, isPremium := parseMemoryOptimizedPremiumSKU(sku); isPremium {
+			if !shouldUseSKUForPricing(sku, false, displayLower) {
+				skippedByTaxonomyCount++
+				continue
+			}
+			price, hasPricing := pricing[sku.SkuId]
+			if !hasPricing {
+				continue
+			}
+			memoryPremiumSKUCount++
+
+			for _, targetRegion := range targetRegionsForSKU(sku, skuRegion(sku)) {
+				key := premiumKey{region: targetRegion, resourceType: premiumResource}
+				premiumData[key] = append(premiumData[key], price)
+
+				for _, expandedRegion := range expandedRegionsForMultiRegion(targetRegion) {
+					expandedKey := premiumKey{region: expandedRegion, resourceType: premiumResource}
+					premiumData[expandedKey] = append(premiumData[expandedKey], price)
+				}
+			}
+			continue
+		}
+
 		// Process both instance SKUs and Windows licensing SKUs. C2's legacy
 		// SKUs ("Compute optimized Core/Ram running in ...") predate the
 		// "<FAMILY> Instance Core/Ram" naming and carry no "instance" token,
@@ -420,13 +460,14 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 	}
 
 	log.Printf(
-		"GCP SKU filtering: parsed=%d priced=%d skippedByTaxonomy=%d duplicateCandidateKeys=%d cudSKUs=%d localSSDSKUs=%d",
+		"GCP SKU filtering: parsed=%d priced=%d skippedByTaxonomy=%d duplicateCandidateKeys=%d cudSKUs=%d localSSDSKUs=%d memoryPremiumSKUs=%d",
 		parsedSKUCount,
 		pricedSKUCount,
 		skippedByTaxonomyCount,
 		duplicatePriceKeys,
 		cudSKUCount,
 		localSSDSKUCount,
+		memoryPremiumSKUCount,
 	)
 
 	// localSSDRate resolves the per GiB-hour Local SSD rate for a machine
@@ -443,6 +484,16 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 			}
 		}
 		return 0, false
+	}
+
+	// premiumRate resolves the per-hour Memory Optimized Upgrade Premium rate
+	// for a resource in a region, used to synthesize M2 on-demand pricing.
+	premiumRate := func(region, resourceType string) (float64, bool) {
+		candidates, ok := premiumData[premiumKey{region: region, resourceType: resourceType}]
+		if !ok {
+			return 0, false
+		}
+		return selectHourlyPrice(candidates, false)
 	}
 
 	// Build instances from machine specs
@@ -479,6 +530,19 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 		// Extract machine family from instance type (e.g., "n2" from "n2-standard-4")
 		machineFamily := strings.ToUpper(strings.Split(instanceType, "-")[0])
 
+		// M2 machine types have no SKUs of their own: Google bills M2 as the M1
+		// base core/RAM rates plus a per-region Memory Optimized Upgrade Premium
+		// surcharge. Read M2's base rates from the M1 bucket and fold the
+		// premium in below. Only on-demand is synthesized -- the catalog has no
+		// premium Spot or committed-use SKU, so M2 Spot and CUD prices are
+		// intentionally left unset (a known limitation, like the Local SSD
+		// commitment exclusion above).
+		isM2 := machineFamily == "M2"
+		baseFamily := machineFamily
+		if isM2 {
+			baseFamily = "M1"
+		}
+
 		// Group pricing by region, spot status, and OS
 		type regionKey struct {
 			region    string
@@ -493,7 +557,13 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 		})
 
 		for key, candidates := range skuData {
-			if key.machineType != machineFamily {
+			if key.machineType != baseFamily {
+				continue
+			}
+
+			// M2 borrows only M1's on-demand rates; without a premium Spot SKU
+			// its Spot price cannot be synthesized.
+			if isM2 && key.isSpot {
 				continue
 			}
 
@@ -502,6 +572,16 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 			hourlyPrice, hasPrice := selectHourlyPrice(candidates, key.isSpot)
 			if !hasPrice {
 				continue
+			}
+
+			// Fold the M2 premium onto the M1 base rate. A region without a
+			// premium rate for this resource yields no M2 price there.
+			if isM2 {
+				premium, hasPremium := premiumRate(key.region, key.resourceType)
+				if !hasPremium {
+					continue
+				}
+				hourlyPrice += premium
 			}
 
 			rk := regionKey{region: key.region, isSpot: key.isSpot, isWindows: key.isWindows}

--- a/scraper/gcp/scrape.go
+++ b/scraper/gcp/scrape.go
@@ -1,8 +1,11 @@
 package gcp
 
 import (
+	"fmt"
 	"log"
+	"maps"
 	"scraper/utils"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -34,6 +37,21 @@ func shouldUseSKUForPricing(sku SKU, isSpot bool, displayLower string) bool {
 	// Sole tenancy SKUs are dedicated-host style charges and should not be
 	// mixed into baseline VM on-demand/spot instance pricing.
 	if strings.Contains(displayLower, "sole tenancy") {
+		return false
+	}
+
+	// Reservation-scheduling products (Dynamic Workload Scheduler calendar mode
+	// and flex-start) are separately-priced products, not a cheaper way to buy
+	// the same VM, and must not feed baseline pricing. Only the "DWS Calendar
+	// Mode H4D Instance Core/Ram" pair currently reaches this far -- the other
+	// DWS families spell their SKUs "<FAMILY> Core" with no "Instance", so
+	// machineTypeRegex never claims them -- but that is an accident of Google's
+	// naming, and it left H4D correct only because the duplicate happened to be
+	// the cheaper of the two. parseLocalSSDSKU gates the Local SSD twins of
+	// these same products.
+	if strings.Contains(displayLower, "dws") ||
+		strings.Contains(displayLower, "calendar") ||
+		strings.Contains(displayLower, "flex start") {
 		return false
 	}
 
@@ -136,35 +154,155 @@ func expandedRegionsForMultiRegion(region string) []string {
 	}
 }
 
-func selectHourlyPrice(candidates []PriceInfo, preferLower bool) (float64, bool) {
+// bundledSSDBillsAtGenericRate are the machine families whose bundled Local SSD
+// is billed at the generic "SSD backed Local Storage" rate even though the
+// catalog also carries a per-family Local SSD SKU for them.
+//
+// Google's published prices decide this, and they split cleanly. C4, C4A, C4D
+// and H4D bundled shapes are built from their own per-family rate in every
+// region where the two rates differ. Z3 is built from the generic rate in every
+// such region, on all four price columns -- most decisively on Spot, where the
+// Z3 rate differs from the generic rate in 42 of 47 regions: reconstructing the
+// published total as vCPU x core + RAM x ram + capacity x ssd from the catalog's
+// own Z3 core and RAM SKUs lands on the generic SSD rate in 363 of 363 cells and
+// on the Z3 SSD rate in none. The page uses per-family core and RAM alongside a
+// generic SSD rate inside the same arithmetic, so this is a deliberate
+// asymmetry rather than a lookup the page generator skipped.
+//
+// What the per-family Z3 Local SSD SKU does price is unknown. It is not the
+// bare z3-highmem-88/176 shapes: those are spec-identical aliases of
+// z3-highmem-88-highlssd and z3-highmem-176-standardlssd, so there is no
+// distinct product for it to apply to.
+//
+// Keys are uppercase to match machineFamily, which is uppercased at its source.
+// A lowercase key here would make this map a silent no-op.
+var bundledSSDBillsAtGenericRate = map[string]bool{"Z3": true}
+
+// ssdFamilyPrecedence is the order to try Local SSD rate buckets for a family,
+// where "" is the generic bucket. Reversing the order rather than dropping the
+// per-family SKU keeps the losing bucket as a fallback: c4/asia-southeast3 is
+// live proof that a family can have a rate in one bucket and nothing in the
+// other, so neither bucket can be assumed present.
+func ssdFamilyPrecedence(family string) []string {
+	if bundledSSDBillsAtGenericRate[family] {
+		return []string{"", family}
+	}
+	return []string{family, ""}
+}
+
+// regionalPrice is a candidate price for one region, tagged with how it got
+// there. A multi-regional SKU ("... running in Americas") is expanded into every
+// member region so those regions have a price at all, but where Google also
+// publishes a SKU scoped to the region itself, that one is what it bills.
+type regionalPrice struct {
+	PriceInfo
+	fromMultiRegion bool
+}
+
+func regionScoped(price PriceInfo) regionalPrice {
+	return regionalPrice{PriceInfo: price}
+}
+
+func multiRegionFallback(price PriceInfo) regionalPrice {
+	return regionalPrice{PriceInfo: price, fromMultiRegion: true}
+}
+
+// selectHourlyPrice picks one rate from the candidates for a region.
+//
+// Candidates scoped to the region win outright over rates inherited from a
+// multi-regional SKU ("... running in Americas"), which is only ever a fallback
+// for regions Google publishes no scoped SKU for. Mixing the two tiers into a
+// single min or max is wrong in both directions: taking the min let the cheaper
+// Americas rate beat us-east5's own on Spot, putting Z3 shapes 27% under
+// Google's published price with every Americas region collapsed to one number,
+// and taking the max would let a multi-regional rate that happens to exceed the
+// region's own win on demand.
+//
+// Within the winning tier the highest rate wins. Two region-scoped SKUs at
+// different prices are a duplicated catalog entry rather than a cheaper option,
+// and the higher rate reproduces Google's published price in every M1
+// memory-optimized case (us-east4, asia-northeast1, asia-southeast1) except one:
+// asia-southeast1 on-demand core, where Google bills the lower of the two. That
+// exception costs +0.035% on four cells and no field in the SKU record predicts
+// it, so it is left as-is rather than encoded as a per-region table. The
+// ambiguity warning names every such bucket, so a future region where Google
+// bills the lower twin shows up instead of passing unnoticed.
+func selectHourlyPrice(candidates []regionalPrice) (float64, bool) {
+	if scoped := regionScopedOnly(candidates); len(scoped) > 0 {
+		candidates = scoped
+	}
+
 	var selected float64
 	hasValue := false
 
 	for _, candidate := range candidates {
-		hourlyPrice := calculateHourlyPrice(candidate)
+		hourlyPrice := calculateHourlyPrice(candidate.PriceInfo)
 		if hourlyPrice <= 0 {
 			continue
 		}
 
-		if !hasValue {
+		if !hasValue || hourlyPrice > selected {
 			selected = hourlyPrice
 			hasValue = true
-			continue
-		}
-
-		if preferLower {
-			if hourlyPrice < selected {
-				selected = hourlyPrice
-			}
-			continue
-		}
-
-		if hourlyPrice > selected {
-			selected = hourlyPrice
 		}
 	}
 
 	return selected, hasValue
+}
+
+// ambiguousRateKeys labels every rate bucket whose winning tier holds more than
+// one distinct rate, so a duplicated catalog entry is reported rather than
+// silently resolved by selectHourlyPrice's max.
+//
+// Callers cover the instance, CUD and Memory Optimized Upgrade Premium buckets.
+// Local SSD, Local SSD CUD and Windows license buckets are not covered: none has
+// a duplicate in the live catalog today, so wiring them would add reporting for a
+// case that has never occurred. This is therefore not a count of every ambiguous
+// bucket in the catalog, only of the three pools that have ever had one.
+func ambiguousRateKeys[K comparable](data map[K][]regionalPrice, label func(K) string) []string {
+	var ambiguous []string
+	for key, candidates := range data {
+		if distinctScopedRates(candidates) > 1 {
+			ambiguous = append(ambiguous, label(key))
+		}
+	}
+	return ambiguous
+}
+
+// distinctScopedRates counts the distinct usable rates among the candidates
+// scoped to the region. Anything above 1 means two SKUs Google scopes to the same
+// region disagree on price, and selectHourlyPrice's max is standing in for a
+// product-classification question rather than reading a single published rate.
+//
+// The multi-regional tier is deliberately not counted. A duplicate there expands
+// into every member region, so one disagreeing pair of "... running in Americas"
+// SKUs would report fourteen regions and drown out the per-region case this
+// exists to surface.
+func distinctScopedRates(candidates []regionalPrice) int {
+	rates := make(map[float64]bool)
+	for _, candidate := range candidates {
+		if candidate.fromMultiRegion {
+			continue
+		}
+		if hourlyPrice := calculateHourlyPrice(candidate.PriceInfo); hourlyPrice > 0 {
+			rates[hourlyPrice] = true
+		}
+	}
+	return len(rates)
+}
+
+// regionScopedOnly returns the candidates that came from a SKU scoped to the
+// region, dropping multi-regional inheritances. A candidate with no usable
+// hourly price does not count as scoped coverage, so a $0 or malformed regional
+// SKU cannot suppress a valid multi-regional fallback.
+func regionScopedOnly(candidates []regionalPrice) []regionalPrice {
+	scoped := make([]regionalPrice, 0, len(candidates))
+	for _, candidate := range candidates {
+		if !candidate.fromMultiRegion && calculateHourlyPrice(candidate.PriceInfo) > 0 {
+			scoped = append(scoped, candidate)
+		}
+	}
+	return scoped
 }
 
 // Process SKUs and pricing data to generate GCP instances
@@ -180,7 +318,7 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 		resourceType string
 	}
 
-	skuData := make(map[skuKey][]PriceInfo)
+	skuData := make(map[skuKey][]regionalPrice)
 
 	// Resource-based committed use discount (CUD) pricing, kept entirely separate
 	// from on-demand/spot so commitment rates never bleed into baseline pricing.
@@ -190,7 +328,7 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 		term         string // cudTerm1Yr or cudTerm3Yr
 		resourceType string // "core" or "ram"
 	}
-	cudData := make(map[cudKey][]PriceInfo)
+	cudData := make(map[cudKey][]regionalPrice)
 	cudSKUCount := 0
 
 	// Local SSD committed-use discount pricing, keyed by machine family ("" for
@@ -203,7 +341,7 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 		region string
 		term   string // cudTerm1Yr or cudTerm3Yr
 	}
-	ssdCudData := make(map[ssdCudKey][]PriceInfo)
+	ssdCudData := make(map[ssdCudKey][]regionalPrice)
 	ssdCudSKUCount := 0
 
 	// Local SSD usage pricing, keyed by machine family ("" for the generic
@@ -216,7 +354,7 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 		region string
 		isSpot bool
 	}
-	ssdData := make(map[localSSDKey][]PriceInfo)
+	ssdData := make(map[localSSDKey][]regionalPrice)
 	localSSDSKUCount := 0
 
 	// Memory Optimized Upgrade Premium pricing, keyed by region and resource
@@ -227,14 +365,14 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 		region       string
 		resourceType string
 	}
-	premiumData := make(map[premiumKey][]PriceInfo)
+	premiumData := make(map[premiumKey][]regionalPrice)
 	memoryPremiumSKUCount := 0
 
 	// Store Windows license fees separately (they're global, not region-specific)
 	type windowsLicenseType struct {
 		resourceType string // "core" or "ram"
 	}
-	windowsLicenses := make(map[windowsLicenseType][]PriceInfo)
+	windowsLicenses := make(map[windowsLicenseType][]regionalPrice)
 
 	// Debug counters
 	instanceSKUCount := 0
@@ -271,7 +409,7 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 						duplicatePriceKeys++
 					}
 					// Store all candidate licenses and select later.
-					windowsLicenses[key] = append(windowsLicenses[key], price)
+					windowsLicenses[key] = append(windowsLicenses[key], regionScoped(price))
 					windowsSKUCount++
 				}
 			}
@@ -305,7 +443,7 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 						term:         cudCommitTerm,
 						resourceType: cudResource,
 					}
-					cudData[key] = append(cudData[key], price)
+					cudData[key] = append(cudData[key], regionScoped(price))
 
 					for _, expandedRegion := range expandedRegionsForMultiRegion(targetRegion) {
 						expandedKey := cudKey{
@@ -314,7 +452,7 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 							term:         cudCommitTerm,
 							resourceType: cudResource,
 						}
-						cudData[expandedKey] = append(cudData[expandedKey], price)
+						cudData[expandedKey] = append(cudData[expandedKey], multiRegionFallback(price))
 					}
 				}
 				continue
@@ -329,11 +467,11 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 
 				for _, targetRegion := range cudTargetRegions(sku) {
 					key := ssdCudKey{family: ssdFamily, region: targetRegion, term: ssdTerm}
-					ssdCudData[key] = append(ssdCudData[key], price)
+					ssdCudData[key] = append(ssdCudData[key], regionScoped(price))
 
 					for _, expandedRegion := range expandedRegionsForMultiRegion(targetRegion) {
 						expandedKey := ssdCudKey{family: ssdFamily, region: expandedRegion, term: ssdTerm}
-						ssdCudData[expandedKey] = append(ssdCudData[expandedKey], price)
+						ssdCudData[expandedKey] = append(ssdCudData[expandedKey], multiRegionFallback(price))
 					}
 				}
 				continue
@@ -347,7 +485,7 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 		// Storage" SKUs carry no "instance" token, and the per-family
 		// "<FAMILY> Instance Local SSD" SKUs would otherwise fail the
 		// core/ram parse. Local SSD commitment SKUs never reach this point:
-		// they contain "commitment v" and are consumed by the CUD block above
+		// they contain "commitment" and are consumed by the CUD block above
 		// (routed to ssdCudData), so only usage SKUs remain here.
 		if ssdFamily, ssdSpot, isLocalSSD := parseLocalSSDSKU(sku); isLocalSSD {
 			if !shouldUseLocalSSDSKUForPricing(sku, displayLower) {
@@ -370,13 +508,13 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 			}
 			for _, targetRegion := range targetRegions {
 				key := localSSDKey{family: ssdFamily, region: targetRegion, isSpot: ssdSpot}
-				ssdData[key] = append(ssdData[key], price)
+				ssdData[key] = append(ssdData[key], regionScoped(price))
 
 				// Keep multi-regional prices as fallback candidates for
 				// specific regions, mirroring the core/ram handling.
 				for _, expandedRegion := range expandedRegionsForMultiRegion(targetRegion) {
 					expandedKey := localSSDKey{family: ssdFamily, region: expandedRegion, isSpot: ssdSpot}
-					ssdData[expandedKey] = append(ssdData[expandedKey], price)
+					ssdData[expandedKey] = append(ssdData[expandedKey], multiRegionFallback(price))
 				}
 			}
 			continue
@@ -401,11 +539,11 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 
 			for _, targetRegion := range targetRegionsForSKU(sku, skuRegion(sku)) {
 				key := premiumKey{region: targetRegion, resourceType: premiumResource}
-				premiumData[key] = append(premiumData[key], price)
+				premiumData[key] = append(premiumData[key], regionScoped(price))
 
 				for _, expandedRegion := range expandedRegionsForMultiRegion(targetRegion) {
 					expandedKey := premiumKey{region: expandedRegion, resourceType: premiumResource}
-					premiumData[expandedKey] = append(premiumData[expandedKey], price)
+					premiumData[expandedKey] = append(premiumData[expandedKey], multiRegionFallback(price))
 				}
 			}
 			continue
@@ -478,7 +616,7 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 			if len(skuData[key]) > 0 {
 				duplicatePriceKeys++
 			}
-			skuData[key] = append(skuData[key], price)
+			skuData[key] = append(skuData[key], regionScoped(price))
 
 			// Keep multi-regional prices as fallback candidates for specific regions.
 			for _, expandedRegion := range expandedRegionsForMultiRegion(targetRegion) {
@@ -492,7 +630,7 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 				if len(skuData[expandedKey]) > 0 {
 					duplicatePriceKeys++
 				}
-				skuData[expandedKey] = append(skuData[expandedKey], price)
+				skuData[expandedKey] = append(skuData[expandedKey], multiRegionFallback(price))
 			}
 		}
 	}
@@ -509,16 +647,57 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 		memoryPremiumSKUCount,
 	)
 
+	isSyntheticRegion := func(region string) bool {
+		return strings.HasPrefix(region, "multi-")
+	}
+
+	// A family that prices Local SSD through its own SKUs in some regions but
+	// not others is a catalog gap, not a family that uses the generic rate:
+	// per-family Titanium SSD rates run about twice the generic "SSD backed
+	// Local Storage" rate, so silently falling through understates the shape by
+	// roughly half its SSD component. Families with no per-family SKU anywhere
+	// (A2, A3, C3, C3D) genuinely bill at the generic rate and must not warn,
+	// and neither must the families in bundledSSDBillsAtGenericRate, for which
+	// the generic rate is the intended answer.
+	familyHasOwnSSDSKU := make(map[string]bool)
+	for key := range ssdData {
+		if key.family != "" {
+			familyHasOwnSSDSKU[key.family] = true
+		}
+	}
+	for key := range ssdCudData {
+		if key.family != "" {
+			familyHasOwnSSDSKU[key.family] = true
+		}
+	}
+	genericSSDFallbacks := make(map[string]bool)
+	missingGenericSSDRates := make(map[string]bool)
+
+	// noteSSDRateSource records the two ways resolving a bundled Local SSD rate
+	// can land on a rate Google does not bill for that family, so the scrape
+	// reports them once at the end instead of per shape/region/term.
+	noteSSDRateSource := func(family, region string, usedGeneric bool) {
+		if isSyntheticRegion(region) {
+			return
+		}
+		switch {
+		case usedGeneric && familyHasOwnSSDSKU[family] && !bundledSSDBillsAtGenericRate[family]:
+			genericSSDFallbacks[fmt.Sprintf("%s/%s", family, region)] = true
+		case !usedGeneric && bundledSSDBillsAtGenericRate[family]:
+			missingGenericSSDRates[fmt.Sprintf("%s/%s", family, region)] = true
+		}
+	}
+
 	// localSSDRate resolves the per GiB-hour Local SSD rate for a machine
-	// family in a region. Per-family SKUs take precedence over the generic
-	// "SSD backed Local Storage" SKUs.
+	// family in a region, following ssdFamilyPrecedence.
 	localSSDRate := func(family, region string, isSpot bool) (float64, bool) {
-		for _, candidateFamily := range []string{family, ""} {
+		for _, candidateFamily := range ssdFamilyPrecedence(family) {
 			candidates, ok := ssdData[localSSDKey{family: candidateFamily, region: region, isSpot: isSpot}]
 			if !ok {
 				continue
 			}
-			if rate, hasRate := selectHourlyPrice(candidates, isSpot); hasRate {
+			if rate, hasRate := selectHourlyPrice(candidates); hasRate {
+				noteSSDRateSource(family, region, candidateFamily == "")
 				return rate, true
 			}
 		}
@@ -530,17 +709,34 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 	// precedence over the generic "Commitment v1: Local SSD" SKUs, matching the
 	// on-demand localSSDRate precedence.
 	ssdCudRate := func(family, region, term string) (float64, bool) {
-		for _, candidateFamily := range []string{family, ""} {
+		for _, candidateFamily := range ssdFamilyPrecedence(family) {
 			candidates, ok := ssdCudData[ssdCudKey{family: candidateFamily, region: region, term: term}]
 			if !ok {
 				continue
 			}
-			if rate, hasRate := selectHourlyPrice(candidates, false); hasRate {
+			if rate, hasRate := selectHourlyPrice(candidates); hasRate {
+				noteSSDRateSource(family, region, candidateFamily == "")
 				return rate, true
 			}
 		}
 		return 0, false
 	}
+
+	// A bundled Local SSD shape whose region has neither a per-family nor a
+	// generic Local SSD rate falls back to a core+RAM-only price, which is the
+	// exact bug the SSD fold-in exists to fix. Collect the misses and report
+	// them once at the end rather than per shape/region/term, which would be
+	// thousands of Slack warnings.
+	//
+	// The synthetic multi-region keys are excluded. Per-family Local SSD SKUs
+	// ("C4D Instance Local SSD running in Americas") are TYPE_MULTI_REGIONAL
+	// and do resolve to them, but the legacy generic "SSD backed Local Storage"
+	// SKUs carry their region list in multiRegionalMetadata, which expands only
+	// to member regions and never to the group key. Families with no per-family
+	// SSD SKU (A2, A3, C3, C3D) therefore have no rate at a group key and would
+	// report a miss on every scrape, drowning out a real per-region gap.
+	missingSSDRates := make(map[string]bool)
+	missingSSDCudRates := make(map[string]bool)
 
 	// premiumRate resolves the per-hour Memory Optimized Upgrade Premium rate
 	// for a resource in a region, used to synthesize M2 on-demand pricing.
@@ -549,7 +745,7 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 		if !ok {
 			return 0, false
 		}
-		return selectHourlyPrice(candidates, false)
+		return selectHourlyPrice(candidates)
 	}
 
 	// Build instances from machine specs
@@ -648,9 +844,7 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 				continue
 			}
 
-			// Select hourly price from all candidates for this SKU key.
-			// Spot should prefer lower prices; on-demand should prefer baseline list prices.
-			hourlyPrice, hasPrice := selectHourlyPrice(candidates, key.isSpot)
+			hourlyPrice, hasPrice := selectHourlyPrice(candidates)
 			if !hasPrice {
 				continue
 			}
@@ -699,6 +893,8 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 			if specs.LocalSSDGB > 0 {
 				if ssdRate, hasSSDRate := localSSDRate(machineFamily, rk.region, rk.isSpot); hasSSDRate {
 					totalPrice += float64(specs.LocalSSDGB) * ssdRate
+				} else if !isSyntheticRegion(rk.region) {
+					missingSSDRates[fmt.Sprintf("%s/%s/spot=%v", machineFamily, rk.region, rk.isSpot)] = true
 				}
 			}
 
@@ -765,7 +961,7 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 
 			// CUD list prices are baseline rates; use the standard list-price
 			// selection (same as on-demand, not the spot-style minimum).
-			hourlyPrice, hasPrice := selectHourlyPrice(candidates, false)
+			hourlyPrice, hasPrice := selectHourlyPrice(candidates)
 			if !hasPrice {
 				continue
 			}
@@ -810,6 +1006,8 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 			if specs.LocalSSDGB > 0 {
 				if ssdRate, hasSSDRate := ssdCudRate(machineFamily, crk.region, crk.term); hasSSDRate {
 					totalCUD += float64(specs.LocalSSDGB) * ssdRate
+				} else if !isSyntheticRegion(crk.region) {
+					missingSSDCudRates[fmt.Sprintf("%s/%s/%s", machineFamily, crk.region, crk.term)] = true
 				}
 			}
 
@@ -845,6 +1043,43 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 		}
 	}
 
+	if len(missingSSDRates) > 0 {
+		utils.SendWarning("GCP bundled Local SSD priced without its SSD, no Local SSD rate for family/region/spot:",
+			strings.Join(slices.Sorted(maps.Keys(missingSSDRates)), " "))
+	}
+	if len(missingSSDCudRates) > 0 {
+		utils.SendWarning("GCP bundled Local SSD CUD priced without its SSD, no Local SSD commitment rate for family/region/term:",
+			strings.Join(slices.Sorted(maps.Keys(missingSSDCudRates)), " "))
+	}
+	if len(genericSSDFallbacks) > 0 {
+		utils.SendWarning("GCP bundled Local SSD priced from the generic Local SSD rate, family has its own Local SSD SKUs elsewhere but not here (likely understated by about half the SSD component) for family/region:",
+			strings.Join(slices.Sorted(maps.Keys(genericSSDFallbacks)), " "))
+	}
+	if len(missingGenericSSDRates) > 0 {
+		utils.SendWarning("GCP bundled Local SSD priced from the per-family Local SSD rate, but this family bills at the generic rate and no generic rate exists in this region, for family/region:",
+			strings.Join(slices.Sorted(maps.Keys(missingGenericSSDRates)), " "))
+	}
+	ambiguousRates := ambiguousRateKeys(skuData, func(key skuKey) string {
+		term := "ondemand"
+		if key.isSpot {
+			term = "spot"
+		}
+		if key.isWindows {
+			term += "+windows"
+		}
+		return fmt.Sprintf("%s/%s/%s/%s", key.machineType, key.region, key.resourceType, term)
+	})
+	ambiguousRates = append(ambiguousRates, ambiguousRateKeys(cudData, func(key cudKey) string {
+		return fmt.Sprintf("%s/%s/%s/cud_%s", key.machineType, key.region, key.resourceType, key.term)
+	})...)
+	ambiguousRates = append(ambiguousRates, ambiguousRateKeys(premiumData, func(key premiumKey) string {
+		return fmt.Sprintf("premium/%s/%s", key.region, key.resourceType)
+	})...)
+	if len(ambiguousRates) > 0 {
+		utils.SendWarning("GCP two region-scoped SKUs disagree on price, the higher rate was selected (Google bills the lower twin for M1 asia-southeast1 on-demand core, so verify rather than assume) for family/region/resource/term:",
+			strings.Join(slices.Sorted(slices.Values(ambiguousRates)), " "))
+	}
+
 	// Now add Windows pricing to all instances
 	windowsInstanceCount := 0
 
@@ -861,10 +1096,10 @@ func processGCPData(skus []SKU, pricing map[string]PriceInfo, machineSpecs map[s
 		}
 
 		// Calculate Windows license cost (same for all regions)
-		coreLicensePrice, hasCorePrice := selectHourlyPrice(coreLicenseCandidates, false)
+		coreLicensePrice, hasCorePrice := selectHourlyPrice(coreLicenseCandidates)
 		ramLicensePrice := 0.0
 		if hasRamLicense {
-			if selectedRAM, hasRAMPrice := selectHourlyPrice(ramLicenseCandidates, false); hasRAMPrice {
+			if selectedRAM, hasRAMPrice := selectHourlyPrice(ramLicenseCandidates); hasRAMPrice {
 				ramLicensePrice = selectedRAM
 			}
 		}


### PR DESCRIPTION
**AI disclosure:** Claude implemented the changes, and Codex reviewed them. I directed the work and performed the validation below.

## Validation

The Billing SKU API was treated as the source of truth. Everything below is a cross-check on the parser.

- Claude built a second, independent parser for the JSON backing Google's [published Compute pricing pages](https://cloud.google.com/products/compute/pricing/) and swept it against the scraper's output, roughly 16,600 on-demand and 33,000 CUD comparisons. Every disagreement was triaged against the live billing catalog. A few were real scraper bugs and are fixed in this PR (the m4-ultramem-224 rates, the decimal-GB RAM units, and the C4-metal SSD capacity were all found this way). The rest were stale pricing pages, pages showing a generic rate where the catalog has regional ones, or the pre-existing gaps listed at the bottom.
- For every affected family, representative shape prices were recomputed by hand from raw catalog SKU rates and compared to what the scraper produced.
- A differential scrape at each commit confirmed the change touched only the prices it was supposed to, compared against a pre-fix baseline.
- I visually inspected scraped prices for a sampling of machine families on a local build, with particular attention to the trickier ones: Z3, M1, M2, and 1st/2nd-gen machines in the five original GCP regions, which use different billing SKU names than newer regions.
- Unit tests accompany each parser change, and every commit passes `go test ./gcp/...`.

Spot prices (which Google doesn't publish on those pages) and Windows prices (derived from Linux totals) can't be swept this way. For those, a sample of shape prices was recomputed directly from billing API SKU rates and compared to the scraper's output.

## Problem

- C2, M1, C4A, C4D, C4N, N4A, M4N, H4D, and X4 were missing because the scraper's family allowlist and SKU parser did not recognize them.
- M2 was missing because Google publishes no dedicated M2 core or RAM SKUs.
- Bundled Local SSD was omitted from prices and metadata, so SSD-backed shapes showed the same price as their SSD-less variants.
- `m4-ultramem-224` used standard M4 rates instead of its dedicated SKUs. Decimal-GB RAM SKUs also understated M4 and C4D prices.
- C2, M1, and M2 lacked committed-use prices, while bundled-SSD CUD prices excluded the SSD component.

## Changes

1. Add supported machine series, legacy C2/M1 SKU parsing, and correct Z3/C4N classification.
2. Discover bundled Local SSD capacity and include its regional rate in on-demand and Spot prices, including the documented Z3, C4 metal, and A4X partition sizes.
3. Synthesize M2 on-demand pricing from M1 rates plus the regional Upgrade Premium.
4. Route `m4-ultramem-224` to its dedicated SKUs and normalize decimal-GB RAM rates.
5. Add C2/M1/M2 and bundled Local SSD committed-use pricing.
6. Record missing accelerator memory values and true fractional G4 GPU counts. This data is unused for now. A follow-up PR is planned to add the missing GPU prices for the GPU machine types, which will also let A4, A4X, and G4 be published.

## Known gaps

- A4, A4X, and G4 remain excluded because the scraper cannot yet assemble their mandatory GPU charges. A2, A3, and G2 retain their pre-existing core/RAM-only prices. Adding GPU pricing later will raise those published totals.
- M3 and N1-era commitment SKUs remain unparsed, and flexible spend-based CUDs are not modeled.
- E2 shared-core shapes remain unpriced.
