### PR TITLE
fix(next): change filter button sizing

### DIFF
--- a/next/components/ColumnFilter.tsx
+++ b/next/components/ColumnFilter.tsx
@@ -72,7 +72,7 @@ export default function ColumnFilter<Key extends keyof typeof columnData>({
                         role="combobox"
                         aria-expanded={open}
                         id={buttonId}
-                        className="w-[200px] justify-between"
+                        className="w-fit justify-between"
                     >
                         Columns
                         <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />

--- a/next/components/FilterDropdown.tsx
+++ b/next/components/FilterDropdown.tsx
@@ -88,7 +88,12 @@ export default function FilterDropdown({
     }, [groupedOptions, searchTerm]);
 
     return (
-        <div className="flex flex-col gap-0.5">
+        <div
+            className={cn(
+                "flex flex-col gap-0.5",
+                small && label === "Currency" && "max-w-[200px]",
+            )}
+        >
             {!hideLabel && (
                 <label htmlFor={buttonId} className="text-xs text-gray-1">
                     {label}
@@ -108,17 +113,19 @@ export default function FilterDropdown({
                         aria-label={hideLabel ? label : undefined}
                         id={buttonId}
                         className={cn(
-                            "w-full justify-between py-4.5",
+                            "min-w-0 w-full max-w-full shrink justify-between overflow-hidden py-4.5",
                             small ? "text-xs" : "",
                         )}
                     >
                         {icon && (
                             <i
                                 aria-hidden="true"
-                                className={`icon-${icon} text-white me-1`}
+                                className={`icon-${icon} text-white me-1 shrink-0`}
                             ></i>
                         )}
-                        {selectedOption?.label || "Select..."}
+                        <span className="min-w-0 flex-1 truncate text-left">
+                            {selectedOption?.label || "Select..."}
+                        </span>
                         <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
                     </Button>
                 </PopoverTrigger>


### PR DESCRIPTION
## Summary

On laptop screens, the instance table filter bar runs out of horizontal space. The **Columns** button was fixed at 200px even though its label is just "Columns", and long selected values (especially **Currency**) could grow the dropdown buttons and squeeze **Clear Filters**.

This PR makes two small layout fixes:

- **Columns button** — changed from a fixed `200px` width to `w-fit`, so it only takes the space its label needs.
- **Filter dropdown truncation** — long selected values now ellipsize instead of expanding the button. The selected label is wrapped in a truncating span, and the Currency dropdown is capped at `200px` so names like "Bosnia-Herzegovina Convertible Mark" don't expand to be huge. Default values like "US Dollar ($)" still fit comfortably.

## Verification
<img width="1510" height="117" alt="Screenshot 2026-08-06 at 6 58 29 PM" src="https://github.com/user-attachments/assets/b80033d5-83c4-4a92-b2b3-f79941673c43" />
