### PR TITLE
feat(ec2): add baseline and burst network bandwidth columns

### DIFF
--- a/next/components/IndividualColumnFilter.tsx
+++ b/next/components/IndividualColumnFilter.tsx
@@ -226,6 +226,8 @@ const exprColumns = [
     "thread_count_per_numa_node",
     "memory_per_numa_node_mb",
     "l3_per_numa_node_mb",
+    "baseline_bandwidth_gbps",
+    "burst_bandwidth_gbps",
     "ebs_baseline_bandwidth",
     "ebs_baseline_throughput",
     "ebs_baseline_iops",

--- a/next/types.ts
+++ b/next/types.ts
@@ -59,6 +59,8 @@ export interface EC2Instance {
     };
     arch: string[];
     network_performance: string;
+    baseline_bandwidth_gbps?: number;
+    burst_bandwidth_gbps?: number;
     ebs_baseline_bandwidth?: number;
     ebs_baseline_throughput: number;
     ebs_baseline_iops: number;

--- a/next/utils/colunnData/ec2/columns.tsx
+++ b/next/utils/colunnData/ec2/columns.tsx
@@ -946,6 +946,60 @@ export const columnsGen = (
         cell: (info) => info.getValue() as string,
     },
     {
+        accessorKey: "baseline_bandwidth_gbps",
+        header: "Network: Baseline Bandwidth",
+        id: "baseline_bandwidth_gbps",
+        sortingFn: (rowA, rowB) => {
+            const valueA = rowA.original.baseline_bandwidth_gbps;
+            const valueB = rowB.original.baseline_bandwidth_gbps;
+            if (!valueA) return -1;
+            if (!valueB) return 1;
+            return valueA - valueB;
+        },
+        filterFn: (row, _, filterValue) => {
+            const value = row.original.baseline_bandwidth_gbps;
+            if (!value) return false;
+            try {
+                return exprCompiler(filterValue)(value, `${value} Gbps`);
+            } catch {
+                // Just allow all if the expr is invalid.
+                return true;
+            }
+        },
+        cell: (info) => {
+            const value = info.getValue() as number | undefined;
+            if (!value) return undefined;
+            return `${value} Gbps`;
+        },
+    },
+    {
+        accessorKey: "burst_bandwidth_gbps",
+        header: "Network: Burst Bandwidth",
+        id: "burst_bandwidth_gbps",
+        sortingFn: (rowA, rowB) => {
+            const valueA = rowA.original.burst_bandwidth_gbps;
+            const valueB = rowB.original.burst_bandwidth_gbps;
+            if (!valueA) return -1;
+            if (!valueB) return 1;
+            return valueA - valueB;
+        },
+        filterFn: (row, _, filterValue) => {
+            const value = row.original.burst_bandwidth_gbps;
+            if (!value) return false;
+            try {
+                return exprCompiler(filterValue)(value, `${value} Gbps`);
+            } catch {
+                // Just allow all if the expr is invalid.
+                return true;
+            }
+        },
+        cell: (info) => {
+            const value = info.getValue() as number | undefined;
+            if (!value) return undefined;
+            return `${value} Gbps`;
+        },
+    },
+    {
         accessorKey: "ebs_baseline_bandwidth",
         header: "EBS Optimized: Baseline Bandwidth",
         id: "ebs_baseline_bandwidth",

--- a/next/utils/colunnData/ec2/index.ts
+++ b/next/utils/colunnData/ec2/index.ts
@@ -30,6 +30,8 @@ const initialColumnsArr = [
     ["storage_write_iops", false],
     ["arch", false],
     ["network_performance", true],
+    ["baseline_bandwidth_gbps", false],
+    ["burst_bandwidth_gbps", false],
     ["ebs_baseline_bandwidth", false],
     ["ebs_baseline_throughput", false],
     ["ebs_baseline_iops", false],
@@ -183,6 +185,11 @@ export function makePrettyNames<V>(
         makeColumnOption("storage_write_iops", "Instance Store: Write IOPS"),
         makeColumnOption("arch", "Arch"),
         makeColumnOption("network_performance", "Network Performance"),
+        makeColumnOption(
+            "baseline_bandwidth_gbps",
+            "Network: Baseline Bandwidth",
+        ),
+        makeColumnOption("burst_bandwidth_gbps", "Network: Burst Bandwidth"),
         makeColumnOption(
             "ebs_baseline_bandwidth",
             "EBS Optimized: Baseline Bandwidth",

--- a/next/utils/mocks/ec2_single_instance.json
+++ b/next/utils/mocks/ec2_single_instance.json
@@ -41,6 +41,8 @@
   "l3_per_numa_node_mb": null,
   "l3_shared": null,
   "network_performance": "100 Gigabit",
+  "baseline_bandwidth_gbps": 100,
+  "burst_bandwidth_gbps": 100,
   "physical_processor": "Intel Xeon Scalable (Icelake)",
   "placement_group_support": true,
   "pretty_name": "X2IEDN 32xlarge",

--- a/scraper/aws/ec2/ec2_instance.go
+++ b/scraper/aws/ec2/ec2_instance.go
@@ -138,6 +138,8 @@ type EC2Instance struct {
 	MaxECSTasks              *int                       `json:"max_ecs_tasks,omitempty"`
 	DateIntroduced           *string                    `json:"date_introduced,omitempty"`
 	MaxPods                  *int                       `json:"max_pods,omitempty"`
+	BaselineBandwidth        *float64                   `json:"baseline_bandwidth_gbps,omitempty"`
+	BurstBandwidth           *float64                   `json:"burst_bandwidth_gbps,omitempty"`
 }
 
 func avg(ints []int) *float64 {

--- a/scraper/aws/ec2/enrichment.go
+++ b/scraper/aws/ec2/enrichment.go
@@ -112,6 +112,13 @@ func enrichEc2Instance(instance *EC2Instance, attributes map[string]string, ec2A
 		} else if *apiDescription.NetworkInfo.NetworkPerformance != "NA" {
 			instance.NetworkPerformance = *apiDescription.NetworkInfo.NetworkPerformance
 		}
+
+		if len(apiDescription.NetworkInfo.NetworkCards) > 0 {
+			card := apiDescription.NetworkInfo.NetworkCards[0]
+			instance.BaselineBandwidth = card.BaselineBandwidthInGbps
+			instance.BurstBandwidth = card.PeakBandwidthInGbps
+		}
+
 	} else {
 		if instance.Arch == nil {
 			// Try and figure out the value with a best guess


### PR DESCRIPTION
## Summary

- Scrapes baseline and burst network bandwidth from `DescribeInstanceTypes` (`NetworkCards[0].BaselineBandwidthInGbps` / `PeakBandwidthInGbps`) and writes them as `baseline_bandwidth_gbps` and `burst_bandwidth_gbps` on each EC2 instance.
- Adds two optional EC2 comparison-table columns: **Network: Baseline Bandwidth** and **Network: Burst Bandwidth** with units of gbps, with numeric sorting and expression filters.
- Closes #617.

## Notes

- Columns are hidden by default and available via the column picker.
- Values are omitted when AWS does not report network cards (older / missing API descriptions).
- Bandwidth is taken from the first network card, matching the approach suggested in #617. Multi-card instances show the first network card's information rather than aggregate bandwidth.

## Test plan

- [x] Run a fresh EC2 scrape and confirm `www/instances.json` includes `baseline_bandwidth_gbps` / `burst_bandwidth_gbps` for modern types (e.g. `r6g.large` → baseline `0.75`, burst `10`).
- [x] Confirm older types without network-card data omit the fields rather than showing `0`.
- [x] On the EC2 table, enable both new columns from the column picker and verify values render as `X Gbps`.
- [x] Sort each column ascending/descending; missing values should sort to the bottom.
- [x] Expression-filter each column (e.g. `>=10`) and confirm the expr filter UI is used.

## Verification
<img width="1043" height="608" alt="Screenshot 2026-07-17 at 5 40 36 PM" src="https://github.com/user-attachments/assets/de45e9de-077d-42c2-b25b-e80e4be5c730" />
<img width="892" height="619" alt="Screenshot 2026-07-17 at 5 41 01 PM" src="https://github.com/user-attachments/assets/bbb7c409-d675-416e-9f18-487c663db204" />
