### PR TITLE
fix(scraper): remove china regions from availabilty zones

### DIFF
--- a/scraper/aws/ec2/process_data.go
+++ b/scraper/aws/ec2/process_data.go
@@ -293,7 +293,9 @@ func processEC2Data(
 	addPlacementGroupInfo(instancesHashmap)
 
 	// Add availability zone information
-	addAvailabilityZoneInfo(instancesHashmap, regionDescriptions)
+	if !china {
+		addAvailabilityZoneInfo(instancesHashmap, regionDescriptions)
+	}
 
 	// Add dedicated host pricing
 	if china {


### PR DESCRIPTION
## Summary
- Availability zone scraping was failing because `DescribeInstanceTypeOfferings` against Chinese regions requires China-partition credentials, causing the China EC2 pipeline to fatal and abort the entire scrape.
- Skip AZ fetching when `china == true`,


## Verification
<img width="1023" height="791" alt="Screenshot 2026-08-11 at 11 53 55 AM" src="https://github.com/user-attachments/assets/08a5a3d5-397a-466b-964d-0cf825d431bd" />

