### PR TITLE
feat(ec2): add availability zone scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The scraper is written in Go and fetches data from AWS, Azure, and GCP APIs. You
             "Action": [
                 "ec2:DescribeInstanceTypes",
                 "ec2:DescribeSpotPriceHistory",
+                "ec2:DescribeInstanceTypeOfferings",
                 "elasticache:DescribeEngineDefaultParameters",
                 "rds:DescribeDBEngineVersions",
                 "rds:DescribeOrderableDBInstanceOptions"

--- a/scraper/aws/ec2/availability_zones.go
+++ b/scraper/aws/ec2/availability_zones.go
@@ -1,0 +1,99 @@
+package ec2
+
+import (
+	"context"
+	"log"
+	"scraper/utils"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+func addAvailabilityZoneInfo(instances map[string]*EC2Instance, regions map[string]string) {
+	log.Default().Println("Adding availability zone info to EC2")
+
+	var fg utils.FunctionGroup
+	var instancesMutex sync.Mutex
+	var success uintptr
+
+	for region := range regions {
+		fg.Add(func() {
+			awsConfig, err := config.LoadDefaultConfig(context.TODO(),
+				config.WithRetryMaxAttempts(10),
+				config.WithRetryMode(aws.RetryModeAdaptive),
+			)
+			if err != nil {
+				log.Fatal(err)
+			}
+			awsConfig.Region = region
+			ec2Client := ec2.NewFromConfig(awsConfig)
+			paginator := ec2.NewDescribeInstanceTypeOfferingsPaginator(ec2Client, &ec2.DescribeInstanceTypeOfferingsInput{
+				LocationType: types.LocationTypeAvailabilityZoneId,
+				MaxResults:   int32Ptr(100),
+			})
+
+			// For each region, we can make our own local map of instances to AZ's and then merge back
+			// this means we have to lock the main thread less, as we are only blocking when merging this "local" map, and not on every lookup into instances map
+
+			local := make(map[string][]string)
+			firstPage := true
+			for paginator.HasMorePages() {
+				output, err := paginator.NextPage(context.Background())
+				if err != nil {
+					if firstPage {
+						if strings.Contains(err.Error(), "RateLimitExceeded") {
+							log.Fatal("EC2 region has a rate limit error", region)
+						}
+						if region == "us-east-1" {
+							log.Fatal("failed to get availability zones for us-east-1 ", err)
+						}
+						break
+					}
+					log.Fatal(err)
+				}
+				firstPage = false
+				atomic.AddUintptr(&success, 1)
+
+				for _, offering := range output.InstanceTypeOfferings {
+					instanceType := string(offering.InstanceType)
+					location := aws.ToString(offering.Location)
+					if location == "" {
+						continue
+					}
+
+					local[instanceType] = append(
+						local[instanceType],
+						location,
+					)
+				}
+			}
+
+			if len(local) == 0 {
+				return
+			}
+
+			instancesMutex.Lock()
+			for instanceType, instanceAvailabilityZonesForRegion := range local {
+				instance := instances[instanceType]
+				if instance == nil {
+					continue
+				}
+				if instance.AvailabilityZones == nil {
+					instance.AvailabilityZones = make(map[string][]string)
+				}
+				instance.AvailabilityZones[region] = instanceAvailabilityZonesForRegion
+			}
+			instancesMutex.Unlock()
+		})
+	}
+	fg.Run()
+
+	if success == 0 {
+		log.Fatalln("EC2 availability zone data failed to get any data")
+	}
+}

--- a/scraper/aws/ec2/process_data.go
+++ b/scraper/aws/ec2/process_data.go
@@ -292,6 +292,9 @@ func processEC2Data(
 	// Add placement group information
 	addPlacementGroupInfo(instancesHashmap)
 
+	// Add availability zone information
+	addAvailabilityZoneInfo(instancesHashmap, regionDescriptions)
+
 	// Add dedicated host pricing
 	if china {
 		addDedicatedHostPricingCn(instancesHashmap, regionsInverted)


### PR DESCRIPTION
## Summary
- Add availability zone data for EC2 instances. 
- Closes #439

## Implementation
- The EC2Instance struct already had the correct data shape, but there was nowhere in the scraper that actually wrote to the field.
- Front end is already correctly configured to use this data.
- Added a new `scraper/aws/ec2/availability_zones.go`, which goes through every region and creates a map of instances to availability zones, before merging this back into the main instance map.
- Each region runs in parallel via `FunctionGroup`; results are collected in a local
  map and merged into the instance hashmap under a mutex.
- Wired into `process_data.go` via `addAvailabilityZoneInfo(instancesHashmap, regionDescriptions)`.

## Note
- This would require a new IAM permission, `ec2:DescribeInstanceTypeOfferings`.