### PR TITLE
feat(rds): multi az pricing

### DIFF
--- a/next/components/EC2InstanceRoot.tsx
+++ b/next/components/EC2InstanceRoot.tsx
@@ -100,6 +100,7 @@ export default function EC2InstanceRoot({
                             useSpotMin={false}
                             setPathSuffix={setPathSuffix}
                             onPlatformChange={setSelectedPlatform}
+                            supportRdsMultiAz={generatorKey === "rds"}
                         />
                         <VantageDemo link="https://www.vantage.sh/lp/aws-instances-demo?utm_campaign=Instances%20Blog%20Clicks&utm_source=details-sidebar" />
                         <FamilySize

--- a/next/components/Filters.tsx
+++ b/next/components/Filters.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { CostDuration, PricingUnit, Region, RdsDeploymentOption } from "@/types";
+import {
+    CostDuration,
+    PricingUnit,
+    Region,
+    RdsDeploymentOption,
+} from "@/types";
 import FilterDropdown from "./FilterDropdown";
 import ColumnFilter from "./ColumnFilter";
 import ExportDropdown from "./ExportDropdown";

--- a/next/components/Filters.tsx
+++ b/next/components/Filters.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CostDuration, PricingUnit, Region } from "@/types";
+import { CostDuration, PricingUnit, Region, RdsDeploymentOption } from "@/types";
 import FilterDropdown from "./FilterDropdown";
 import ColumnFilter from "./ColumnFilter";
 import ExportDropdown from "./ExportDropdown";
@@ -10,6 +10,7 @@ import {
     usePricingUnit,
     useDuration,
     useReservedTerm,
+    useRdsDeploymentOption,
     useCompareOn,
     useColumnVisibility,
     useSelected,
@@ -53,6 +54,8 @@ export default function Filters<DataKey extends keyof typeof columnData>({
     const [pricingUnit, setPricingUnit] = usePricingUnit(pathname, ecuRename);
     const [duration, setDuration] = useDuration(pathname);
     const [reservedTerm, setReservedTerm] = useReservedTerm(pathname);
+    const [rdsDeploymentOption, setRdsDeploymentOption] =
+        useRdsDeploymentOption(pathname);
     const [compareOn, setCompareOn] = useCompareOn(pathname);
     const [selected] = useSelected(pathname);
     const [currency, setCurrency] = useCurrency(pathname, currencies);
@@ -221,6 +224,21 @@ export default function Filters<DataKey extends keyof typeof columnData>({
                         hideSearch={true}
                         small={true}
                     />
+                    {pathname === "/rds" && (
+                        <FilterDropdown
+                            label="Deployment"
+                            value={rdsDeploymentOption}
+                            onChange={(v) =>
+                                setRdsDeploymentOption(v as RdsDeploymentOption)
+                            }
+                            options={[
+                                { value: "single-az", label: "Single-AZ" },
+                                { value: "multi-az", label: "Multi-AZ" },
+                            ]}
+                            hideSearch={true}
+                            small={true}
+                        />
+                    )}
                     {reservedTermOptions.length > 0 && (
                         <FilterDropdown
                             label={reservedLabel ?? "Reserved"}

--- a/next/components/InstanceTable.tsx
+++ b/next/components/InstanceTable.tsx
@@ -15,6 +15,7 @@ import {
     useSearchTerm,
     useSelectedRegion,
     useReservedTerm,
+    useRdsDeploymentOption,
     useActiveTableDataFormatter,
     usePricingUnit,
     useDuration,
@@ -91,6 +92,7 @@ export default function InstanceTable<
     const [pricingUnit] = usePricingUnit(pathname, ecuRename);
     const [costDuration] = useDuration(pathname);
     const [reservedTerm] = useReservedTerm(pathname);
+    const [rdsDeploymentOption] = useRdsDeploymentOption(pathname);
     const [columnFilters, setColumnFilters] = useColumnFilters(pathname);
     const [compareOn] = useCompareOn(pathname);
     const [selected, setSelected] = useSelected(pathname);
@@ -98,17 +100,29 @@ export default function InstanceTable<
     const [currency] = useCurrency(pathname);
     const conversionRate = currencyRateAtom.use();
 
-    const columns = columnData[columnAtomKey].columnsGen(
-        selectedRegion,
-        pricingUnit,
-        costDuration,
-        reservedTerm,
-        {
-            code: currency,
-            usdRate: conversionRate.usd,
-            cnyRate: conversionRate.cny,
-        },
-    );
+    const currencyObj = {
+        code: currency,
+        usdRate: conversionRate.usd,
+        cnyRate: conversionRate.cny,
+    };
+
+    const columns =
+        columnAtomKey === "rds"
+            ? columnData.rds.columnsGen(
+                  selectedRegion,
+                  pricingUnit,
+                  costDuration,
+                  reservedTerm,
+                  currencyObj,
+                  rdsDeploymentOption,
+              )
+            : columnData[columnAtomKey].columnsGen(
+                  selectedRegion,
+                  pricingUnit,
+                  costDuration,
+                  reservedTerm,
+                  currencyObj,
+              );
     for (const col of columns) {
         col.sortUndefined = "last";
     }

--- a/next/components/PricingCalculator.tsx
+++ b/next/components/PricingCalculator.tsx
@@ -1,14 +1,15 @@
 "use client";
 
-import { CostDuration, Region } from "@/types";
+import { CostDuration, Region, RdsDeploymentOption } from "@/types";
 import { DollarSignIcon } from "lucide-react";
 import { useMemo, useState, useId, useEffect, useCallback } from "react";
 import processRainbowTable from "@/utils/processRainbowTable";
 import { durationOptions } from "@/utils/dataMappings";
 import type { CurrencyItem } from "@/utils/loadCurrencies";
-import { currencyRateAtom } from "@/state";
+import { currencyRateAtom, useRdsDeploymentOption } from "@/state";
 import CurrencySelector from "./CurrencySelector";
 import { browserBlockingLocalStorage } from "@/utils/abGroup";
+import { rdsEngineBucket, type RdsEnginePricing } from "@/utils/rdsPricing";
 
 interface Platform {
     ondemand: string | number;
@@ -77,6 +78,7 @@ function Calculator({
     setPathSuffix,
     currencies,
     onPlatformChange,
+    supportRdsMultiAz = false,
 }: {
     pricing: Record<string, Record<string, Platform>>;
     regions: Region;
@@ -90,8 +92,11 @@ function Calculator({
     setPathSuffix: (value: string) => void;
     currencies: CurrencyItem[];
     onPlatformChange?: (platform: string) => void;
+    supportRdsMultiAz?: boolean;
 }) {
     const priceHoldersId = useId();
+    const [rdsDeploymentOption, setRdsDeploymentOption] =
+        useRdsDeploymentOption("/rds");
 
     const defaultRegion = useMemo(() => {
         if (!pricing[defaultRegionForType]) return Object.keys(pricing)[0];
@@ -260,7 +265,13 @@ function Calculator({
     );
 
     const prices = useMemo(() => {
-        const root = pricing[region]?.[platform];
+        const root = supportRdsMultiAz
+            ? rdsEngineBucket(
+                  pricing[region] as Record<string, RdsEnginePricing>,
+                  platform,
+                  rdsDeploymentOption,
+              )
+            : pricing[region]?.[platform];
         const a = [
             {
                 label: "On Demand",
@@ -320,6 +331,8 @@ function Calculator({
         currency,
         conversionRate,
         reservedTermOptions,
+        supportRdsMultiAz,
+        rdsDeploymentOption,
     ]);
 
     const handleRegions = (
@@ -448,6 +461,23 @@ function Calculator({
                     </select>
                 )}
 
+                {supportRdsMultiAz && (
+                    <select
+                        aria-label="Deployment"
+                        aria-controls={priceHoldersId}
+                        value={rdsDeploymentOption}
+                        className={selectStyling}
+                        onChange={(e) =>
+                            setRdsDeploymentOption(
+                                e.target.value as RdsDeploymentOption,
+                            )
+                        }
+                    >
+                        <option value="single-az">Single-AZ</option>
+                        <option value="multi-az">Multi-AZ</option>
+                    </select>
+                )}
+
                 <select
                     aria-label="Duration"
                     aria-controls={priceHoldersId}
@@ -523,6 +553,7 @@ type PricingCalculatorProps = {
     setPathSuffix: (value: string) => void;
     currencies: CurrencyItem[];
     onPlatformChange?: (platform: string) => void;
+    supportRdsMultiAz?: boolean;
 };
 
 export default function PricingCalculator({
@@ -539,6 +570,7 @@ export default function PricingCalculator({
     setPathSuffix,
     currencies,
     onPlatformChange,
+    supportRdsMultiAz = false,
 }: PricingCalculatorProps) {
     const instance = useMemo(() => {
         if (!Array.isArray(compressedInstance.pricing))
@@ -565,6 +597,7 @@ export default function PricingCalculator({
                 setPathSuffix={setPathSuffix}
                 currencies={currencies}
                 onPlatformChange={onPlatformChange}
+                supportRdsMultiAz={supportRdsMultiAz}
             />
         </section>
     );

--- a/next/state.ts
+++ b/next/state.ts
@@ -1,7 +1,7 @@
 import { atom } from "atomtree";
 import { useEffect, useSyncExternalStore } from "react";
 import handleCompressedFile from "./utils/handleCompressedFile";
-import { CostDuration, PricingUnit } from "./types";
+import { CostDuration, PricingUnit, RdsDeploymentOption } from "./types";
 import {
     useGlobalStateValue,
     useLastCurrencyLocalStorageValue,
@@ -105,6 +105,17 @@ export function useReservedTerm(pathname: string) {
         : "yrTerm1Standard.noUpfront";
 
     return useGlobalStateValue("reservedTerm", pathname, defaultReservedTerm);
+}
+
+export function useRdsDeploymentOption(pathname: string) {
+    return useGlobalStateValue(
+        "rdsDeploymentOption",
+        pathname,
+        "single-az",
+    ) as readonly [
+        RdsDeploymentOption,
+        (value: RdsDeploymentOption) => void,
+    ];
 }
 
 export function useCompareOn(pathname: string) {

--- a/next/state.ts
+++ b/next/state.ts
@@ -112,10 +112,7 @@ export function useRdsDeploymentOption(pathname: string) {
         "rdsDeploymentOption",
         pathname,
         "single-az",
-    ) as readonly [
-        RdsDeploymentOption,
-        (value: RdsDeploymentOption) => void,
-    ];
+    ) as readonly [RdsDeploymentOption, (value: RdsDeploymentOption) => void];
 }
 
 export function useCompareOn(pathname: string) {

--- a/next/types.ts
+++ b/next/types.ts
@@ -142,3 +142,5 @@ export type CostDuration =
     | "weekly"
     | "monthly"
     | "annually";
+
+export type RdsDeploymentOption = "single-az" | "multi-az";

--- a/next/utils/colunnData/rds.tsx
+++ b/next/utils/colunnData/rds.tsx
@@ -1,4 +1,10 @@
-import { CostDuration, EC2Instance, PricingUnit } from "@/types";
+import {
+    CostDuration,
+    EC2Instance,
+    Pricing,
+    PricingUnit,
+    RdsDeploymentOption,
+} from "@/types";
 import {
     regex,
     makeCellWithRegexSorter,
@@ -9,6 +15,7 @@ import { ColumnDef } from "@tanstack/react-table";
 import RegionLinkPreloader from "@/components/RegionLinkPreloader";
 import { getPricingSorter } from "./ec2/columns";
 import sortByInstanceType from "../sortByInstanceType";
+import { rdsEngineBucket } from "../rdsPricing";
 
 const initialColumnsArr = [
     ["name", true],
@@ -159,7 +166,19 @@ export const columnsGen = (
         usdRate: number;
         cnyRate: number;
     },
-): ColumnDef<EC2Instance>[] => [
+    rdsDeploymentOption: RdsDeploymentOption = "single-az",
+): ColumnDef<EC2Instance>[] => {
+    type RegionPricing = Pricing[string];
+
+    const rdsOnDemand = (engineKey: string) => (pricing: RegionPricing | undefined) =>
+        rdsEngineBucket(pricing, engineKey, rdsDeploymentOption)?.ondemand;
+
+    const rdsReserved = (engineKey: string) => (pricing: RegionPricing | undefined) =>
+        rdsEngineBucket(pricing, engineKey, rdsDeploymentOption)?.reserved?.[
+            reservedTerm
+        ];
+
+    return [
     {
         header: "Name",
         id: "name",
@@ -274,7 +293,7 @@ export const columnsGen = (
             selectedRegion,
             pricingUnit,
             costDuration,
-            (pricing) => pricing?.["14"]?.ondemand,
+            (pricing) => rdsOnDemand("14")(pricing),
             true,
             currency,
         ),
@@ -287,7 +306,7 @@ export const columnsGen = (
             selectedRegion,
             pricingUnit,
             costDuration,
-            (pricing) => pricing?.["14"]?.reserved?.[reservedTerm],
+            (pricing) => rdsReserved("14")(pricing),
             true,
             currency,
         ),
@@ -300,7 +319,7 @@ export const columnsGen = (
             selectedRegion,
             pricingUnit,
             costDuration,
-            (pricing) => pricing?.["2"]?.ondemand,
+            (pricing) => rdsOnDemand("2")(pricing),
             true,
             currency,
         ),
@@ -313,7 +332,7 @@ export const columnsGen = (
             selectedRegion,
             pricingUnit,
             costDuration,
-            (pricing) => pricing?.["2"]?.reserved?.[reservedTerm],
+            (pricing) => rdsReserved("2")(pricing),
             true,
             currency,
         ),
@@ -326,7 +345,7 @@ export const columnsGen = (
             selectedRegion,
             pricingUnit,
             costDuration,
-            (pricing) => pricing?.["10"]?.ondemand,
+            (pricing) => rdsOnDemand("10")(pricing),
             true,
             currency,
         ),
@@ -339,7 +358,7 @@ export const columnsGen = (
             selectedRegion,
             pricingUnit,
             costDuration,
-            (pricing) => pricing?.["10"]?.reserved?.[reservedTerm],
+            (pricing) => rdsReserved("10")(pricing),
             true,
             currency,
         ),
@@ -352,7 +371,7 @@ export const columnsGen = (
             selectedRegion,
             pricingUnit,
             costDuration,
-            (pricing) => pricing?.["11"]?.ondemand,
+            (pricing) => rdsOnDemand("11")(pricing),
             true,
             currency,
         ),
@@ -365,7 +384,7 @@ export const columnsGen = (
             selectedRegion,
             pricingUnit,
             costDuration,
-            (pricing) => pricing?.["11"]?.reserved?.[reservedTerm],
+            (pricing) => rdsReserved("11")(pricing),
             true,
             currency,
         ),
@@ -378,7 +397,7 @@ export const columnsGen = (
             selectedRegion,
             pricingUnit,
             costDuration,
-            (pricing) => pricing?.["12"]?.ondemand,
+            (pricing) => rdsOnDemand("12")(pricing),
             true,
             currency,
         ),
@@ -391,7 +410,7 @@ export const columnsGen = (
             selectedRegion,
             pricingUnit,
             costDuration,
-            (pricing) => pricing?.["12"]?.reserved?.[reservedTerm],
+            (pricing) => rdsReserved("12")(pricing),
             true,
             currency,
         ),
@@ -404,7 +423,7 @@ export const columnsGen = (
             selectedRegion,
             pricingUnit,
             costDuration,
-            (pricing) => pricing?.["15"]?.ondemand,
+            (pricing) => rdsOnDemand("15")(pricing),
             true,
             currency,
         ),
@@ -417,7 +436,7 @@ export const columnsGen = (
             selectedRegion,
             pricingUnit,
             costDuration,
-            (pricing) => pricing?.["15"]?.reserved?.[reservedTerm],
+            (pricing) => rdsReserved("15")(pricing),
             true,
             currency,
         ),
@@ -430,7 +449,7 @@ export const columnsGen = (
             selectedRegion,
             pricingUnit,
             costDuration,
-            (pricing) => pricing?.["21"]?.ondemand,
+            (pricing) => rdsOnDemand("21")(pricing),
             true,
             currency,
         ),
@@ -443,7 +462,7 @@ export const columnsGen = (
             selectedRegion,
             pricingUnit,
             costDuration,
-            (pricing) => pricing?.["21"]?.reserved?.[reservedTerm],
+            (pricing) => rdsReserved("21")(pricing),
             true,
             currency,
         ),
@@ -456,7 +475,7 @@ export const columnsGen = (
             selectedRegion,
             pricingUnit,
             costDuration,
-            (pricing) => pricing?.["211"]?.ondemand,
+            (pricing) => rdsOnDemand("211")(pricing),
             true,
             currency,
         ),
@@ -469,7 +488,7 @@ export const columnsGen = (
             selectedRegion,
             pricingUnit,
             costDuration,
-            (pricing) => pricing?.["18"]?.ondemand,
+            (pricing) => rdsOnDemand("18")(pricing),
             true,
             currency,
         ),
@@ -482,7 +501,7 @@ export const columnsGen = (
             selectedRegion,
             pricingUnit,
             costDuration,
-            (pricing) => pricing?.["18"]?.reserved?.[reservedTerm],
+            (pricing) => rdsReserved("18")(pricing),
             true,
             currency,
         ),
@@ -495,7 +514,7 @@ export const columnsGen = (
             selectedRegion,
             pricingUnit,
             costDuration,
-            (pricing) => pricing?.["5"]?.ondemand,
+            (pricing) => rdsOnDemand("5")(pricing),
             true,
             currency,
         ),
@@ -508,7 +527,7 @@ export const columnsGen = (
             selectedRegion,
             pricingUnit,
             costDuration,
-            (pricing) => pricing?.["5"]?.reserved?.[reservedTerm],
+            (pricing) => rdsReserved("5")(pricing),
             true,
             currency,
         ),
@@ -560,4 +579,5 @@ export const columnsGen = (
         sortingFn: "alphanumeric",
         filterFn: (row, _, filterValue) => expr(row, "ebs_iops", filterValue),
     },
-];
+    ];
+};

--- a/next/utils/colunnData/rds.tsx
+++ b/next/utils/colunnData/rds.tsx
@@ -170,414 +170,416 @@ export const columnsGen = (
 ): ColumnDef<EC2Instance>[] => {
     type RegionPricing = Pricing[string];
 
-    const rdsOnDemand = (engineKey: string) => (pricing: RegionPricing | undefined) =>
-        rdsEngineBucket(pricing, engineKey, rdsDeploymentOption)?.ondemand;
+    const rdsOnDemand =
+        (engineKey: string) => (pricing: RegionPricing | undefined) =>
+            rdsEngineBucket(pricing, engineKey, rdsDeploymentOption)?.ondemand;
 
-    const rdsReserved = (engineKey: string) => (pricing: RegionPricing | undefined) =>
-        rdsEngineBucket(pricing, engineKey, rdsDeploymentOption)?.reserved?.[
-            reservedTerm
-        ];
+    const rdsReserved =
+        (engineKey: string) => (pricing: RegionPricing | undefined) =>
+            rdsEngineBucket(pricing, engineKey, rdsDeploymentOption)
+                ?.reserved?.[reservedTerm];
 
     return [
-    {
-        header: "Name",
-        id: "name",
-        accessorKey: "pretty_name",
-        sortingFn: "alphanumeric",
-        filterFn: regex({ accessorKey: "pretty_name" }),
-    },
-    {
-        header: "API Name",
-        id: "apiname",
-        accessorKey: "instance_type",
-        sortingFn: (rowA, rowB) => {
-            const valueA = rowA.original.instance_type;
-            const valueB = rowB.original.instance_type;
-            return sortByInstanceType(valueA, valueB, ".", "db.");
+        {
+            header: "Name",
+            id: "name",
+            accessorKey: "pretty_name",
+            sortingFn: "alphanumeric",
+            filterFn: regex({ accessorKey: "pretty_name" }),
         },
-        cell: (info) => {
-            const value = info.getValue() as string;
-            return (
-                <RegionLinkPreloader
-                    onClick={(e) => e.stopPropagation()}
-                    href={`/aws/rds/${value}`}
-                >
-                    {value}
-                </RegionLinkPreloader>
-            );
+        {
+            header: "API Name",
+            id: "apiname",
+            accessorKey: "instance_type",
+            sortingFn: (rowA, rowB) => {
+                const valueA = rowA.original.instance_type;
+                const valueB = rowB.original.instance_type;
+                return sortByInstanceType(valueA, valueB, ".", "db.");
+            },
+            cell: (info) => {
+                const value = info.getValue() as string;
+                return (
+                    <RegionLinkPreloader
+                        onClick={(e) => e.stopPropagation()}
+                        href={`/aws/rds/${value}`}
+                    >
+                        {value}
+                    </RegionLinkPreloader>
+                );
+            },
+            filterFn: regex({ accessorKey: "instance_type" }),
         },
-        filterFn: regex({ accessorKey: "instance_type" }),
-    },
-    {
-        accessorKey: "family",
-        header: "Compute Family",
-        size: 150,
-        id: "compute_family",
-        sortingFn: "alphanumeric",
-        filterFn: regex({ accessorKey: "family" }),
-    },
-    {
-        header: "Memory",
-        id: "memory",
-        accessorKey: "memory",
-        filterFn: expr,
-        sortingFn: "alphanumeric",
-    },
-    {
-        header: "Storage",
-        id: "storage",
-        accessorKey: "storage",
-        filterFn: expr,
-        sortingFn: "alphanumeric",
-    },
-    {
-        header: "EBS Throughput",
-        id: "ebs-throughput",
-        accessorKey: "ebs_throughput",
-        sortingFn: "alphanumeric",
-        filterFn: (row, _, filterValue) =>
-            expr(row, "ebs_throughput", filterValue),
-    },
-    {
-        header: "Processor",
-        id: "physical_processor",
-        accessorKey: "physicalProcessor",
-        sortingFn: "alphanumeric",
-        // @ts-expect-error: The typing is weird in the file
-        filterFn: regex({ accessorKey: "physicalProcessor" }),
-    },
-    {
-        header: "vCPUs",
-        id: "vcpu",
-        accessorKey: "vcpu",
-        filterFn: expr,
-        sortingFn: "alphanumeric",
-    },
-    {
-        header: "Network Performance",
-        id: "networkperf",
-        accessorKey: "network_performance",
-        sortingFn: "alphanumeric",
-        filterFn: regex({ accessorKey: "network_performance" }),
-    },
-    {
-        accessorKey: "arch",
-        header: "Arch",
-        size: 100,
-        id: "architecture",
-        sortingFn: (rowA, rowB) => {
-            const valueA = rowA.original.arch;
-            const valueB = rowB.original.arch;
-            if (!valueA) return -1;
-            if (!valueB) return 1;
-            return JSON.stringify(
-                typeof valueA === "string" ? [valueA] : valueA.sort(),
-            ).localeCompare(
-                JSON.stringify(
-                    typeof valueB === "string" ? [valueB] : valueB.sort(),
-                ),
-            );
+        {
+            accessorKey: "family",
+            header: "Compute Family",
+            size: 150,
+            id: "compute_family",
+            sortingFn: "alphanumeric",
+            filterFn: regex({ accessorKey: "family" }),
         },
-        ...makeCellWithRegexSorter("arch", (info) => {
-            const arch = info.getValue() as string[] | string;
-            if (typeof arch === "string") return arch;
-            if (!arch) return "";
-            return arch.sort().join(", ");
-        }),
-    },
-    {
-        header: "PostgreSQL",
-        id: "cost-ondemand-14",
-        accessorKey: "pricing",
-        ...getPricingSorter(
-            selectedRegion,
-            pricingUnit,
-            costDuration,
-            (pricing) => rdsOnDemand("14")(pricing),
-            true,
-            currency,
-        ),
-    },
-    {
-        header: "PostgreSQL Reserved Cost",
-        id: "cost-reserved-14t",
-        accessorKey: "pricing",
-        ...getPricingSorter(
-            selectedRegion,
-            pricingUnit,
-            costDuration,
-            (pricing) => rdsReserved("14")(pricing),
-            true,
-            currency,
-        ),
-    },
-    {
-        header: "MySQL On Demand Cost",
-        id: "cost-ondemand-2",
-        accessorKey: "pricing",
-        ...getPricingSorter(
-            selectedRegion,
-            pricingUnit,
-            costDuration,
-            (pricing) => rdsOnDemand("2")(pricing),
-            true,
-            currency,
-        ),
-    },
-    {
-        header: "MySQL Reserved Cost",
-        id: "cost-reserved-2",
-        accessorKey: "pricing",
-        ...getPricingSorter(
-            selectedRegion,
-            pricingUnit,
-            costDuration,
-            (pricing) => rdsReserved("2")(pricing),
-            true,
-            currency,
-        ),
-    },
-    {
-        header: "SQL Server Expresss On Demand Cost",
-        id: "cost-ondemand-10",
-        accessorKey: "pricing",
-        ...getPricingSorter(
-            selectedRegion,
-            pricingUnit,
-            costDuration,
-            (pricing) => rdsOnDemand("10")(pricing),
-            true,
-            currency,
-        ),
-    },
-    {
-        header: "SQL Server Expresss Reserved Cost",
-        id: "cost-reserved-10",
-        accessorKey: "pricing",
-        ...getPricingSorter(
-            selectedRegion,
-            pricingUnit,
-            costDuration,
-            (pricing) => rdsReserved("10")(pricing),
-            true,
-            currency,
-        ),
-    },
-    {
-        header: "SQL Server Web On Demand Cost",
-        id: "cost-ondemand-11",
-        accessorKey: "pricing",
-        ...getPricingSorter(
-            selectedRegion,
-            pricingUnit,
-            costDuration,
-            (pricing) => rdsOnDemand("11")(pricing),
-            true,
-            currency,
-        ),
-    },
-    {
-        header: "SQL Server Web Reserved Cost",
-        id: "cost-reserved-11",
-        accessorKey: "pricing",
-        ...getPricingSorter(
-            selectedRegion,
-            pricingUnit,
-            costDuration,
-            (pricing) => rdsReserved("11")(pricing),
-            true,
-            currency,
-        ),
-    },
-    {
-        header: "SQL Server Standard On Demand Cost",
-        id: "cost-ondemand-12",
-        accessorKey: "pricing",
-        ...getPricingSorter(
-            selectedRegion,
-            pricingUnit,
-            costDuration,
-            (pricing) => rdsOnDemand("12")(pricing),
-            true,
-            currency,
-        ),
-    },
-    {
-        header: "SQL Server Standard Reserved Cost",
-        id: "cost-reserved-12",
-        accessorKey: "pricing",
-        ...getPricingSorter(
-            selectedRegion,
-            pricingUnit,
-            costDuration,
-            (pricing) => rdsReserved("12")(pricing),
-            true,
-            currency,
-        ),
-    },
-    {
-        header: "SQL Server Enterprise On Demand Cost",
-        id: "cost-ondemand-15",
-        accessorKey: "pricing",
-        ...getPricingSorter(
-            selectedRegion,
-            pricingUnit,
-            costDuration,
-            (pricing) => rdsOnDemand("15")(pricing),
-            true,
-            currency,
-        ),
-    },
-    {
-        header: "SQL Server Enterprise Reserved Cost",
-        id: "cost-reserved-15",
-        accessorKey: "pricing",
-        ...getPricingSorter(
-            selectedRegion,
-            pricingUnit,
-            costDuration,
-            (pricing) => rdsReserved("15")(pricing),
-            true,
-            currency,
-        ),
-    },
-    {
-        header: "Aurora Postgres & MySQL On Demand Cost",
-        id: "cost-ondemand-21",
-        accessorKey: "pricing",
-        ...getPricingSorter(
-            selectedRegion,
-            pricingUnit,
-            costDuration,
-            (pricing) => rdsOnDemand("21")(pricing),
-            true,
-            currency,
-        ),
-    },
-    {
-        header: "Aurora Postgres & MySQL Reserved Cost",
-        id: "cost-reserved-21",
-        accessorKey: "pricing",
-        ...getPricingSorter(
-            selectedRegion,
-            pricingUnit,
-            costDuration,
-            (pricing) => rdsReserved("21")(pricing),
-            true,
-            currency,
-        ),
-    },
-    {
-        header: "Aurora I/O Optimized On Demand Cost",
-        id: "cost-ondemand-211",
-        accessorKey: "pricing",
-        ...getPricingSorter(
-            selectedRegion,
-            pricingUnit,
-            costDuration,
-            (pricing) => rdsOnDemand("211")(pricing),
-            true,
-            currency,
-        ),
-    },
-    {
-        header: "MariaDB On Demand Cost",
-        id: "cost-ondemand-18",
-        accessorKey: "pricing",
-        ...getPricingSorter(
-            selectedRegion,
-            pricingUnit,
-            costDuration,
-            (pricing) => rdsOnDemand("18")(pricing),
-            true,
-            currency,
-        ),
-    },
-    {
-        header: "MariaDB Reserved Cost",
-        id: "cost-reserved-18",
-        accessorKey: "pricing",
-        ...getPricingSorter(
-            selectedRegion,
-            pricingUnit,
-            costDuration,
-            (pricing) => rdsReserved("18")(pricing),
-            true,
-            currency,
-        ),
-    },
-    {
-        header: "Oracle Enterprise On Demand Cost",
-        id: "cost-ondemand-5",
-        accessorKey: "pricing",
-        ...getPricingSorter(
-            selectedRegion,
-            pricingUnit,
-            costDuration,
-            (pricing) => rdsOnDemand("5")(pricing),
-            true,
-            currency,
-        ),
-    },
-    {
-        header: "Oracle Enterprise Reserved Cost",
-        id: "cost-reserved-5",
-        accessorKey: "pricing",
-        ...getPricingSorter(
-            selectedRegion,
-            pricingUnit,
-            costDuration,
-            (pricing) => rdsReserved("5")(pricing),
-            true,
-            currency,
-        ),
-    },
-    {
-        header: "EBS Optimized: Baseline Bandwidth",
-        id: "ebs-baseline-bandwidth",
-        accessorKey: "ebs_baseline_bandwidth",
-        sortingFn: "alphanumeric",
-        filterFn: (row, _, filterValue) =>
-            expr(row, "ebs_baseline_bandwidth", filterValue),
-    },
-    {
-        header: "EBS Optimized: Baseline Throughput (128K)",
-        id: "ebs-baseline-throughput",
-        accessorKey: "ebs_baseline_throughput",
-        sortingFn: "alphanumeric",
-        filterFn: (row, _, filterValue) =>
-            expr(row, "ebs_baseline_throughput", filterValue),
-    },
-    {
-        header: "EBS Optimized: Baseline IOPS (16K)",
-        id: "ebs-baseline-iops",
-        accessorKey: "ebs_baseline_iops",
-        sortingFn: "alphanumeric",
-        filterFn: (row, _, filterValue) =>
-            expr(row, "ebs_baseline_iops", filterValue),
-    },
-    {
-        header: "EBS Optimized: Max Bandwidth",
-        id: "ebs-max-bandwidth",
-        accessorKey: "ebs_max_bandwidth",
-        sortingFn: "alphanumeric",
-        filterFn: (row, _, filterValue) =>
-            expr(row, "ebs_max_bandwidth", filterValue),
-    },
-    {
-        header: "EBS Optimized: Max Throughput (128K)",
-        id: "ebs-max-throughput",
-        accessorKey: "ebs_throughput",
-        sortingFn: "alphanumeric",
-        filterFn: (row, _, filterValue) =>
-            expr(row, "ebs_throughput", filterValue),
-    },
-    {
-        header: "EBS Optimized: Max IOPS (16K)",
-        id: "ebs-iops",
-        accessorKey: "ebs_iops",
-        sortingFn: "alphanumeric",
-        filterFn: (row, _, filterValue) => expr(row, "ebs_iops", filterValue),
-    },
+        {
+            header: "Memory",
+            id: "memory",
+            accessorKey: "memory",
+            filterFn: expr,
+            sortingFn: "alphanumeric",
+        },
+        {
+            header: "Storage",
+            id: "storage",
+            accessorKey: "storage",
+            filterFn: expr,
+            sortingFn: "alphanumeric",
+        },
+        {
+            header: "EBS Throughput",
+            id: "ebs-throughput",
+            accessorKey: "ebs_throughput",
+            sortingFn: "alphanumeric",
+            filterFn: (row, _, filterValue) =>
+                expr(row, "ebs_throughput", filterValue),
+        },
+        {
+            header: "Processor",
+            id: "physical_processor",
+            accessorKey: "physicalProcessor",
+            sortingFn: "alphanumeric",
+            // @ts-expect-error: The typing is weird in the file
+            filterFn: regex({ accessorKey: "physicalProcessor" }),
+        },
+        {
+            header: "vCPUs",
+            id: "vcpu",
+            accessorKey: "vcpu",
+            filterFn: expr,
+            sortingFn: "alphanumeric",
+        },
+        {
+            header: "Network Performance",
+            id: "networkperf",
+            accessorKey: "network_performance",
+            sortingFn: "alphanumeric",
+            filterFn: regex({ accessorKey: "network_performance" }),
+        },
+        {
+            accessorKey: "arch",
+            header: "Arch",
+            size: 100,
+            id: "architecture",
+            sortingFn: (rowA, rowB) => {
+                const valueA = rowA.original.arch;
+                const valueB = rowB.original.arch;
+                if (!valueA) return -1;
+                if (!valueB) return 1;
+                return JSON.stringify(
+                    typeof valueA === "string" ? [valueA] : valueA.sort(),
+                ).localeCompare(
+                    JSON.stringify(
+                        typeof valueB === "string" ? [valueB] : valueB.sort(),
+                    ),
+                );
+            },
+            ...makeCellWithRegexSorter("arch", (info) => {
+                const arch = info.getValue() as string[] | string;
+                if (typeof arch === "string") return arch;
+                if (!arch) return "";
+                return arch.sort().join(", ");
+            }),
+        },
+        {
+            header: "PostgreSQL",
+            id: "cost-ondemand-14",
+            accessorKey: "pricing",
+            ...getPricingSorter(
+                selectedRegion,
+                pricingUnit,
+                costDuration,
+                (pricing) => rdsOnDemand("14")(pricing),
+                true,
+                currency,
+            ),
+        },
+        {
+            header: "PostgreSQL Reserved Cost",
+            id: "cost-reserved-14t",
+            accessorKey: "pricing",
+            ...getPricingSorter(
+                selectedRegion,
+                pricingUnit,
+                costDuration,
+                (pricing) => rdsReserved("14")(pricing),
+                true,
+                currency,
+            ),
+        },
+        {
+            header: "MySQL On Demand Cost",
+            id: "cost-ondemand-2",
+            accessorKey: "pricing",
+            ...getPricingSorter(
+                selectedRegion,
+                pricingUnit,
+                costDuration,
+                (pricing) => rdsOnDemand("2")(pricing),
+                true,
+                currency,
+            ),
+        },
+        {
+            header: "MySQL Reserved Cost",
+            id: "cost-reserved-2",
+            accessorKey: "pricing",
+            ...getPricingSorter(
+                selectedRegion,
+                pricingUnit,
+                costDuration,
+                (pricing) => rdsReserved("2")(pricing),
+                true,
+                currency,
+            ),
+        },
+        {
+            header: "SQL Server Expresss On Demand Cost",
+            id: "cost-ondemand-10",
+            accessorKey: "pricing",
+            ...getPricingSorter(
+                selectedRegion,
+                pricingUnit,
+                costDuration,
+                (pricing) => rdsOnDemand("10")(pricing),
+                true,
+                currency,
+            ),
+        },
+        {
+            header: "SQL Server Expresss Reserved Cost",
+            id: "cost-reserved-10",
+            accessorKey: "pricing",
+            ...getPricingSorter(
+                selectedRegion,
+                pricingUnit,
+                costDuration,
+                (pricing) => rdsReserved("10")(pricing),
+                true,
+                currency,
+            ),
+        },
+        {
+            header: "SQL Server Web On Demand Cost",
+            id: "cost-ondemand-11",
+            accessorKey: "pricing",
+            ...getPricingSorter(
+                selectedRegion,
+                pricingUnit,
+                costDuration,
+                (pricing) => rdsOnDemand("11")(pricing),
+                true,
+                currency,
+            ),
+        },
+        {
+            header: "SQL Server Web Reserved Cost",
+            id: "cost-reserved-11",
+            accessorKey: "pricing",
+            ...getPricingSorter(
+                selectedRegion,
+                pricingUnit,
+                costDuration,
+                (pricing) => rdsReserved("11")(pricing),
+                true,
+                currency,
+            ),
+        },
+        {
+            header: "SQL Server Standard On Demand Cost",
+            id: "cost-ondemand-12",
+            accessorKey: "pricing",
+            ...getPricingSorter(
+                selectedRegion,
+                pricingUnit,
+                costDuration,
+                (pricing) => rdsOnDemand("12")(pricing),
+                true,
+                currency,
+            ),
+        },
+        {
+            header: "SQL Server Standard Reserved Cost",
+            id: "cost-reserved-12",
+            accessorKey: "pricing",
+            ...getPricingSorter(
+                selectedRegion,
+                pricingUnit,
+                costDuration,
+                (pricing) => rdsReserved("12")(pricing),
+                true,
+                currency,
+            ),
+        },
+        {
+            header: "SQL Server Enterprise On Demand Cost",
+            id: "cost-ondemand-15",
+            accessorKey: "pricing",
+            ...getPricingSorter(
+                selectedRegion,
+                pricingUnit,
+                costDuration,
+                (pricing) => rdsOnDemand("15")(pricing),
+                true,
+                currency,
+            ),
+        },
+        {
+            header: "SQL Server Enterprise Reserved Cost",
+            id: "cost-reserved-15",
+            accessorKey: "pricing",
+            ...getPricingSorter(
+                selectedRegion,
+                pricingUnit,
+                costDuration,
+                (pricing) => rdsReserved("15")(pricing),
+                true,
+                currency,
+            ),
+        },
+        {
+            header: "Aurora Postgres & MySQL On Demand Cost",
+            id: "cost-ondemand-21",
+            accessorKey: "pricing",
+            ...getPricingSorter(
+                selectedRegion,
+                pricingUnit,
+                costDuration,
+                (pricing) => rdsOnDemand("21")(pricing),
+                true,
+                currency,
+            ),
+        },
+        {
+            header: "Aurora Postgres & MySQL Reserved Cost",
+            id: "cost-reserved-21",
+            accessorKey: "pricing",
+            ...getPricingSorter(
+                selectedRegion,
+                pricingUnit,
+                costDuration,
+                (pricing) => rdsReserved("21")(pricing),
+                true,
+                currency,
+            ),
+        },
+        {
+            header: "Aurora I/O Optimized On Demand Cost",
+            id: "cost-ondemand-211",
+            accessorKey: "pricing",
+            ...getPricingSorter(
+                selectedRegion,
+                pricingUnit,
+                costDuration,
+                (pricing) => rdsOnDemand("211")(pricing),
+                true,
+                currency,
+            ),
+        },
+        {
+            header: "MariaDB On Demand Cost",
+            id: "cost-ondemand-18",
+            accessorKey: "pricing",
+            ...getPricingSorter(
+                selectedRegion,
+                pricingUnit,
+                costDuration,
+                (pricing) => rdsOnDemand("18")(pricing),
+                true,
+                currency,
+            ),
+        },
+        {
+            header: "MariaDB Reserved Cost",
+            id: "cost-reserved-18",
+            accessorKey: "pricing",
+            ...getPricingSorter(
+                selectedRegion,
+                pricingUnit,
+                costDuration,
+                (pricing) => rdsReserved("18")(pricing),
+                true,
+                currency,
+            ),
+        },
+        {
+            header: "Oracle Enterprise On Demand Cost",
+            id: "cost-ondemand-5",
+            accessorKey: "pricing",
+            ...getPricingSorter(
+                selectedRegion,
+                pricingUnit,
+                costDuration,
+                (pricing) => rdsOnDemand("5")(pricing),
+                true,
+                currency,
+            ),
+        },
+        {
+            header: "Oracle Enterprise Reserved Cost",
+            id: "cost-reserved-5",
+            accessorKey: "pricing",
+            ...getPricingSorter(
+                selectedRegion,
+                pricingUnit,
+                costDuration,
+                (pricing) => rdsReserved("5")(pricing),
+                true,
+                currency,
+            ),
+        },
+        {
+            header: "EBS Optimized: Baseline Bandwidth",
+            id: "ebs-baseline-bandwidth",
+            accessorKey: "ebs_baseline_bandwidth",
+            sortingFn: "alphanumeric",
+            filterFn: (row, _, filterValue) =>
+                expr(row, "ebs_baseline_bandwidth", filterValue),
+        },
+        {
+            header: "EBS Optimized: Baseline Throughput (128K)",
+            id: "ebs-baseline-throughput",
+            accessorKey: "ebs_baseline_throughput",
+            sortingFn: "alphanumeric",
+            filterFn: (row, _, filterValue) =>
+                expr(row, "ebs_baseline_throughput", filterValue),
+        },
+        {
+            header: "EBS Optimized: Baseline IOPS (16K)",
+            id: "ebs-baseline-iops",
+            accessorKey: "ebs_baseline_iops",
+            sortingFn: "alphanumeric",
+            filterFn: (row, _, filterValue) =>
+                expr(row, "ebs_baseline_iops", filterValue),
+        },
+        {
+            header: "EBS Optimized: Max Bandwidth",
+            id: "ebs-max-bandwidth",
+            accessorKey: "ebs_max_bandwidth",
+            sortingFn: "alphanumeric",
+            filterFn: (row, _, filterValue) =>
+                expr(row, "ebs_max_bandwidth", filterValue),
+        },
+        {
+            header: "EBS Optimized: Max Throughput (128K)",
+            id: "ebs-max-throughput",
+            accessorKey: "ebs_throughput",
+            sortingFn: "alphanumeric",
+            filterFn: (row, _, filterValue) =>
+                expr(row, "ebs_throughput", filterValue),
+        },
+        {
+            header: "EBS Optimized: Max IOPS (16K)",
+            id: "ebs-iops",
+            accessorKey: "ebs_iops",
+            sortingFn: "alphanumeric",
+            filterFn: (row, _, filterValue) =>
+                expr(row, "ebs_iops", filterValue),
+        },
     ];
 };

--- a/next/utils/instancesKvClient.ts
+++ b/next/utils/instancesKvClient.ts
@@ -19,6 +19,7 @@ type DumpV1 = {
     costDuration: string;
     region: string;
     reservedTerm: string;
+    rdsDeploymentOption: string;
     compareOn: boolean;
     selected: string[];
     visibleColumns: Record<string, boolean>;

--- a/next/utils/rdsPricing.test.ts
+++ b/next/utils/rdsPricing.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "vitest";
+import { rdsEngineBucket, type RdsEnginePricing } from "./rdsPricing";
+
+const postgresPricing: RdsEnginePricing = {
+    ondemand: "0.178",
+    reserved: { "yrTerm1Standard.noUpfront": "0.12" },
+    multi_az: {
+        ondemand: "0.356",
+        reserved: { "yrTerm1Standard.noUpfront": "0.24" },
+    },
+};
+
+const pricingByEngine: Record<string, RdsEnginePricing> = {
+    "14": postgresPricing,
+};
+
+test("single-az returns root engine pricing", () => {
+    const bucket = rdsEngineBucket(pricingByEngine, "14", "single-az");
+    expect(bucket?.ondemand).toBe("0.178");
+    expect(bucket?.reserved?.["yrTerm1Standard.noUpfront"]).toBe("0.12");
+});
+
+test("multi-az returns nested multi_az pricing", () => {
+    const bucket = rdsEngineBucket(pricingByEngine, "14", "multi-az");
+    expect(bucket?.ondemand).toBe("0.356");
+    expect(bucket?.reserved?.["yrTerm1Standard.noUpfront"]).toBe("0.24");
+});
+
+test("missing engine key returns undefined", () => {
+    expect(rdsEngineBucket(pricingByEngine, "2", "single-az")).toBeUndefined();
+});
+
+test("missing multi_az returns undefined in multi-az mode", () => {
+    const singleOnly: Record<string, RdsEnginePricing> = {
+        "14": { ondemand: "0.178" },
+    };
+    expect(rdsEngineBucket(singleOnly, "14", "multi-az")).toBeUndefined();
+});
+
+test("undefined region pricing returns undefined", () => {
+    expect(rdsEngineBucket(undefined, "14", "single-az")).toBeUndefined();
+});

--- a/next/utils/rdsPricing.ts
+++ b/next/utils/rdsPricing.ts
@@ -13,7 +13,7 @@ export function rdsEngineBucket(
     pricingByEngine: Pricing[string] | undefined,
     engineKey: string,
     deployment: RdsDeploymentOption,
-): Pick<RdsEnginePricing, "ondemand" | "reserved"> | undefined {
+): PlatformPricing | undefined {
     const engine = pricingByEngine?.[engineKey];
     if (!engine) {
         return undefined;

--- a/next/utils/rdsPricing.ts
+++ b/next/utils/rdsPricing.ts
@@ -1,0 +1,25 @@
+import { PlatformPricing, Pricing, RdsDeploymentOption } from "@/types";
+
+// RDS scraper nests Multi-AZ ondemand/reserved under multi_az per engine. Kept
+// here (not types.ts) so shared EC2/PlatformPricing isn't modified.
+export type RdsEnginePricing = PlatformPricing & {
+    multi_az?: {
+        ondemand: string;
+        reserved?: Record<string, string>;
+    };
+};
+
+export function rdsEngineBucket(
+    pricingByEngine: Pricing[string] | undefined,
+    engineKey: string,
+    deployment: RdsDeploymentOption,
+): Pick<RdsEnginePricing, "ondemand" | "reserved"> | undefined {
+    const engine = pricingByEngine?.[engineKey];
+    if (!engine) {
+        return undefined;
+    }
+    if (deployment === "multi-az") {
+        return (engine as RdsEnginePricing).multi_az;
+    }
+    return engine;
+}

--- a/next/utils/useGlobalStateValue.ts
+++ b/next/utils/useGlobalStateValue.ts
@@ -109,6 +109,7 @@ const blankStateDump: StateDump = {
     // noUpfront here overrode the Azure default, leaving Azure's reserved/savings
     // columns blank because noUpfront isn't a valid Azure term. Mirrors region/filter.
     reservedTerm: "",
+    rdsDeploymentOption: "single-az",
 };
 
 function deepCopy<T>(v: T): T {

--- a/scraper/aws/rds.go
+++ b/scraper/aws/rds.go
@@ -49,6 +49,23 @@ var pipeIntoAverager = []string{
 	"vcpu",
 }
 
+var RDS_SUPPORTED_DEPLOYMENT_OPTIONS = map[string]bool{
+	"Single-AZ": true,
+	"Multi-AZ":  true,
+}
+
+type genericAwsPricingData struct {
+	OnDemand float64            `json:"ondemand"`
+	Reserved map[string]float64 `json:"reserved"`
+}
+
+// rdsPricing is per-engine pricing for one RDS instance type in one region.
+// Single-AZ ondemand/reserved serialize at the root; Multi-AZ nests under multi_az.
+type rdsPricing struct {
+	genericAwsPricingData
+	MultiAZ *genericAwsPricingData `json:"multi_az,omitempty"`
+}
+
 func addRdsVcpuByEngine(instance map[string]any, attributes map[string]string) {
 	vcpu := attributes["vcpu"]
 	if vcpu == "" || vcpu == "NA" {
@@ -129,7 +146,6 @@ var BAD_DESCRIPTION_CHUNKS = []string{
 	"storage",
 	"iops",
 	"requests",
-	"multi-az",
 }
 
 // SQL_SERVER_REAL_EDITIONS are the SQL Server editions that carry a separately
@@ -151,11 +167,6 @@ func isUnbundledSqlServerProduct(attributes map[string]string) bool {
 	return attributes["databaseEngine"] == "SQL Server" &&
 		attributes["licenseModel"] == "Bring your own media" &&
 		SQL_SERVER_REAL_EDITIONS[attributes["databaseEdition"]]
-}
-
-type genericAwsPricingData struct {
-	OnDemand float64            `json:"ondemand"`
-	Reserved map[string]float64 `json:"reserved"`
 }
 
 // unbundledSqlServerLicenseSurcharge returns the per-hour Windows + SQL Server
@@ -222,7 +233,7 @@ func processRdsOnDemandDimension(
 	attributes map[string]string,
 	instanceType string,
 	priceDimension awsutils.RegionPriceDimension,
-	getPricingdata func(platform string) *genericAwsPricingData,
+	getPricingBucket func(platform string) *genericAwsPricingData,
 	currency string,
 	unbundledInstanceTypes map[string]bool,
 	licenseRates map[engineCode]float64,
@@ -259,12 +270,23 @@ func processRdsOnDemandDimension(
 	if attributes["storage"] == "Aurora IO Optimization Mode" {
 		engineCode = "211"
 	}
-	pricingData := getPricingdata(engineCode)
-	pricingData.OnDemand = usdF
 
-	pricingData = getPricingdata(attributes["databaseEngine"])
-	if usdF > pricingData.OnDemand {
-		pricingData.OnDemand = usdF
+	pricingBucket := getPricingBucket(engineCode)
+
+	if pricingBucket == nil {
+		return
+	}
+
+	pricingBucket.OnDemand = usdF
+
+	pricingBucket = getPricingBucket(attributes["databaseEngine"])
+
+	if pricingBucket == nil {
+		return
+	}
+
+	if usdF > pricingBucket.OnDemand {
+		pricingBucket.OnDemand = usdF
 	}
 }
 
@@ -283,7 +305,7 @@ func translateGenericAwsReservedTermAttributes(termAttributes map[string]string)
 }
 
 func processRDSAndElastiCacheReservedOffer(
-	data []*genericAwsPricingData,
+	pricingBuckets []*genericAwsPricingData,
 	termCode string,
 	offer awsutils.RegionTerm,
 	currency string,
@@ -292,9 +314,9 @@ func processRDSAndElastiCacheReservedOffer(
 	if effectiveHourly <= 0 {
 		return
 	}
-	for _, data := range data {
-		if effectiveHourly > data.Reserved[termCode] {
-			data.Reserved[termCode] = effectiveHourly
+	for _, pricingBucket := range pricingBuckets {
+		if effectiveHourly > pricingBucket.Reserved[termCode] {
+			pricingBucket.Reserved[termCode] = effectiveHourly
 		}
 	}
 }
@@ -302,20 +324,16 @@ func processRDSAndElastiCacheReservedOffer(
 func processRdsReservedOffer(
 	attributes map[string]string,
 	offer awsutils.RegionTerm,
-	getPricingData func(platform string) *genericAwsPricingData,
+	getPricingBucket func(platform string) *genericAwsPricingData,
 	currency string,
 ) {
-	if attributes["deploymentOption"] != "Single-AZ" {
+	pricingBuckets := rdsEnginePricingBuckets(getPricingBucket, attributes)
+	if pricingBuckets == nil {
 		return
 	}
 
-	data := []*genericAwsPricingData{
-		getPricingData(attributes["databaseEngine"]),
-		getPricingData(attributes["engineCode"]),
-	}
-
 	termCode := translateGenericAwsReservedTermAttributes(offer.TermAttributes)
-	processRDSAndElastiCacheReservedOffer(data, termCode, offer, currency)
+	processRDSAndElastiCacheReservedOffer(pricingBuckets, termCode, offer, currency)
 }
 
 type genericAwsSkuData struct {
@@ -330,20 +348,99 @@ var RDS_DUPLICATED_KEYS = map[string]string{
 	"arch":                "processorArchitecture",
 }
 
-func getgenericAwsPricingData(instance map[string]any, regionName, platform string) *genericAwsPricingData {
-	regionMap := instance["pricing"].(map[string]map[string]any)[regionName]
-	if regionMap == nil {
-		regionMap = make(map[string]any)
-		instance["pricing"].(map[string]map[string]any)[regionName] = regionMap
+func getOrCreateRdsEnginePricing(instance map[string]any, regionName, platform string) *rdsPricing {
+	pricingByRegion := instance["pricing"].(map[string]map[string]*rdsPricing)
+	pricingByEngine := pricingByRegion[regionName]
+	if pricingByEngine == nil {
+		pricingByEngine = make(map[string]*rdsPricing)
+		pricingByRegion[regionName] = pricingByEngine
 	}
-	osMap := regionMap[platform]
-	if osMap == nil {
-		osMap = &genericAwsPricingData{
-			Reserved: make(map[string]float64),
+	enginePricing := pricingByEngine[platform]
+	if enginePricing == nil {
+		enginePricing = &rdsPricing{
+			genericAwsPricingData: genericAwsPricingData{
+				Reserved: make(map[string]float64),
+			},
 		}
-		regionMap[platform] = osMap
+		pricingByEngine[platform] = enginePricing
 	}
-	return osMap.(*genericAwsPricingData)
+	return enginePricing
+}
+
+func getRdsDeploymentPricingBucket(
+	instance map[string]any,
+	regionName, platform, deploymentOption string,
+) *genericAwsPricingData {
+	enginePricing := getOrCreateRdsEnginePricing(instance, regionName, platform)
+	switch deploymentOption {
+	case "Single-AZ":
+		return &enginePricing.genericAwsPricingData
+	case "Multi-AZ":
+		if enginePricing.MultiAZ == nil {
+			enginePricing.MultiAZ = &genericAwsPricingData{
+				Reserved: make(map[string]float64),
+			}
+		}
+		return enginePricing.MultiAZ
+	default:
+		return nil
+	}
+}
+
+func rdsPricingBucketByEngineKey(
+	instance map[string]any,
+	regionName, deploymentOption string,
+) func(platform string) *genericAwsPricingData {
+	return func(platform string) *genericAwsPricingData {
+		return getRdsDeploymentPricingBucket(instance, regionName, platform, deploymentOption)
+	}
+}
+
+func rdsEnginePricingBuckets(
+	getPricingBucket func(platform string) *genericAwsPricingData,
+	attributes map[string]string,
+) []*genericAwsPricingData {
+	engineBucket := getPricingBucket(attributes["databaseEngine"])
+	if engineBucket == nil {
+		return nil
+	}
+	codeBucket := getPricingBucket(attributes["engineCode"])
+	if codeBucket == nil {
+		return nil
+	}
+	return []*genericAwsPricingData{engineBucket, codeBucket}
+}
+
+func (p *rdsPricing) hasPricing() bool {
+	if p.OnDemand != 0 || len(p.Reserved) > 0 {
+		return true
+	}
+	return p.MultiAZ != nil &&
+		(p.MultiAZ.OnDemand != 0 || len(p.MultiAZ.Reserved) > 0)
+}
+
+func cleanEmptyRdsRegions(
+	pricing map[string]map[string]*rdsPricing,
+	regionDescriptions map[string]string,
+) map[string]string {
+	for region, pricingByEngine := range pricing {
+		okEngineCount := 0
+		for engine, pricingForEngine := range pricingByEngine {
+			if !pricingForEngine.hasPricing() {
+				delete(pricingByEngine, engine)
+			} else {
+				okEngineCount++
+			}
+		}
+		if okEngineCount == 0 {
+			delete(pricing, region)
+		}
+	}
+	regions := make(map[string]string)
+	for region := range pricing {
+		regions[region] = regionDescriptions[region]
+	}
+	return regions
 }
 
 func processRDSData(
@@ -403,6 +500,10 @@ func processRDSData(
 				unbundledSqlServerInstanceTypes[instanceType] = true
 			}
 
+			if !RDS_SUPPORTED_DEPLOYMENT_OPTIONS[product.Attributes["deploymentOption"]] {
+				continue
+			}
+
 			location := product.Attributes["location"]
 			if location != "" {
 				if regionDescription != "" && regionDescription != location {
@@ -411,15 +512,11 @@ func processRDSData(
 				regionDescription = location
 			}
 
-			if product.Attributes["deploymentOption"] != "Single-AZ" {
-				continue
-			}
-
 			instance, ok := instancesHashmap[instanceType]
 			if !ok {
 				instance = map[string]any{
 					"instance_type":           instanceType,
-					"pricing":                 make(map[string]map[string]any),
+					"pricing":                 make(map[string]map[string]*rdsPricing),
 					"ebs_baseline_throughput": 0.0,
 					"ebs_baseline_iops":       0,
 					"ebs_baseline_bandwidth":  0,
@@ -458,15 +555,14 @@ func processRDSData(
 					// Intentionally empty - this just gets the first one
 				}
 
-				// Handle getting the on demand pricing
-				getPricingdataScoped := func(platform string) *genericAwsPricingData {
-					return getgenericAwsPricingData(instance, rawRegion.RegionName, platform)
-				}
+				getPricingBucket := rdsPricingBucketByEngineKey(
+					instance, rawRegion.RegionName, attributes["deploymentOption"],
+				)
 				processRdsOnDemandDimension(
 					attributes,
 					instance["instance_type"].(string),
 					priceDimension,
-					getPricingdataScoped,
+					getPricingBucket,
 					currency,
 					unbundledSqlServerInstanceTypes,
 					licenseRatesByRegion[rawRegion.RegionName],
@@ -485,11 +581,10 @@ func processRDSData(
 				instance := skuData.instance
 				attributes := skuData.attributes
 
-				// Process the reserved pricing
-				getPricingdataScoped := func(platform string) *genericAwsPricingData {
-					return getgenericAwsPricingData(instance, rawRegion.RegionName, platform)
-				}
-				processRdsReservedOffer(attributes, offer, getPricingdataScoped, currency)
+				getPricingBucket := rdsPricingBucketByEngineKey(
+					instance, rawRegion.RegionName, attributes["deploymentOption"],
+				)
+				processRdsReservedOffer(attributes, offer, getPricingBucket, currency)
 			}
 		}
 
@@ -508,16 +603,16 @@ func processRDSData(
 			if !ok {
 				continue
 			}
+			getPricingBucket := rdsPricingBucketByEngineKey(
+				skuInfo.instance, region, skuInfo.attributes["deploymentOption"],
+			)
+			pricingBuckets := rdsEnginePricingBuckets(getPricingBucket, skuInfo.attributes)
+			if pricingBuckets == nil {
+				continue
+			}
 			for term, price := range termMap {
-				data := []*genericAwsPricingData{
-					getgenericAwsPricingData(skuInfo.instance, region, skuInfo.attributes["databaseEngine"]),
-					getgenericAwsPricingData(skuInfo.instance, region, skuInfo.attributes["engineCode"]),
-				}
-				for _, pricingData := range data {
-					if pricingData.Reserved == nil {
-						pricingData.Reserved = map[string]float64{}
-					}
-					pricingData.Reserved[term] = price
+				for _, pricingBucket := range pricingBuckets {
+					pricingBucket.Reserved[term] = price
 				}
 			}
 		}
@@ -525,7 +620,7 @@ func processRDSData(
 
 	// Clean up empty regions and set the regions map for non-empty regions
 	for _, instance := range instancesHashmap {
-		instance["regions"] = cleanEmptyRegions(instance["pricing"].(map[string]map[string]any), regionDescriptions)
+		instance["regions"] = cleanEmptyRdsRegions(instance["pricing"].(map[string]map[string]*rdsPricing), regionDescriptions)
 	}
 
 	// Attach the supported database engine version ranges (issue #710). Sourced

--- a/scraper/aws/rds_test.go
+++ b/scraper/aws/rds_test.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"encoding/json"
 	"testing"
 
 	"scraper/aws/awsutils"
@@ -15,12 +16,12 @@ func assembleOnDemand(
 	unbundled map[string]bool,
 	licenseRates map[engineCode]float64,
 ) float64 {
-	instance := map[string]any{
-		"pricing": make(map[string]map[string]any),
+	instance := newRdsPricingInstance()
+	deploymentOption := attributes["deploymentOption"]
+	if deploymentOption == "" {
+		deploymentOption = "Single-AZ"
 	}
-	getPricing := func(platform string) *genericAwsPricingData {
-		return getgenericAwsPricingData(instance, "us-east-1", platform)
-	}
+	getPricingBucket := rdsPricingBucketByEngineKey(instance, "us-east-1", deploymentOption)
 	pd := awsutils.RegionPriceDimension{
 		Description:  "instance hour running SQL Server",
 		PricePerUnit: map[string]string{"USD": basePrice},
@@ -29,12 +30,16 @@ func assembleOnDemand(
 		attributes,
 		attributes["instanceType"],
 		pd,
-		getPricing,
+		getPricingBucket,
 		"USD",
 		unbundled,
 		licenseRates,
 	)
-	return getPricing(attributes["engineCode"]).OnDemand
+	engineBucket := getPricingBucket(attributes["engineCode"])
+	if engineBucket == nil {
+		return 0
+	}
+	return engineBucket.OnDemand
 }
 
 // approxEqual is defined once for package aws in reserved_pricing_test.go.
@@ -262,5 +267,117 @@ func TestAddRdsVcpuByEngine(t *testing.T) {
 		if got := vcpuByEngine[engine]; got != want {
 			t.Errorf("vcpu_by_engine[%q] = %q, want %q", engine, got, want)
 		}
+	}
+}
+
+func TestRdsPricingJSON(t *testing.T) {
+	p := &rdsPricing{
+		genericAwsPricingData: genericAwsPricingData{
+			OnDemand: 0.178,
+			Reserved: map[string]float64{"yrTerm1Standard.noUpfront": 0.12},
+		},
+		MultiAZ: &genericAwsPricingData{
+			OnDemand: 0.356,
+			Reserved: map[string]float64{"yrTerm1Standard.noUpfront": 0.24},
+		},
+	}
+
+	got := map[string]any{}
+	b, err := json.Marshal(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+
+	if got["ondemand"] != 0.178 {
+		t.Errorf("ondemand = %v, want 0.178", got["ondemand"])
+	}
+	reserved, ok := got["reserved"].(map[string]any)
+	if !ok || reserved["yrTerm1Standard.noUpfront"] != 0.12 {
+		t.Errorf("reserved = %v, want yrTerm1Standard.noUpfront=0.12", got["reserved"])
+	}
+	multiAZ, ok := got["multi_az"].(map[string]any)
+	if !ok {
+		t.Fatalf("multi_az = %T, want object", got["multi_az"])
+	}
+	if multiAZ["ondemand"] != 0.356 {
+		t.Errorf("multi_az.ondemand = %v, want 0.356", multiAZ["ondemand"])
+	}
+}
+
+func newRdsPricingInstance() map[string]any {
+	return map[string]any{
+		"pricing": make(map[string]map[string]*rdsPricing),
+	}
+}
+
+func TestGetRdsPricingData(t *testing.T) {
+	instance := newRdsPricingInstance()
+
+	first := getOrCreateRdsEnginePricing(instance, "us-east-1", "14")
+	if first == nil {
+		t.Fatal("getRdsPricingData returned nil")
+	}
+	if first.Reserved == nil {
+		t.Fatal("Reserved map should be initialized")
+	}
+
+	second := getOrCreateRdsEnginePricing(instance, "us-east-1", "14")
+	if second != first {
+		t.Fatal("getRdsPricingData should return the same *rdsPricing for the same keys")
+	}
+
+	otherEngine := getOrCreateRdsEnginePricing(instance, "us-east-1", "PostgreSQL")
+	if otherEngine == first {
+		t.Fatal("different platform keys should get distinct *rdsPricing values")
+	}
+
+	otherRegion := getOrCreateRdsEnginePricing(instance, "eu-west-1", "14")
+	if otherRegion == first {
+		t.Fatal("different region keys should get distinct *rdsPricing values")
+	}
+
+	pricingByRegion := instance["pricing"].(map[string]map[string]*rdsPricing)
+	if len(pricingByRegion["us-east-1"]) != 2 {
+		t.Errorf("us-east-1 engine count = %d, want 2", len(pricingByRegion["us-east-1"]))
+	}
+	if pricingByRegion["eu-west-1"]["14"] != otherRegion {
+		t.Error("nested map should store the eu-west-1 engine pricing pointer")
+	}
+}
+
+func TestGetRdsDeploymentPricingData(t *testing.T) {
+	instance := newRdsPricingInstance()
+
+	single := getRdsDeploymentPricingBucket(instance, "us-east-1", "14", "Single-AZ")
+	if single == nil {
+		t.Fatal("Single-AZ should be supported")
+	}
+	single.OnDemand = 0.178
+
+	multi := getRdsDeploymentPricingBucket(instance, "us-east-1", "14", "Multi-AZ")
+	if multi == nil {
+		t.Fatal("Multi-AZ should be supported")
+	}
+	if multi == single {
+		t.Fatal("Multi-AZ bucket must be distinct from Single-AZ bucket")
+	}
+	if multi.Reserved == nil {
+		t.Fatal("Multi-AZ bucket should initialize Reserved map")
+	}
+	multi.OnDemand = 0.356
+
+	if getRdsDeploymentPricingBucket(instance, "us-east-1", "14", "Multi-AZ (readable standbys)") != nil {
+		t.Fatal("readable standbys should not be supported yet")
+	}
+
+	engine := getOrCreateRdsEnginePricing(instance, "us-east-1", "14")
+	if engine.OnDemand != 0.178 {
+		t.Errorf("Single-AZ OnDemand = %v, want 0.178", engine.OnDemand)
+	}
+	if engine.MultiAZ == nil || engine.MultiAZ.OnDemand != 0.356 {
+		t.Errorf("Multi-AZ OnDemand = %v, want 0.356", engine.MultiAZ)
 	}
 }

--- a/scraper/aws/utils.go
+++ b/scraper/aws/utils.go
@@ -6,6 +6,22 @@ import (
 	"strings"
 )
 
+func getgenericAwsPricingData(instance map[string]any, regionName, platform string) *genericAwsPricingData {
+	regionToEngineToPricingMap := instance["pricing"].(map[string]map[string]any)[regionName]
+	if regionToEngineToPricingMap == nil {
+		regionToEngineToPricingMap = make(map[string]any)
+		instance["pricing"].(map[string]map[string]any)[regionName] = regionToEngineToPricingMap
+	}
+	enginePricing := regionToEngineToPricingMap[platform]
+	if enginePricing == nil {
+		enginePricing = &genericAwsPricingData{
+			Reserved: make(map[string]float64),
+		}
+		regionToEngineToPricingMap[platform] = enginePricing
+	}
+	return enginePricing.(*genericAwsPricingData)
+}
+
 func cleanEmptyRegions(pricing map[string]map[string]any, regionDescriptions map[string]string) map[string]string {
 	for region, regionData := range pricing {
 		okOsCount := 0


### PR DESCRIPTION
## Summary

- Scrape RDS Multi-AZ on-demand and reserved instance pricing from AWS and nest it under `multi_az` per engine in keeping existing Single-AZ prices at the root for backward compatibility.
- Add a Single-AZ / Multi-AZ deployment toggle on the RDS table and pricing calculator so cost columns reflect the selected deployment option.
- Introduce `rdsEngineBucket()` on the frontend to read either the root pricing object or the nested `multi_az` bucket without changing the shared `PlatformPricing` type used by EC2.
- Closes #245

## Implementation
**Refactor RDS pricing storage in the scraper** — replace `*genericAwsPricingData` per engine with `rdsPricing`, which embeds Single-AZ `ondemand`/`reserved` at the JSON root and nests Multi-AZ under `multi_az`.
- **Index Multi-AZ SKUs** — stop filtering to `Single-AZ` only; accept `Single-AZ` and `Multi-AZ` via `RDS_SUPPORTED_DEPLOYMENT_OPTIONS` and register both in `sku2SkuData`.
- **Route prices by deployment option** — add `getOrCreateRdsEnginePricing` and `getRdsDeploymentPricingBucket` so on-demand and reserved writes land in the correct bucket based on `deploymentOption`.
- **Remove `"multi-az"` from `BAD_DESCRIPTION_CHUNKS`** 
- **Update region cleanup** — add `cleanEmptyRdsRegions` and `hasPricing()` so engines/regions are kept when only `multi_az` has pricing.
- **Move `getgenericAwsPricingData` to `utils.go`** — shared helper for ElastiCache and savings-plan paths that still use flat pricing.
- **Add frontend pricing helper** — `rdsEngineBucket()` in `next/utils/rdsPricing.ts` reads root pricing for Single-AZ or `multi_az` for Multi-AZ; returns `PlatformPricing` for compatibility with `PricingCalculator`.
- **Add deployment toggle** — `RdsDeploymentOption` (`single-az` | `multi-az`) persisted in URL state via `useRdsDeploymentOption`; filter dropdown on `/aws/rds`.
- **Wire table and calculator** — RDS columns and `PricingCalculator` use `rdsEngineBucket()` so on-demand/reserved reflect the selected deployment option


## Notes
- There is currently no support for multiple AZ pricing on the individual instance details pages. 
- There is also no support for `Multi-AZ (readable standbys)`.
### Data shape

```json
"14": {
  "ondemand": 0.018,
  "reserved": { "yrTerm1Standard.noUpfront": 0.0129 },
  "multi_az": {
    "ondemand": 0.036,
    "reserved": { "yrTerm1Standard.noUpfront": 0.0258 }
  }
}