### PR TITLE
fix: guard against empty disk list in EC2 instance storage details

### DIFF
--- a/scraper/aws/ec2/instance_storage.go
+++ b/scraper/aws/ec2/instance_storage.go
@@ -3,6 +3,7 @@ package ec2
 import (
 	"log"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 )
 
@@ -13,26 +14,28 @@ var OK_NVME_STRINGS = map[string]bool{
 
 func addInstanceStorageDetails(instance *EC2Instance, apiDescription *types.InstanceTypeInfo) {
 	storageInfo := apiDescription.InstanceStorageInfo
-	if storageInfo != nil {
-		if len(storageInfo.Disks) == 0 {
-			log.Default().Println("No disks found for", instance.InstanceType)
-		}
-		disk := storageInfo.Disks[0]
-		instance.Storage = &Storage{
-			NVMeSSD: OK_NVME_STRINGS[string(storageInfo.NvmeSupport)],
-			SSD:     disk.Type == "ssd",
+	if storageInfo == nil {
+		return
+	}
+	if len(storageInfo.Disks) == 0 {
+		log.Default().Println("No disks found for", instance.InstanceType)
+		return
+	}
+	disk := storageInfo.Disks[0]
+	instance.Storage = &Storage{
+		NVMeSSD: OK_NVME_STRINGS[string(storageInfo.NvmeSupport)],
+		SSD:     disk.Type == "ssd",
 
-			// Redundant column - but here for legacy reasons. Any SSD will have trim support
-			TrimSupport: disk.Type == "ssd",
+		// Redundant column - but here for legacy reasons. Any SSD will have trim support
+		TrimSupport: disk.Type == "ssd",
 
-			// Always seems to be false in the Python code
-			// TODO: add this? Unsure why its not in the Python code
-			StorageNeedsInitalization: false,
-			IncludesSwapPartition:     false,
+		// Always seems to be false in the Python code
+		// TODO: add this? Unsure why its not in the Python code
+		StorageNeedsInitalization: false,
+		IncludesSwapPartition:     false,
 
-			Devices:  int(*disk.Count),
-			Size:     int(*disk.SizeInGB),
-			SizeUnit: "GB",
-		}
+		Devices:  int(aws.ToInt32(disk.Count)),
+		Size:     int(aws.ToInt64(disk.SizeInGB)),
+		SizeUnit: "GB",
 	}
 }

--- a/scraper/aws/ec2/instance_storage_test.go
+++ b/scraper/aws/ec2/instance_storage_test.go
@@ -1,0 +1,81 @@
+package ec2
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+func TestAddInstanceStorageDetailsWithoutStorageInfo(t *testing.T) {
+	instance := &EC2Instance{InstanceType: "m5.large"}
+
+	addInstanceStorageDetails(instance, &types.InstanceTypeInfo{})
+
+	if instance.Storage != nil {
+		t.Errorf("expected no storage for an EBS-only instance, got %+v", instance.Storage)
+	}
+}
+
+func TestAddInstanceStorageDetailsWithEmptyDisks(t *testing.T) {
+	instance := &EC2Instance{InstanceType: "test.large"}
+	apiDescription := &types.InstanceTypeInfo{
+		InstanceStorageInfo: &types.InstanceStorageInfo{},
+	}
+
+	addInstanceStorageDetails(instance, apiDescription)
+
+	if instance.Storage != nil {
+		t.Errorf("expected no storage when the API reports no disks, got %+v", instance.Storage)
+	}
+}
+
+func TestAddInstanceStorageDetailsWithNilDiskFields(t *testing.T) {
+	instance := &EC2Instance{InstanceType: "test.large"}
+	apiDescription := &types.InstanceTypeInfo{
+		InstanceStorageInfo: &types.InstanceStorageInfo{
+			Disks: []types.DiskInfo{{Type: types.DiskTypeSsd}},
+		},
+	}
+
+	addInstanceStorageDetails(instance, apiDescription)
+
+	if instance.Storage == nil {
+		t.Fatal("expected storage to be recorded for a disk with missing count/size")
+	}
+	if instance.Storage.Devices != 0 || instance.Storage.Size != 0 {
+		t.Errorf("expected zero devices/size for nil count/size, got %+v", instance.Storage)
+	}
+}
+
+func TestAddInstanceStorageDetailsWithDisk(t *testing.T) {
+	instance := &EC2Instance{InstanceType: "i3.large"}
+	apiDescription := &types.InstanceTypeInfo{
+		InstanceStorageInfo: &types.InstanceStorageInfo{
+			NvmeSupport: types.EphemeralNvmeSupportRequired,
+			Disks: []types.DiskInfo{{
+				Count:    aws.Int32(2),
+				SizeInGB: aws.Int64(1900),
+				Type:     types.DiskTypeSsd,
+			}},
+		},
+	}
+
+	addInstanceStorageDetails(instance, apiDescription)
+
+	if instance.Storage == nil {
+		t.Fatal("expected storage to be recorded")
+	}
+	got := *instance.Storage
+	want := Storage{
+		SSD:         true,
+		TrimSupport: true,
+		NVMeSSD:     true,
+		Devices:     2,
+		Size:        1900,
+		SizeUnit:    "GB",
+	}
+	if got != want {
+		t.Errorf("storage mismatch:\n got  %+v\n want %+v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- `addInstanceStorageDetails` logs "No disks found" when the EC2 API returns `InstanceStorageInfo` with an empty `Disks` slice, then reads `Disks[0]` on the very next line anyway. The log was meant to be a guard, it's just missing its `return`.
- Nothing recovers from a panic in the scraper, so if AWS ever returns that shape the whole scrape run dies with it.
- To be upfront: I haven't seen this fire on the Go scraper. It's a latent crash, not one we're hitting today. The Python scraper did hit this same class a few times (#239, #482, #323)

Reproduced against the current code with a new test:

```
2026/08/11 09:56:40 No disks found for test.large
--- FAIL: TestAddInstanceStorageDetailsWithEmptyDisks
panic: runtime error: index out of range [0] with length 0
    scraper/aws/ec2/instance_storage.go:20
```

## Fix

- Return after the "No disks found" log. An instance with no disks now comes through as EBS only instead of taking down the run.
- Flattened the function into guard clauses while I was in there.
- `disk.Count` and `disk.SizeInGB` are pointers too and were dereferenced straight, so they're now `aws.ToInt32` / `aws.ToInt64`. Same crash class, one line each.

## Testing

New `instance_storage_test.go` covers the four shapes of `InstanceStorageInfo`: no storage info, empty disks, nil count/size, and a normal disk. `go build`, `go vet`, `go test ./...` and `gofmt -l` are all clean locally.