### PR TITLE
fix(scraper): patch date_introduced for r9g instances

### DIFF
--- a/scraper/aws/ec2/date_introduced.go
+++ b/scraper/aws/ec2/date_introduced.go
@@ -192,8 +192,19 @@ func addDateIntroduced(instances map[string]*EC2Instance) {
 		if !ok {
 			fallback, ok := dateIntroducedFallback[instanceType]
 			if !ok {
-				utils.SendWarning("Date introduced data missing for", instanceType)
-				continue
+				// Temporary until r9g/r9gd land in instancetyp.es/timeline.json.
+				// https://aws.amazon.com/about-aws/whats-new/2026/08/amazon-ec2-r9g-and-r9gd-memory-optimized-instances-are-now-available/
+				family := strings.SplitN(instanceType, ".", 2)[0]
+				if family != "r9g" && family != "r9gd" {
+					utils.SendWarning("Date introduced data missing for", instanceType)
+					continue
+				}
+				fallback = timelineEntry{
+					ReleaseMonth: "August",
+					ReleaseYear:  2026,
+					Announcement: timelineSource{Published: strPtr("Aug 31, 2026")},
+					BlogPost:     timelineSource{Published: strPtr("Aug 31, 2026")},
+				}
 			}
 			entry = fallback
 		}


### PR DESCRIPTION
# Summary
- New EC2instances were released, the[ r9g ](https://aws.amazon.com/blogs/aws/amazon-ec2-r9g-and-r9gd-instances-powered-by-aws-graviton5-processors-are-now-generally-available/)family, and instancetyp.es timeline hasn't yet added them, emitting warnings in slack. 
- In `date_introduced.go`, if the instance isn't in the manually introduced map, check if the instance is apart of the new r9g family and manually set`timelineEntry`.
